### PR TITLE
Re-disable unauthenticated kubelet --read-only-port

### DIFF
--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -88,6 +88,7 @@ module Pharos
           args << '--container-runtime-endpoint=/var/run/crio/crio.sock'
         end
 
+        args << '--read-only-port=0'
         args << "--node-ip=#{node_ip}"
         args << "--cloud-provider=#{@config.cloud.provider}" if @config.cloud
         args << "--hostname-override=#{@host.hostname}"

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -21,7 +21,7 @@ describe Pharos::Phases::ConfigureKubelet do
     it "returns a systemd unit" do
       expect(subject.build_systemd_dropin).to eq <<~EOM
         [Service]
-        Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override='
+        Environment='KUBELET_EXTRA_ARGS=--read-only-port=0 --node-ip=192.168.42.1 --hostname-override='
         Environment='KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local'
         ExecStartPre=-/sbin/swapoff -a
       EOM
@@ -38,14 +38,8 @@ describe Pharos::Phases::ConfigureKubelet do
       ) }
 
       it "uses the customized --cluster-dns" do
-        expect(subject.build_systemd_dropin).to eq <<~EOM
-          [Service]
-          Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override='
-          Environment='KUBELET_DNS_ARGS=--cluster-dns=172.255.0.10 --cluster-domain=cluster.local'
-          ExecStartPre=-/sbin/swapoff -a
-        EOM
+        expect(subject.build_systemd_dropin).to match /KUBELET_DNS_ARGS=--cluster-dns=172.255.0.10 --cluster-domain=cluster.local/
       end
-
     end
   end
 end


### PR DESCRIPTION
Revert the #120 revert of #76 now that we have #121 and no longer need the readonly port for stats.

The kubelet defaults to `--read-only-port=10255`, which exposes sensitive information including the complete pod specs on any nodes with public IP addresses.