### PR TITLE
Silence output during spec run

### DIFF
--- a/lib/kupo/phases/logging.rb
+++ b/lib/kupo/phases/logging.rb
@@ -1,7 +1,7 @@
 require 'logger'
 
 module Kupo::Phases::Logging
-  def self.initialize_logger(log_target = STDOUT, log_level = Logger::INFO)
+  def self.initialize_logger(log_target = $stdout, log_level = Logger::INFO)
     @logger = Logger.new(log_target)
     @logger.progname = 'API'
     @logger.level = ENV["DEBUG"] ? Logger::DEBUG : log_level

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,4 +100,18 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  unless ENV['DEBUG'].to_s == 'true'
+    config.around(:each) do |example|
+      stdout = $stdout
+      stderr = $stderr
+      $stdout = $stderr = StringIO.new
+
+      begin
+        example.run
+      ensure
+        $stdout = stdout
+        $stderr = stderr
+      end
+    end
+  end
 end


### PR DESCRIPTION
Silence stdout/stderr during spec runs unless `DEBUG=true`.

Before:

![image](https://user-images.githubusercontent.com/224971/37342419-319b0a0a-26cd-11e8-8ca5-65e923e4d0ef.png)

After:

![image](https://user-images.githubusercontent.com/224971/37342429-38a71190-26cd-11e8-8d0a-9a672d606103.png)
