### PR TITLE
Docker dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.4.3
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock *.gemspec ./
+COPY lib/kupo/version.rb ./lib/kupo/
+RUN bundle install
+
+COPY . .
+
+CMD ["./bin/kupo"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+dev:
+  build: .
+  volumes:
+  - .:/app
+  - $SSH_AUTH_SOCK:/run/ssh-agent.sock
+  environment:
+  - SSH_AUTH_SOCK=/run/ssh-agent.sock
+  command: bin/kupo up


### PR DESCRIPTION
Allow running via `docker-compose up` with the correct version of ruby.

Exports the ssh-agent socket to the container for SSH access.

```
$ docker-compose up
Recreating kupo_dev_1
Attaching to kupo_dev_1
dev_1  | ==> Reading instructions ...
dev_1  | ==> Sharpening tools ...
dev_1  | ==> Starting to craft cluster ...
dev_1  | ==> master: 167.99.36.141
...
```