### PR TITLE
Fix private interface advertise address

### DIFF
--- a/cluster.example.yml
+++ b/cluster.example.yml
@@ -11,7 +11,8 @@ hosts:
     private_address: 10.10.1.3
     role: worker
 network:
-  ipalloc_range: 10.32.0.0/12
+  service_cidr: 10.96.0.0/12
+  pod_network_cidr: 10.32.0.0/12
   trusted_subnets:
     - 10.10.0.0/16
 addons:

--- a/lib/kupo/config_schema.rb
+++ b/lib/kupo/config_schema.rb
@@ -18,7 +18,8 @@ module Kupo
           end
         end
         optional(:network).schema do
-          optional(:ipalloc_range).filled(:str?)
+          optional(:service_cidr).filled(:str?)
+          optional(:pod_network_cidr).filled(:str?)
           optional(:trusted_subnets).each(type?: String)
         end
         optional(:addons).filled

--- a/lib/kupo/configuration/network.rb
+++ b/lib/kupo/configuration/network.rb
@@ -2,7 +2,8 @@ module Kupo::Configuration
   class Network < Dry::Struct
     constructor_type :schema
 
-    attribute :ipalloc_range, Kupo::Types::String.default('10.32.0.0/12')
+    attribute :service_cidr, Kupo::Types::String.default('10.96.0.0/12')
+    attribute :pod_network_cidr, Kupo::Types::String.default('10.32.0.0/12')
     attribute :trusted_subnets, Kupo::Types::Array.member(Kupo::Types::String)
   end
 end

--- a/lib/kupo/phases/configure_network.rb
+++ b/lib/kupo/phases/configure_network.rb
@@ -41,7 +41,7 @@ module Kupo::Phases
       logger.info { "Configuring overlay network ..." }
       Kupo::Kube.apply_stack(@master.address, 'weave', {
         trusted_subnets: trusted_subnets,
-        ipalloc_range: @config.ipalloc_range
+        ipalloc_range: @config.pod_network_cidr
       })
     end
 

--- a/lib/kupo/up_command.rb
+++ b/lib/kupo/up_command.rb
@@ -113,7 +113,7 @@ module Kupo
       log_host_header(master)
       Phases::ConfigureHost.new(master).call
       Phases::ConfigureKubelet.new(master).call
-      Phases::ConfigureMaster.new(master).call
+      Phases::ConfigureMaster.new(master, config.network).call
       Phases::ConfigureClient.new(master).call
       Phases::ConfigureNetwork.new(master, config.network).call
       Phases::ConfigureMetrics.new(master).call


### PR DESCRIPTION
Without cluster-cidr and pod-network-cidr workers somehow cannot connect to the kube service vip.

Fixes #23 