### PR TITLE
Move Pharos::Kube::Client to separate file

### DIFF
--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -6,74 +6,7 @@ require 'deep_merge'
 module Pharos
   module Kube
     autoload :CertManager, 'pharos/kube/cert_manager'
-
-    class Client < ::Kubeclient::Client
-      def entities
-        if @entities.empty?
-          discover
-        end
-        @entities
-      end
-
-      def update_entity_approval(resource_name, entity_config)
-        name      = entity_config[:metadata][:name]
-        ns_prefix = build_namespace_prefix(entity_config[:metadata][:namespace])
-        response = handle_exception do
-          rest_client[ns_prefix + resource_name + "/#{name}/approval"]
-            .put(entity_config.to_h.to_json, { 'Content-Type' => 'application/json' }.merge(@headers))
-        end
-        format_response(@as, response.body)
-      end
-
-      def entity_for_resource(resource)
-        name = Kubeclient::ClientMixin.underscore_entity(resource.kind.to_s)
-        definition = entities[name]
-
-        fail "Unknown entity for resource #{resource.kind} => #{name}" unless definition
-
-        definition
-      end
-
-      def apis(options = {})
-        response = rest_client.get(@headers)
-        format_response(options[:as] || @as, response.body)
-      end
-
-      # @param resource [Kubeclient::Resource]
-      # @return [Kubeclient::Resource]
-      def update_resource(resource)
-        definition = entity_for_resource(resource)
-
-        old_resource = get_entity(definition.resource_name, resource.metadata.name, resource.metadata.namespace)
-        resource.metadata.resourceVersion = old_resource.metadata.resourceVersion
-        merged_resource = Kubeclient::Resource.new(old_resource.to_h.deep_merge!(resource.to_h, overwrite_arrays: true))
-        update_entity(definition.resource_name, merged_resource)
-      end
-
-      # @param resource [Kubeclient::Resource]
-      # @return [Kubeclient::Resource]
-      def update_resource_approval(resource)
-        definition = entity_for_resource(resource)
-
-        update_entity_approval(definition.resource_name, resource)
-      end
-
-      # @param resource [Kubeclient::Resource]
-      # @return [Kubeclient::Resource]
-      def create_resource(resource)
-        definition = entity_for_resource(resource)
-
-        create_entity(resource.kind, definition.resource_name, resource)
-      end
-
-      # @param resource [Kubeclient::Resource]
-      # @return [Kubeclient::Resource]
-      def get_resource(resource)
-        definition = entity_for_resource(resource)
-
-        get_entity(definition.resource_name, resource.metadata.name, resource.metadata.namespace)
-      end
-    end
+    autoload :Client, 'pharos/kube/client'
 
     RESOURCE_LABEL = 'pharos.kontena.io/stack'
     RESOURCE_ANNOTATION = 'pharos.kontena.io/stack-checksum'

--- a/lib/pharos/kube/client.rb
+++ b/lib/pharos/kube/client.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'kubeclient'
+
+module Pharos
+  module Kube
+    class Client < ::Kubeclient::Client
+      def entities
+        if @entities.empty?
+          discover
+        end
+        @entities
+      end
+
+      def update_entity_approval(resource_name, entity_config)
+        name      = entity_config[:metadata][:name]
+        ns_prefix = build_namespace_prefix(entity_config[:metadata][:namespace])
+        response = handle_exception do
+          rest_client[ns_prefix + resource_name + "/#{name}/approval"]
+            .put(entity_config.to_h.to_json, { 'Content-Type' => 'application/json' }.merge(@headers))
+        end
+        format_response(@as, response.body)
+      end
+
+      def entity_for_resource(resource)
+        name = Kubeclient::ClientMixin.underscore_entity(resource.kind.to_s)
+        definition = entities[name]
+
+        fail "Unknown entity for resource #{resource.kind} => #{name}" unless definition
+
+        definition
+      end
+
+      def apis(options = {})
+        response = rest_client.get(@headers)
+        format_response(options[:as] || @as, response.body)
+      end
+
+      # @param resource [Kubeclient::Resource]
+      # @return [Kubeclient::Resource]
+      def update_resource(resource)
+        definition = entity_for_resource(resource)
+
+        old_resource = get_entity(definition.resource_name, resource.metadata.name, resource.metadata.namespace)
+        resource.metadata.resourceVersion = old_resource.metadata.resourceVersion
+        merged_resource = Kubeclient::Resource.new(old_resource.to_h.deep_merge!(resource.to_h, overwrite_arrays: true))
+        update_entity(definition.resource_name, merged_resource)
+      end
+
+      # @param resource [Kubeclient::Resource]
+      # @return [Kubeclient::Resource]
+      def update_resource_approval(resource)
+        definition = entity_for_resource(resource)
+
+        update_entity_approval(definition.resource_name, resource)
+      end
+
+      # @param resource [Kubeclient::Resource]
+      # @return [Kubeclient::Resource]
+      def create_resource(resource)
+        definition = entity_for_resource(resource)
+
+        create_entity(resource.kind, definition.resource_name, resource)
+      end
+
+      # @param resource [Kubeclient::Resource]
+      # @return [Kubeclient::Resource]
+      def get_resource(resource)
+        definition = entity_for_resource(resource)
+
+        get_entity(definition.resource_name, resource.metadata.name, resource.metadata.namespace)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just moves the class to its own file from the `lib/pharos/kube.rb`
