### PR TITLE
Fix ssh file_contents for non-root users

### DIFF
--- a/lib/kupo/ssh/client.rb
+++ b/lib/kupo/ssh/client.rb
@@ -222,7 +222,7 @@ module Kupo::SSH
     # @param path [String]
     # @return [String]
     def file_contents(path)
-      exec!("cat #{path}")
+      exec!("sudo cat #{path}")
     end
 
     def disconnect


### PR DESCRIPTION
Fixes https://github.com/kontena/kupo/pull/102#discussion_r175445660

`ConfigureClient` will currently fail on `cat /etc/kubernetes/admin.conf` for a non-root SSH user.