### PR TITLE
make host config fail if scripts fail

### DIFF
--- a/lib/kupo/phases/configure_host.rb
+++ b/lib/kupo/phases/configure_host.rb
@@ -53,8 +53,6 @@ module Kupo::Phases
       exec_script('configure-kube.sh', {
         kube_version: KUBE_VERSION
       })
-    rescue Kupo::Error => exc
-      logger.error { exc.message }
     end
 
     def configure_repos


### PR DESCRIPTION
fixes #86 

## After:
```
Configuring container runtime (cri-o) packages ...
    +     mkdir     -p     /etc/systemd/system/crio.service.d    
    + cat
    + apt-get install -y cri-o-1.9
    Reading package lists...    
    Building dependency tree...    
    Reading state information...    
    The following additional packages will be installed:
      cri-o-runc dirmngr gnupg-agent gnupg2 libassuan0 libgpgme11 libksba8
      libnpth0 pinentry-curses skopeo-containers
    Suggested packages:
      containernetworking-plugins gnupg-doc parcimonie xloadimage gpgsm
      pinentry-doc
    The following NEW packages will be installed:
      cri-o-1.9 cri-o-runc dirmngr gnupg-agent gnupg2 libassuan0 libgpgme11
      libksba8 libnpth0 pinentry-curses skopeo-containers
    0 upgraded, 11 newly installed, 0 to remove and 12 not upgraded.
    Need to get 3,788 B/9,903 kB of archives.
    After this operation, 43.4 MB of additional disk space will be used.
    Get:1 http://ppa.launchpad.net/projectatomic/ppa/ubuntu xenial/main amd64 skopeo-containers amd64 0.1.28-2~ubuntu16.04.2~ppa5 [3,788 B]
    Err:1 http://ppa.launchpad.net/projectatomic/ppa/ubuntu xenial/main amd64 skopeo-containers amd64 0.1.28-2~ubuntu16.04.2~ppa5
      Hash Sum mismatch
    Fetched 2,588 B in 0s (14.0 kB/s)
    E    :     Failed to fetch http://ppa.launchpad.net/projectatomic/ppa/ubuntu/pool/main/s/skopeo/skopeo-containers_0.1.28-2~ubuntu16.04.2~ppa5_amd64.deb  Hash Sum mismatch
    
    E    :     Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?    
Failed to execute configure-cri-o.sh
/Users/jussi/code/kupo/lib/kupo/phases/configure_host.rb:71:in `rescue in exec_script'
/Users/jussi/code/kupo/lib/kupo/phases/configure_host.rb:67:in `exec_script'
/Users/jussi/code/kupo/lib/kupo/phases/configure_host.rb:44:in `call'
/Users/jussi/code/kupo/lib/kupo/up_command.rb:133:in `handle_masters'
/Users/jussi/code/kupo/lib/kupo/up_command.rb:41:in `configure'
/Users/jussi/code/kupo/lib/kupo/up_command.rb:26:in `execute'
/Users/jussi/.rvm/gems/ruby-2.4.2/gems/clamp-1.2.1/lib/clamp/command.rb:63:in `run'
/Users/jussi/.rvm/gems/ruby-2.4.2/gems/clamp-1.2.1/lib/clamp/subcommand/execution.rb:11:in `execute'
/Users/jussi/.rvm/gems/ruby-2.4.2/gems/clamp-1.2.1/lib/clamp/command.rb:63:in `run'
/Users/jussi/.rvm/gems/ruby-2.4.2/gems/clamp-1.2.1/lib/clamp/command.rb:132:in `run'
/Users/jussi/code/kupo/lib/kupo/root_command.rb:13:in `run'
/Users/jussi/code/kupo/bin/kupo:12:in `<top (required)>'
/Users/jussi/.rvm/gems/ruby-2.4.2/bin/kupo:23:in `load'
/Users/jussi/.rvm/gems/ruby-2.4.2/bin/kupo:23:in `<main>'
/Users/jussi/.rvm/gems/ruby-2.4.2/bin/ruby_executable_hooks:15:in `eval'
/Users/jussi/.rvm/gems/ruby-2.4.2/bin/ruby_executable_hooks:15:in `<main>'
```

Better to let the script failures break things early.