### PR TITLE
Sort stack resource files

### DIFF
--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -102,6 +102,14 @@ module Pharos
       File.exist?(File.join(Dir.home, ".pharos/#{host}"))
     end
 
+    # @param stack [String] dir name within lib/pharos/resources/
+    # @return [Array<String>]
+    def self.resource_files(stack)
+      files = Dir.glob(File.join(__dir__, 'resources', stack, '*.yml'))
+      files.sort!
+      files
+    end
+
     # @param host [Pharos::Configuration::Host]
     # @param stack [String]
     # @param vars [Hash]

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -117,8 +117,8 @@ module Pharos
     def self.apply_stack(host, stack, vars = {})
       checksum = SecureRandom.hex(16)
       resources = []
-      Dir.glob(File.join(__dir__, 'resources', stack, '*.yml')).each do |file|
-        resource = parse_resource_file("#{stack}/#{File.basename(file)}", vars)
+      resource_files(stack).each do |path|
+        resource = parse_resource_file(path, vars)
         resource.metadata.labels ||= {}
         resource.metadata.annotations ||= {}
         resource.metadata.labels[RESOURCE_LABEL] = stack
@@ -220,7 +220,7 @@ module Pharos
     # @param path [String]
     # @return [Kubeclient::Resource]
     def self.parse_resource_file(path, vars = {})
-      yaml = File.read(File.realpath(File.join(__dir__, 'resources', path)))
+      yaml = File.read(path)
       parsed_yaml = Pharos::Erb.new(yaml).render(vars)
 
       Kubeclient::Resource.new(YAML.safe_load(parsed_yaml))

--- a/spec/pharos/kube_spec.rb
+++ b/spec/pharos/kube_spec.rb
@@ -1,8 +1,10 @@
 describe Pharos::Kube do
 
   describe '.parse_resource_file' do
+    let(:resource_dir) { File.join(__dir__, '../..', 'lib/pharos/resources')}
+
     it 'returns resource' do
-      resource = described_class.parse_resource_file('host-upgrades/daemonset.yml', {
+      resource = described_class.parse_resource_file(resource_dir + '/' + 'host-upgrades/daemonset.yml', {
         arch: double(:arch, name: 'amd64')
       })
       expect(resource.metadata.name).to eq('host-upgrades')


### PR DESCRIPTION
Fixes #199 
Borrows from #162 but simplified (just path strings, not `Pathname`)

Ensure stack resource yaml files get applied in the correct order, instead of relying on the filesystem ordering as a side effect of git creating the files in sorted order on a checkout.

Also simplify the path handling, because spreading it out across three different functions is too ugly.

No spec, because support for spec fixtures is also hidden in #162... and using spec fixtures from git checkout would pass even without sorting the glob.