### PR TITLE
Limit access to the weave status port

### DIFF
--- a/lib/pharos/resources/weave/daemon-set.yml
+++ b/lib/pharos/resources/weave/daemon-set.yml
@@ -38,9 +38,9 @@ spec:
                 secretKeyRef:
                   name: weave-passwd
                   key: weave-passwd
-            # defaults to 0.0.0.0, exposing status API publically; disable
+            # defaults to 0.0.0.0:6782, limit to block public access
             - name: WEAVE_STATUS_ADDR
-              value: ""
+              value: 127.0.0.1:6782
           image: 'docker.io/weaveworks/weave-kube-<%= arch.name %>:<%= version %>'
           livenessProbe:
             httpGet:

--- a/lib/pharos/resources/weave/daemon-set.yml
+++ b/lib/pharos/resources/weave/daemon-set.yml
@@ -38,6 +38,9 @@ spec:
                 secretKeyRef:
                   name: weave-passwd
                   key: weave-passwd
+            # defaults to 0.0.0.0, exposing status API publically; disable
+            - name: WEAVE_STATUS_ADDR
+              value: ""
           image: 'docker.io/weaveworks/weave-kube-<%= arch.name %>:<%= version %>'
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Weave defaults to running `weaver --status-addr=0.0.0.0`, which publicly exposes the weave router status API on nodes with public IP addresses. This is a bad idea.

Fix by listening on localhost only. Unfortunately it isn't possible to disable `--status-addr=` completely, because of how the `WEAVE_STATUS_ADDR=` default value is expanded in [`launch.sh`](https://github.com/weaveworks/weave/blob/v2.2.1/prog/weave-kube/launch.sh#L30).

The weave control API at `--http-addr=127.0.0.1:6784` also defaults to listening on localhost only.