### PR TITLE
Create kubernetes-dashboard admin user automatically

### DIFF
--- a/lib/pharos/addons/kubernetes_dashboard.rb
+++ b/lib/pharos/addons/kubernetes_dashboard.rb
@@ -6,6 +6,19 @@ module Pharos
       name 'kubernetes-dashboard'
       version '1.8.3'
       license 'Apache License 2.0'
+
+      def install
+        super
+
+        logger.info { "~~> kubernetes-dashboard can be accessed via kubectl proxy at http://localhost:8001/ui" }
+
+        kube_client = Pharos::Kube.client(host.address)
+        service_account = kube_client.get_service_account('dashboard-admin', 'kube-system')
+        token_secret = service_account.secrets[0]
+        return unless token_secret
+
+        logger.info { "~~> kubernetes-dashboard admin token can be fetched using: kubectl describe secret #{token_secret.name} -n kube-system" }
+      end
     end
   end
 end

--- a/lib/pharos/resources/kubernetes-dashboard/dashboard-admin-role-binding.yml
+++ b/lib/pharos/resources/kubernetes-dashboard/dashboard-admin-role-binding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: dashboard-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: dashboard-admin
+  namespace: kube-system

--- a/lib/pharos/resources/kubernetes-dashboard/dashboard-admin-sa.yml
+++ b/lib/pharos/resources/kubernetes-dashboard/dashboard-admin-sa.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dashboard-admin
+  namespace: kube-system


### PR DESCRIPTION
Also adds hint to output how to retrieve token:

```
==> addons: x.x.x.x
    Applying addon kubernetes-dashboard ...
    ~~> kubernetes-dashboard can be accessed via kubectl proxy at http://localhost:8001/ui
    ~~> kubernetes-dashboard admin token can be fetched using: kubectl describe secret dashboard-admin-token-x4wcn -n kube-system
==> Cluster has been crafted! (took 42 seconds)
```