### PR TITLE
Enable common global -v/--version -d/--debug

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -2,6 +2,15 @@
 
 module Pharos
   class Command < Clamp::Command
+    option ['-v', '--version'], :flag, "print pharos-cluster version" do
+      puts "pharos-cluster #{Pharos::VERSION}"
+      exit 0
+    end
+
+    option ['-d', '--debug'], :flag, "enable debug output", environment_variable: "DEBUG" do
+      ENV["DEBUG"] = "true"
+    end
+
     def pastel
       @pastel ||= Pastel.new
     end

--- a/lib/pharos/version_command.rb
+++ b/lib/pharos/version_command.rb
@@ -2,14 +2,8 @@
 
 module Pharos
   class VersionCommand < Pharos::Command
-    option "--all", :flag, "Show all versions"
-
     def execute
       puts "pharos-cluster version #{Pharos::VERSION}"
-      report_all if all?
-    end
-
-    def report_all
       load_phases
       puts "3rd party versions:"
       Pharos::Phases.components.each do |c|


### PR DESCRIPTION
And make `pharos-cluster version` always report_all

(see `docker --version` vs `docker version`)
