### PR TITLE
Document open ports (required, monitoring, restricted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,27 +62,27 @@ If using the `ingress-nginx` addon, then TCP ports 80/443 on the worker nodes (o
 
 The following ports serve unauthenticated monitoring/debugging information, and are either disabled, limited to localhost-only or should be restricted from external access to prevent information leaks.
 
-| Protocol    | Port        | Service               | Status                | Notes
-|-------------|-------------|-----------------------|-----------------------|-------
-| TCP         | 6781        | weave-npc metrics     | OPEN                  | unauthenticated weave-npc metrics API
-| TCP         | 6782        | weave status          | localhost-only        | unauthenticated read-only weave status, stats metrics API
-| TCP         | 10255       | kubelet read-only     | DISABLED              | unauthenticated read-only kubelet pod specs, stats metrics API
-| TCP         | 10248       | kubelet               | localhost-only        | ?
-| TCP         | 10249       | kube-proxy metrics    | localhost-only        | ?
-| TCP         | 10251       | kube-scheduler        | localhost-only        | ?
-| TCP         | 10252       | kube-controller       | localhost-only        | ?
-| TCP         | 10256       | kube-proxy healthz    | OPEN                  | ?
-| TCP         | 18080       | ingress-nginx status  | OPEN                  | unauthenticated
+| Protocol    | Port        | Service               | Hosts   | Status          | Notes
+|-------------|-------------|-----------------------|---------|-----------------|-------
+| TCP         | 6781        | weave-npc metrics     | All     | ***OPEN***      | unauthenticated weave-npc metrics API
+| TCP         | 6782        | weave status          | All     | localhost-only  | unauthenticated read-only weave status, stats metrics API
+| TCP         | 10255       | kubelet read-only     | All     | DISABLED        | unauthenticated read-only kubelet pod specs, stats metrics API
+| TCP         | 10248       | kubelet               | All     | localhost-only  | ?
+| TCP         | 10249       | kube-proxy metrics    | All     | localhost-only  | ?
+| TCP         | 10251       | kube-scheduler        | Master  | localhost-only  | ?
+| TCP         | 10252       | kube-controller       | Master  | localhost-only  | ?
+| TCP         | 10256       | kube-proxy healthz    | All     | ***OPEN***      | ?
+| TCP         | 18080       | ingress-nginx status  | workers | ***OPEN***      | unauthenticated
 
 ### Restricted Ports
 
 The following restricted services are only accessible via localhost the nodes, and must not be exposed to any untrusted access.
 
-| Protocol    | Port        | Service               | Hosts   | Notes
-|-------------|-------------|-----------------------|---------|-------
-| TCP         | 2379        | etcd clients          | master  | unauthenticated etcd client API
-| TCP         | 2380        | etcd peers            | master  | unauthenticated etcd peers API
-| TCP         | 6784        | weave control         | All     | unauthenticated weave control API
+| Protocol    | Port        | Service               | Hosts   | Status          | Notes
+|-------------|-------------|-----------------------|---------|-----------------|------
+| TCP         | 2379        | etcd clients          | master  | localhost-only  | unauthenticated etcd client API
+| TCP         | 2380        | etcd peers            | master  | localhost-only  | unauthenticated etcd peers API
+| TCP         | 6784        | weave control         | All     | localhost-only  | unauthenticated weave control API
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ The following ports serve unauthenticated monitoring/debugging information, and 
 
 | Protocol    | Port        | Service               | Hosts   | Status          | Notes
 |-------------|-------------|-----------------------|---------|-----------------|-------
-| TCP         | 6781        | weave-npc metrics     | All     | **OPEN**        | unauthenticated weave-npc metrics API
-| TCP         | 6782        | weave status          | All     | localhost-only  | unauthenticated read-only weave status, stats metrics API
-| TCP         | 10255       | kubelet read-only     | All     | *disabled*      | unauthenticated read-only kubelet pod specs, stats metrics API
+| TCP         | 6781        | weave-npc metrics     | All     | **OPEN**        | unauthenticated `/metrics`
+| TCP         | 6782        | weave status          | All     | localhost-only  | unauthenticated read-only weave `/status`, `/metrics` and `/report`
+| TCP         | 10255       | kubelet read-only     | All     | *disabled*      | unauthenticated read-only `/pods`, various stats metrics
 | TCP         | 10248       | kubelet               | All     | localhost-only  | ?
 | TCP         | 10249       | kube-proxy metrics    | All     | localhost-only  | ?
 | TCP         | 10251       | kube-scheduler        | Master  | localhost-only  | ?
 | TCP         | 10252       | kube-controller       | Master  | localhost-only  | ?
-| TCP         | 10256       | kube-proxy healthz    | All     | **OPEN**        | ?
-| TCP         | 18080       | ingress-nginx status  | Workers | **OPEN**        | unauthenticated
+| TCP         | 10256       | kube-proxy healthz    | All     | **OPEN**        | unauthenticated `/healthz`
+| TCP         | 18080       | ingress-nginx status  | Workers | **OPEN**        | unauthenticated `/healthz`, `/nginx_status` and default backend
 
 ### Restricted Ports
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,48 @@ Pharos Cluster executable can be downloaded from [https://github.com/kontena/pha
 - Minimal Ubuntu 16.04 (amd64 / arm64) hosts with SSH access
 - A user with passwordless sudo permission (`echo "$USER ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/$USER`)
 
+### Required Open Ports
+
+The follow ports are used by the `pharos-cluster` management tool, as well as between nodes in the same cluster. These ports are all authenticated, and can safely be left open for public access if required:
+
+| Protocol    | Port        | Service         | Hosts / Addon         | Notes
+|-------------|-------------|-----------------|-----------------------|-------
+| TCP         | 22          | SSH             | All                   | authenticated management channel for `pharos-cluster` operations (SSH keys)
+| TCP         | 6443        | kube-apiserver  | Master                | authenticated kube API for `pharos-cluster`, `kubectl` and worker node `kubelet` access (kube API tokens, RBAC)
+| TCP         | 6783        | weave           | All (weave)           | authenticated Weave peer control connections (shared weave secret)
+| UDP         | 6783        | weave           | All (weave)           | authenticated Weave sleeve fallback (shared weave secret)
+| UDP         | 6784        | weave           | All (weave)           | unauthenticated Weave fastdp (VXLAN), only used for peers on `network.trusted_subnets` networks
+| ESP (IPSec) |             | weave           | All (weave)           | authenticated Weave fastdp (IPsec encapsulated UDP port 6784 VXLAN), secured using IPSec SAs established over the control channel
+| TCP         | 10250       | kubelet         | All (master + worker) | authenticated kubelet API for the master node `kube-apiserver` and `heapster`/`metrics-server` addons (TLS client certs)
+
+If using the `ingress-nginx` addon, then TCP ports 80/443 on the worker nodes (or nodes matching `addons.ingress-nginx.node_selector`) must also be opened for public access.
+
+### Monitoring Ports
+
+The following ports serve unauthenticated monitoring/debugging information, and are either disabled, limited to localhost-only or should be restricted from external access to prevent information leaks:
+
+| Protocol    | Port        | Service               | Status                | Notes
+|-------------|-------------|-----------------------|-----------------------|-------
+| TCP         | 6781        | weave-npc metrics     | OPEN                  | unauthenticated weave-npc metrics API
+| TCP         | 6782        | weave status          | localhost-only        | unauthenticated read-only weave status, stats metrics API
+| TCP         | 10255       | kubelet read-only     | DISABLED              | unauthenticated read-only kubelet pod specs, stats metrics API
+| TCP         | 10248       | kubelet               | localhost-only        | ?
+| TCP         | 10249       | kube-proxy metrics    | localhost-only        | ?
+| TCP         | 10251       | kube-scheduler        | localhost-only        | ?
+| TCP         | 10252       | kube-controller       | localhost-only        | ?
+| TCP         | 10256       | kube-proxy healthz    | OPEN                  | ?
+| TCP         | 18080       | ingress-nginx status  | OPEN                  | unauthenticated
+
+### Restricted Ports
+
+The following restricted services are only accessible via localhost the nodes, and must not be exposed to any untrusted access:
+
+| Protocol    | Port        | Service               | Hosts   | Notes
+|-------------|-------------|-----------------------|---------|-------
+| TCP         | 2379        | etcd clients          | master  | unauthenticated etcd client API
+| TCP         | 2380        | etcd peers            | master  | unauthenticated etcd peers API
+| TCP         | 6784        | weave control         | All     | unauthenticated weave control API
+
 ## Usage
 
 ```
@@ -315,4 +357,3 @@ Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Pharos Cluster executable can be downloaded from [https://github.com/kontena/pha
 
 ### Required Open Ports
 
-The following ports are used by the `pharos-cluster` management tool, as well as between nodes in the same cluster. These ports are all authenticated, and can safely be left open for public access if required.
+The following ports are used by the `pharos-cluster` management tool, as well as between nodes in the same cluster. These ports are all authenticated, and can safely be left open for public access if desired.
 
 | Protocol    | Port        | Service         | Hosts / Addon         | Notes
 |-------------|-------------|-----------------|-----------------------|-------

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ The following ports serve unauthenticated monitoring/debugging information, and 
 
 | Protocol    | Port        | Service               | Hosts   | Status          | Notes
 |-------------|-------------|-----------------------|---------|-----------------|-------
-| TCP         | 6781        | weave-npc metrics     | All     | ***OPEN***      | unauthenticated weave-npc metrics API
+| TCP         | 6781        | weave-npc metrics     | All     | **OPEN**        | unauthenticated weave-npc metrics API
 | TCP         | 6782        | weave status          | All     | localhost-only  | unauthenticated read-only weave status, stats metrics API
-| TCP         | 10255       | kubelet read-only     | All     | DISABLED        | unauthenticated read-only kubelet pod specs, stats metrics API
+| TCP         | 10255       | kubelet read-only     | All     | *disabled*      | unauthenticated read-only kubelet pod specs, stats metrics API
 | TCP         | 10248       | kubelet               | All     | localhost-only  | ?
 | TCP         | 10249       | kube-proxy metrics    | All     | localhost-only  | ?
 | TCP         | 10251       | kube-scheduler        | Master  | localhost-only  | ?
 | TCP         | 10252       | kube-controller       | Master  | localhost-only  | ?
-| TCP         | 10256       | kube-proxy healthz    | All     | ***OPEN***      | ?
-| TCP         | 18080       | ingress-nginx status  | workers | ***OPEN***      | unauthenticated
+| TCP         | 10256       | kube-proxy healthz    | All     | **OPEN**        | ?
+| TCP         | 18080       | ingress-nginx status  | workers | **OPEN**        | unauthenticated
 
 ### Restricted Ports
 

--- a/README.md
+++ b/README.md
@@ -44,23 +44,23 @@ Pharos Cluster executable can be downloaded from [https://github.com/kontena/pha
 
 ### Required Open Ports
 
-The follow ports are used by the `pharos-cluster` management tool, as well as between nodes in the same cluster. These ports are all authenticated, and can safely be left open for public access if required:
+The following ports are used by the `pharos-cluster` management tool, as well as between nodes in the same cluster. These ports are all authenticated, and can safely be left open for public access if required.
 
 | Protocol    | Port        | Service         | Hosts / Addon         | Notes
 |-------------|-------------|-----------------|-----------------------|-------
-| TCP         | 22          | SSH             | All                   | authenticated management channel for `pharos-cluster` operations (SSH keys)
-| TCP         | 6443        | kube-apiserver  | Master                | authenticated kube API for `pharos-cluster`, `kubectl` and worker node `kubelet` access (kube API tokens, RBAC)
-| TCP         | 6783        | weave           | All (weave)           | authenticated Weave peer control connections (shared weave secret)
-| UDP         | 6783        | weave           | All (weave)           | authenticated Weave sleeve fallback (shared weave secret)
-| UDP         | 6784        | weave           | All (weave)           | unauthenticated Weave fastdp (VXLAN), only used for peers on `network.trusted_subnets` networks
-| ESP (IPSec) |             | weave           | All (weave)           | authenticated Weave fastdp (IPsec encapsulated UDP port 6784 VXLAN), secured using IPSec SAs established over the control channel
-| TCP         | 10250       | kubelet         | All (master + worker) | authenticated kubelet API for the master node `kube-apiserver` and `heapster`/`metrics-server` addons (TLS client certs)
+| TCP         | 22          | SSH             | All                   | authenticated management channel for `pharos-cluster` operations using SSH keys
+| TCP         | 6443        | kube-apiserver  | Master                | authenticated kube API for `pharos-cluster`, `kubectl` and worker node `kubelet` access using kube API tokens, RBAC
+| TCP         | 6783        | weave control   | All (weave)           | authenticated Weave peer control connections using the shared weave secret
+| UDP         | 6783        | weave dataplane | All (weave)           | authenticated Weave `sleeve` fallback using the shared weave secret
+| UDP         | 6784        | weave dataplane | All (weave)           | unauthenticated Weave `fastdp` (VXLAN), only used for peers on `network.trusted_subnets` networks
+| ESP (IPSec) |             | weave dataplane | All (weave)           | authenticated Weave `fastdp` (IPsec encapsulated UDP port 6784 VXLAN) using IPSec SAs established over the control channel
+| TCP         | 10250       | kubelet         | All                   | authenticated kubelet API for the master node `kube-apiserver` (and `heapster`/`metrics-server` addons) using TLS client certs
 
 If using the `ingress-nginx` addon, then TCP ports 80/443 on the worker nodes (or nodes matching `addons.ingress-nginx.node_selector`) must also be opened for public access.
 
 ### Monitoring Ports
 
-The following ports serve unauthenticated monitoring/debugging information, and are either disabled, limited to localhost-only or should be restricted from external access to prevent information leaks:
+The following ports serve unauthenticated monitoring/debugging information, and are either disabled, limited to localhost-only or should be restricted from external access to prevent information leaks.
 
 | Protocol    | Port        | Service               | Status                | Notes
 |-------------|-------------|-----------------------|-----------------------|-------
@@ -76,7 +76,7 @@ The following ports serve unauthenticated monitoring/debugging information, and 
 
 ### Restricted Ports
 
-The following restricted services are only accessible via localhost the nodes, and must not be exposed to any untrusted access:
+The following restricted services are only accessible via localhost the nodes, and must not be exposed to any untrusted access.
 
 | Protocol    | Port        | Service               | Hosts   | Notes
 |-------------|-------------|-----------------------|---------|-------

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If using the `ingress-nginx` addon, then TCP ports 80/443 on the worker nodes (o
 
 ### Monitoring Ports
 
-The following ports serve unauthenticated monitoring/debugging information, and are either disabled, limited to localhost-only or should be restricted from external access to prevent information leaks.
+The following ports serve unauthenticated monitoring/debugging information, and are either disabled, limited to localhost-only or only expose relatively harmless information.
 
 | Protocol    | Port        | Service               | Hosts   | Status          | Notes
 |-------------|-------------|-----------------------|---------|-----------------|-------
@@ -73,6 +73,8 @@ The following ports serve unauthenticated monitoring/debugging information, and 
 | TCP         | 10252       | kube-controller       | Master  | localhost-only  | ?
 | TCP         | 10256       | kube-proxy healthz    | All     | **OPEN**        | unauthenticated `/healthz`
 | TCP         | 18080       | ingress-nginx status  | Workers | **OPEN**        | unauthenticated `/healthz`, `/nginx_status` and default backend
+
+These ports should be restricted from external access to prevent information leaks.
 
 ### Restricted Ports
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following ports serve unauthenticated monitoring/debugging information, and 
 | TCP         | 10251       | kube-scheduler        | Master  | localhost-only  | ?
 | TCP         | 10252       | kube-controller       | Master  | localhost-only  | ?
 | TCP         | 10256       | kube-proxy healthz    | All     | **OPEN**        | ?
-| TCP         | 18080       | ingress-nginx status  | workers | **OPEN**        | unauthenticated
+| TCP         | 18080       | ingress-nginx status  | Workers | **OPEN**        | unauthenticated
 
 ### Restricted Ports
 
@@ -80,8 +80,8 @@ The following restricted services are only accessible via localhost the nodes, a
 
 | Protocol    | Port        | Service               | Hosts   | Status          | Notes
 |-------------|-------------|-----------------------|---------|-----------------|------
-| TCP         | 2379        | etcd clients          | master  | localhost-only  | unauthenticated etcd client API
-| TCP         | 2380        | etcd peers            | master  | localhost-only  | unauthenticated etcd peers API
+| TCP         | 2379        | etcd clients          | Master  | localhost-only  | unauthenticated etcd client API
+| TCP         | 2380        | etcd peers            | Master  | localhost-only  | unauthenticated etcd peers API
 | TCP         | 6784        | weave control         | All     | localhost-only  | unauthenticated weave control API
 
 ## Usage


### PR DESCRIPTION
Fixes  #188

Document all open ports on master/worker nodes: authenticated/required open ports, monitoring ports that are either restricted or should be restricted, and restricted ports that must not be exposed.

Most of the monitoring ports have already been restricted, but some of those are still open...

[Preview](https://github.com/kontena/pharos-cluster/blob/docs/open-ports/README.md#required-open-ports)