### PR TITLE
Audit webhook config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ authentication:
     cache_ttl: 5m # optional
 ```
 
+## Audit Webhook
+
+Cluster supports setting up audit webhooks for external audit event collection.
+
+```yaml
+audit:
+ server: "http://audit.example.com/webhook"
+```
+
+Audit events are delivered in batched mode, multiple events in one webhook `POST` request.
+
+Currently audit events are configured to be emitted at `Metadata` level. See: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/auditing.md#levels
+
 ## Addons
 
 Pharos Cluster includes common functionality as addons. Addons can be enabled by introducing and enabling them in `cluster.yml`.

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -6,6 +6,7 @@ require_relative 'configuration/host'
 require_relative 'configuration/network'
 require_relative 'configuration/etcd'
 require_relative 'configuration/authentication'
+require_relative 'configuration/audit'
 
 module Pharos
   class Config < Dry::Struct
@@ -18,6 +19,7 @@ module Pharos
     attribute :addons, Pharos::Types::Hash
     attribute :etcd, Pharos::Configuration::Etcd
     attribute :authentication, Pharos::Configuration::Authentication
+    attribute :audit, Pharos::Configuration::Audit
 
     # @return [Integer]
     def dns_replicas

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -60,6 +60,10 @@ module Pharos
           end
         end
 
+        optional(:audit).schema do
+          required(:server).filled(:str?)
+        end
+
         optional(:addons).value(type?: Hash)
 
         validate(network_dns_replicas: [:network, :hosts]) do |network, hosts|

--- a/lib/pharos/configuration/audit.rb
+++ b/lib/pharos/configuration/audit.rb
@@ -1,0 +1,12 @@
+
+# frozen_string_literal: true
+
+module Pharos
+    module Configuration
+      class Audit < Dry::Struct
+        constructor_type :schema
+
+        attribute :server, Pharos::Types::String
+      end
+    end
+  end

--- a/lib/pharos/configuration/audit.rb
+++ b/lib/pharos/configuration/audit.rb
@@ -2,11 +2,11 @@
 # frozen_string_literal: true
 
 module Pharos
-    module Configuration
-      class Audit < Dry::Struct
-        constructor_type :schema
+  module Configuration
+    class Audit < Dry::Struct
+      constructor_type :schema
 
-        attribute :server, Pharos::Types::String
-      end
+      attribute :server, Pharos::Types::String
     end
   end
+end

--- a/lib/pharos/phases/base.rb
+++ b/lib/pharos/phases/base.rb
@@ -18,6 +18,12 @@ module Pharos
                           env: vars,
                           path: File.realpath(File.join(__dir__, '..', 'scripts', script)))
       end
+
+      def parse_resource_file(path, vars = {})
+        path = File.realpath(File.join(__dir__, '..', 'resources', path))
+        yaml = File.read(path)
+        Kupo::Erb.new(yaml).render(vars)
+      end
     end
   end
 end

--- a/lib/pharos/phases/base.rb
+++ b/lib/pharos/phases/base.rb
@@ -22,7 +22,7 @@ module Pharos
       def parse_resource_file(path, vars = {})
         path = File.realpath(File.join(__dir__, '..', 'resources', path))
         yaml = File.read(path)
-        Kupo::Erb.new(yaml).render(vars)
+        Pharos::Erb.new(yaml).render(vars)
       end
     end
   end

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -8,6 +8,8 @@ module Pharos
       PHAROS_DIR = '/etc/pharos'
       AUTHENTICATION_TOKEN_WEBHOOK_CONFIG_DIR = '/etc/kubernetes/authentication'
 
+      AUDIT_CFG_DIR = (PHAROS_DIR + '/audit').freeze
+
       # @param master [Pharos::Configuration::Host]
       # @param config [Pharos::Configuration::Network]
       def initialize(master, config)
@@ -61,6 +63,18 @@ module Pharos
           @ssh.write_file('/etc/pharos/etcd/ca-certificate.pem', File.read(@config.etcd.ca_certificate))
           @ssh.write_file('/etc/pharos/etcd/certificate.pem', File.read(@config.etcd.certificate))
           @ssh.write_file('/etc/pharos/etcd/certificate-key.pem', File.read(@config.etcd.key))
+        end
+
+        if @config.audit&.server
+          logger.info(@master.address) { "Pushing audit configs to master" }
+          @ssh.exec!("sudo mkdir -p #{AUDIT_CFG_DIR}")
+          @ssh.write_file("#{AUDIT_CFG_DIR}/webhook.yml",
+            parse_resource_file('audit/webhook-config.yml',
+            {
+              server: @config.audit.server
+            })
+          )
+          @ssh.write_file("#{AUDIT_CFG_DIR}/policy.yml", parse_resource_file('audit/policy.yml', {}))
         end
 
         # Generate and upload authentication token webhook config file if needed
@@ -120,7 +134,28 @@ module Pharos
           config['apiServerExtraVolumes'] += volume_mounts_for_authentication_token_webhook
         end
 
+        # Configure audit related things if needed
+        if @config.audit&.server
+          config['apiServerExtraArgs'].merge!({
+            "audit-webhook-config-file" => AUDIT_CFG_DIR + '/webhook.yml',
+            "audit-policy-file" => AUDIT_CFG_DIR + '/policy.yml'
+          })
+          config['apiServerExtraVolumes'] += volume_mounts_for_audit_webhook
+        end
+
         config
+      end
+
+      def volume_mounts_for_audit_webhook
+        volume_mounts = []
+        volume_mount = {
+          'name' => 'k8s-audit-webhook',
+          'hostPath' => AUDIT_CFG_DIR,
+          'mountPath' => AUDIT_CFG_DIR
+        }
+        volume_mounts << volume_mount
+
+        volume_mounts
       end
 
       def authentication_token_webhook_args(cache_ttl = nil)

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -68,11 +68,12 @@ module Pharos
         if @config.audit&.server
           logger.info(@master.address) { "Pushing audit configs to master" }
           @ssh.exec!("sudo mkdir -p #{AUDIT_CFG_DIR}")
-          @ssh.write_file("#{AUDIT_CFG_DIR}/webhook.yml",
-            parse_resource_file('audit/webhook-config.yml',
-            {
+          @ssh.write_file(
+            "#{AUDIT_CFG_DIR}/webhook.yml",
+            parse_resource_file(
+              'audit/webhook-config.yml',
               server: @config.audit.server
-            })
+            )
           )
           @ssh.write_file("#{AUDIT_CFG_DIR}/policy.yml", parse_resource_file('audit/policy.yml', {}))
         end
@@ -136,10 +137,10 @@ module Pharos
 
         # Configure audit related things if needed
         if @config.audit&.server
-          config['apiServerExtraArgs'].merge!({
+          config['apiServerExtraArgs'].merge!(
             "audit-webhook-config-file" => AUDIT_CFG_DIR + '/webhook.yml',
             "audit-policy-file" => AUDIT_CFG_DIR + '/policy.yml'
-          })
+          )
           config['apiServerExtraVolumes'] += volume_mounts_for_audit_webhook
         end
 

--- a/lib/pharos/resources/audit/policy.yml
+++ b/lib/pharos/resources/audit/policy.yml
@@ -1,0 +1,5 @@
+# Log all requests at the Metadata level.
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+- level: Metadata

--- a/lib/pharos/resources/audit/webhook-config.yml
+++ b/lib/pharos/resources/audit/webhook-config.yml
@@ -1,0 +1,15 @@
+
+apiVersion: v1
+clusters:
+- cluster:
+    server: <%= server %>
+  name: pharos
+contexts:
+- context:
+    cluster: pharos
+    user: ""
+  name: default-context
+current-context: default-context
+kind: Config
+preferences: {}
+users: []

--- a/spec/pharos/phases/configure_master_spec.rb
+++ b/spec/pharos/phases/configure_master_spec.rb
@@ -24,6 +24,28 @@ describe Pharos::Phases::ConfigureMaster do
   end
 
   describe '#generate_config' do
+
+    context 'with auth configuration' do
+      let(:config) { Pharos::Config.new(
+        hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
+        network: {},
+        addons: {},
+        audit: {
+          server: 'foobar'
+        }
+      ) }
+
+      it 'comes with proper audit config' do
+        config = subject.generate_config
+        expect(config.dig('apiServerExtraArgs', 'audit-webhook-config-file')).to eq('/etc/pharos/audit/webhook.yml')
+        expect(config.dig('apiServerExtraVolumes')).to include({
+          'name' => 'k8s-audit-webhook',
+          'hostPath' => '/etc/pharos/audit',
+          'mountPath' => '/etc/pharos/audit'
+        })
+      end
+    end
+
     context 'with network configuration' do
       let(:config) { Pharos::Config.new(
         hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },


### PR DESCRIPTION
Initial rough support for audit webhook config. Tested to work with:
```
audit:
 server: "http://webhook.site/c700f7c0-cf9e-4a2b-b110-8777809b520b"
```

Has currently "hard-coded" audit policy, should be possible in future to support custom provided policies etc..


replaces #165, it was easier to re-create the branch after renaming than to fight all the merge conflicts. :)

fixes #45 