### PR TITLE
Fix kubelet --cluster-dns for customized network service_cidr

### DIFF
--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 module Pharos
   module Configuration
     class Network < Dry::Struct
@@ -9,6 +11,11 @@ module Pharos
       attribute :service_cidr, Pharos::Types::String.default('10.96.0.0/12')
       attribute :pod_network_cidr, Pharos::Types::String.default('10.32.0.0/12')
       attribute :trusted_subnets, Pharos::Types::Array.member(Pharos::Types::String)
+
+      # @return [String] 10.96.0.10
+      def dns_service_ip
+        (IPAddr.new(service_cidr) | 10).to_s
+      end
     end
   end
 end

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -63,9 +63,17 @@ module Pharos
       def build_systemd_dropin
         options = []
         options << "Environment='KUBELET_EXTRA_ARGS=#{kubelet_extra_args.join(' ')}'"
+        options << "Environment='KUBELET_DNS_ARGS=#{kubelet_dns_args.join(' ')}'"
         options << "ExecStartPre=-/sbin/swapoff -a"
 
         "[Service]\n#{options.join("\n")}\n"
+      end
+
+      def kubelet_dns_args
+        [
+          "--cluster-dns=#{@config.network.dns_service_ip}",
+          "--cluster-domain=cluster.local",
+        ]
       end
 
       def kubelet_extra_args

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -73,7 +73,7 @@ module Pharos
       def kubelet_dns_args
         [
           "--cluster-dns=#{@config.network.dns_service_ip}",
-          "--cluster-domain=cluster.local",
+          "--cluster-domain=cluster.local"
         ]
       end
 

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -69,6 +69,7 @@ module Pharos
         "[Service]\n#{options.join("\n")}\n"
       end
 
+      # @return [Array<String>]
       def kubelet_dns_args
         [
           "--cluster-dns=#{@config.network.dns_service_ip}",
@@ -76,6 +77,7 @@ module Pharos
         ]
       end
 
+      # @return [Array<String>]
       def kubelet_extra_args
         args = []
         node_ip = @host.private_address.nil? ? @host.address : @host.private_address

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -1,0 +1,29 @@
+require "pharos/config"
+require "pharos/phases/configure_kubelet"
+
+describe Pharos::Phases::ConfigureKubelet do
+  let(:host) { Pharos::Configuration::Host.new(address: 'test', private_address: '192.168.42.1') }
+
+  let(:config) { Pharos::Config.new(
+      hosts: [host],
+      network: {},
+      addons: {},
+      etcd: {}
+  ) }
+  subject { described_class.new(host, config) }
+  let(:ssh_client) { instance_double(Pharos::SSH::Client) }
+
+  before :each do
+    allow(Pharos::SSH::Client).to receive(:for_host).and_return(ssh_client)
+  end
+
+  describe '#build_systemd_dropin' do
+    it "returns a systemd unit" do
+      expect(subject.build_systemd_dropin).to eq <<~EOM
+        [Service]
+        Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override='
+        ExecStartPre=-/sbin/swapoff -a
+      EOM
+    end
+  end
+end

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -22,8 +22,30 @@ describe Pharos::Phases::ConfigureKubelet do
       expect(subject.build_systemd_dropin).to eq <<~EOM
         [Service]
         Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override='
+        Environment='KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local'
         ExecStartPre=-/sbin/swapoff -a
       EOM
+    end
+
+    context "with a different network.service_cidr" do
+      let(:config) { Pharos::Config.new(
+          hosts: [host],
+          network: {
+            service_cidr: '172.255.0.0/16',
+          },
+          addons: {},
+          etcd: {}
+      ) }
+
+      it "uses the customized --cluster-dns" do
+        expect(subject.build_systemd_dropin).to eq <<~EOM
+          [Service]
+          Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override='
+          Environment='KUBELET_DNS_ARGS=--cluster-dns=172.255.0.10 --cluster-domain=cluster.local'
+          ExecStartPre=-/sbin/swapoff -a
+        EOM
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fixes #137 

```yaml
network:
  service_cidr: 10.250.0.0/16
  pod_network_cidr: 10.32.0.0/12
```

```
$ sudo systemctl cat kubelet
# /lib/systemd/system/kubelet.service
[Unit]
Description=kubelet: The Kubernetes Node Agent
Documentation=http://kubernetes.io/docs/

[Service]
ExecStart=/usr/bin/kubelet
Restart=always
StartLimitInterval=0
RestartSec=10

[Install]
WantedBy=multi-user.target

# /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
[Service]
Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf
Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=0"
Environment="KUBELET_CERTIFICATE_ARGS=--rotate-certificates=true --cert-dir=/var/lib/kubelet/pki"
ExecStart=
ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $K
# /etc/systemd/system/kubelet.service.d/5-pharos.conf
[Service]
Environment='KUBELET_EXTRA_ARGS=--node-ip=167.99.36.141 --hostname-override=terom-kupo-master'
Environment='KUBELET_DNS_ARGS=--cluster-dns=10.250.0.10 --cluster-domain=cluster.local'
ExecStartPre=-/sbin/swapoff -a
```

(not entirely sure why the `Environment="KUBELET_DNS_ARGS=..."` in the `5-pharos.conf` overrides the environment in the `10-kubeadm.conf`, but it does)

```
$ ps aux | grep kubelet | grep -oE -- '--cluster-dns=\S+'
--cluster-dns=10.250.0.10
```

```
$ kubectl run -it --attach --rm --restart=Never curl -l role=test --image=byrnedo/alpine-curl --command -- cat /etc/resolv.conf
nameserver 10.250.0.10
search default.svc.cluster.local svc.cluster.local cluster.local
options ndots:5
$ kubectl run -it --attach --rm --restart=Never curl -l role=test --image=byrnedo/alpine-curl -- -vk https://kubernetes
* Rebuilt URL to: https://kubernetes/
*   Trying 10.250.0.1...
* TCP_NODELAY set
* Connected to kubernetes (10.250.0.1) port 443 (#0)
```