### PR TITLE
Set docker as default runtime

### DIFF
--- a/lib/kupo/configuration/host.rb
+++ b/lib/kupo/configuration/host.rb
@@ -11,7 +11,7 @@ module Kupo::Configuration
     attribute :labels, Kupo::Types::Strict::Hash
     attribute :user, Kupo::Types::Strict::String.default('ubuntu')
     attribute :ssh_key_path, Kupo::Types::Strict::String.default('~/.ssh/id_rsa')
-    attribute :container_runtime, Kupo::Types::Strict::String.default('cri-o')
+    attribute :container_runtime, Kupo::Types::Strict::String.default('docker')
 
     attr_accessor :os_release
     attr_accessor :cpu_arch


### PR DESCRIPTION
Until we are 100% sure that cri-o does not expose any security issues.