### PR TITLE
Refactor SSH client

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -20,6 +20,7 @@ module Pharos
   module SSH
     autoload :Client, 'pharos/ssh/client'
     autoload :RemoteCommand, 'pharos/ssh/remote_command'
+    autoload :Tempfile, 'pharos/ssh/tempfile'
   end
 
   module Terraform

--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -19,6 +19,7 @@ module Pharos
 
   module SSH
     autoload :Client, 'pharos/ssh/client'
+    autoload :RemoteCommand, 'pharos/ssh/remote_command'
   end
 
   module Terraform

--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -20,6 +20,7 @@ module Pharos
   module SSH
     autoload :Client, 'pharos/ssh/client'
     autoload :RemoteCommand, 'pharos/ssh/remote_command'
+    autoload :RemoteFile, 'pharos/ssh/remote_file'
     autoload :Tempfile, 'pharos/ssh/tempfile'
   end
 

--- a/lib/pharos/phases/base.rb
+++ b/lib/pharos/phases/base.rb
@@ -14,9 +14,11 @@ module Pharos
 
       # @param script [String] name of file under ../scripts/
       def exec_script(script, vars = {})
-        @ssh.exec_script!(script,
-                          env: vars,
-                          path: File.realpath(File.join(__dir__, '..', 'scripts', script)))
+        @ssh.exec_script!(
+          script,
+          env: vars,
+          path: File.realpath(File.join(__dir__, '..', 'scripts', script))
+        )
       end
 
       def parse_resource_file(path, vars = {})

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -15,7 +15,7 @@ module Pharos
         Dir.mkdir(config_dir, 0o700) unless Dir.exist?(config_dir)
         config_file = File.join(config_dir, @master.address)
         logger.info { "Fetching kubectl config ..." }
-        config_data = @ssh.read_file("/etc/kubernetes/admin.conf")
+        config_data = @ssh.file("/etc/kubernetes/admin.conf").read
         File.chmod(0o600, config_file) if File.exist?(config_file)
         File.write(config_file, config_data.gsub(%r{(server: https://)(.+)(:6443)}, "\\1#{@master.address}\\3"), perm: 0o600)
         logger.info { "Configuration saved to #{config_file}" }

--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -35,15 +35,19 @@ module Pharos
 
         if docker?
           logger.info { "Configuring container runtime (docker) packages ..." }
-          exec_script('configure-docker.sh',
-                      DOCKER_PACKAGE: 'docker.io',
-                      DOCKER_VERSION: "#{Pharos::DOCKER_VERSION}-0ubuntu1~16.04.2")
+          exec_script(
+            'configure-docker.sh',
+            DOCKER_PACKAGE: 'docker.io',
+            DOCKER_VERSION: "#{Pharos::DOCKER_VERSION}-0ubuntu1~16.04.2"
+          )
         elsif crio?
           logger.info { "Configuring container runtime (cri-o) packages ..." }
-          exec_script('configure-cri-o.sh',
-                      CRIO_VERSION: Pharos::CRIO_VERSION,
-                      CRIO_STREAM_ADDRESS: @host.private_address ? @host.private_address : @host.address,
-                      CPU_ARCH: @host.cpu_arch.name)
+          exec_script(
+            'configure-cri-o.sh',
+            CRIO_VERSION: Pharos::CRIO_VERSION,
+            CRIO_STREAM_ADDRESS: @host.private_address ? @host.private_address : @host.address,
+            CPU_ARCH: @host.cpu_arch.name
+          )
         else
           raise Pharos::Error, "Unknown container runtime: #{@host.container_runtime}"
         end

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -56,7 +56,8 @@ module Pharos
 
       # @return [String, nil]
       def existing_dropin
-        @ssh.file(DROPIN_PATH).with_existing(&:read)
+        file = @ssh.file(DROPIN_PATH)
+        file.read if file.exist?
       end
 
       # @return [String]

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -35,7 +35,7 @@ module Pharos
         return if dropin == existing_dropin
 
         @ssh.exec!("sudo mkdir -p /etc/systemd/system/kubelet.service.d/")
-        @ssh.write_file(DROPIN_PATH, dropin)
+        @ssh.file(DROPIN_PATH).write(dropin)
         @ssh.exec!("sudo systemctl daemon-reload")
         @ssh.exec!("sudo systemctl restart kubelet")
       end
@@ -56,7 +56,7 @@ module Pharos
 
       # @return [String, nil]
       def existing_dropin
-        @ssh.read_file(DROPIN_PATH) if @ssh.file_exists?(DROPIN_PATH)
+        @ssh.file(DROPIN_PATH).with_existing(&:read)
       end
 
       # @return [String]

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -89,7 +89,7 @@ module Pharos
 
         logger.info(@master.address) { "Initializing control plane ..." }
 
-        @ssh.with_tmpfile(cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
+        @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
           @ssh.exec!("sudo kubeadm init --config #{tmp_file}")
         end
 

--- a/lib/pharos/phases/join_node.rb
+++ b/lib/pharos/phases/join_node.rb
@@ -15,13 +15,11 @@ module Pharos
       end
 
       def already_joined?
-        @ssh.file_exists?("/etc/kubernetes/kubelet.conf")
+        @ssh.file("/etc/kubernetes/kubelet.conf").exist?
       end
 
       def call
-        if already_joined?
-          return
-        end
+        return if already_joined?
 
         logger.info { "Joining host to the master ..." }
         join_command = @master_ssh.exec!("sudo kubeadm token create --print-join-command").split(' ')

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -38,7 +38,7 @@ module Pharos
 
       def check_sudo
         ssh.exec!('sudo -n true')
-      rescue Pharos::SSH::RemoteFile::ExecError => exc
+      rescue Pharos::SSH::RemoteCommand::ExecError => exc
         raise Pharos::InvalidHostError, "Unable to sudo: #{exc.output}"
       end
 

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -38,7 +38,7 @@ module Pharos
 
       def check_sudo
         ssh.exec!('sudo -n true')
-      rescue Pharos::SSH::ExecError => exc
+      rescue Pharos::SSH::Exec::ExecError => exc
         raise Pharos::InvalidHostError, "Unable to sudo: #{exc.output}"
       end
 

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -38,7 +38,7 @@ module Pharos
 
       def check_sudo
         ssh.exec!('sudo -n true')
-      rescue Pharos::SSH::Exec::ExecError => exc
+      rescue Pharos::SSH::RemoteFile::ExecError => exc
         raise Pharos::InvalidHostError, "Unable to sudo: #{exc.output}"
       end
 

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -61,7 +61,7 @@ module Pharos
       # @return [Pharos::Configuration::OsRelease]
       def os_release
         os_info = {}
-        ssh.read_file('/etc/os-release').split("\n").each do |line|
+        ssh.file('/etc/os-release').each_line do |line|
           match = line.match(/^(.+)=(.+)$/)
           os_info[match[1]] = match[2].delete('"')
         end

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -87,7 +87,7 @@ module Pharos
         cmd = %w(sudo)
         env.each { |key, value| cmd << "#{key}=#{value.shellescape}" }
         cmd.concat %w(sh -x)
-        exec!(cmd, stdin: script, debug_source: name, **options)
+        exec!(cmd, stdin: script, source: name, **options)
       end
 
       # @param cmd [String] command to execute

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -86,7 +86,7 @@ module Pharos
       def exec_script!(name, env: {}, path: nil, **options)
         script = File.read(path || name)
         cmd = %w(sudo sh -x)
-        cmd.concat(env.map { |pair| pair.map(&:shellescape).join('=') })
+        cmd.concat(env.map { |key, value| "#{key.shellescape}=#{value.shellescape}" })
         exec!(cmd.join(' '), stdin: script, debug_source: name, **options)
       end
 

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -56,12 +56,11 @@ module Pharos
       #   tmp.unlink
       #
       # @param prefix [String] tempfile filename prefix (default "pharos")
-      # @param content [String] initial file content, default blank
-      # @param file [String,IO] path to local file or a readable IO object
+      # @param content [String,IO] initial file content, default blank
       # @return [Pharos::SSH::Tempfile]
       # @yield [Pharos::SSH::Tempfile]
-      def tempfile(prefix: "pharos", content: nil, file: nil, &block)
-        Tempfile.new(self, prefix: prefix, content: content, file: file, &block)
+      def tempfile(prefix: "pharos", content: nil, &block)
+        Tempfile.new(self, prefix: prefix, content: content, &block)
       end
 
       # @param cmd [String] command to execute

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -8,119 +8,6 @@ module Pharos
   module SSH
     Error = Class.new(StandardError)
 
-    class ExecError < Error
-      attr_reader :cmd, :exit_status, :output
-
-      def initialize(cmd, exit_status, output)
-        @cmd = cmd
-        @exit_status = exit_status
-        @output = output
-      end
-
-      def message
-        "SSH exec failed with code #{@exit_status}: #{@cmd}\n#{@output}"
-      end
-    end
-
-    class Exec
-      INDENT = "    "
-
-      def self.debug?
-        ENV['DEBUG'].to_s == 'true'
-      end
-
-      attr_reader :cmd, :exit_status, :stdout, :stderr, :output
-
-      def initialize(cmd, stdin: nil, debug: self.class.debug?, debug_source: nil)
-        @cmd = cmd
-        @stdin = stdin
-        @debug = debug
-        @debug_source = debug_source
-
-        @exit_status = nil
-        @stdout = ''
-        @stderr = ''
-        @output = ''
-      end
-
-      # @param session [Net::SSH::Connection::Session]
-      def open(session)
-        @channel = session.open_channel do |channel|
-          start(channel)
-        end
-      end
-
-      def wait
-        @channel.wait
-      end
-
-      # @param channel [Net::SSH::Connection::Channel]
-      def start(channel)
-        debug_cmd(@cmd, source: @debug_source) if debug?
-
-        channel.exec @cmd do |_, success|
-          raise Error, "Failed to exec #{cmd}" unless success
-
-          channel.on_data do |_, data|
-            @stdout += data
-            @output += data
-
-            debug_stdout(data) if debug?
-          end
-          channel.on_extended_data do |_c, _type, data|
-            @stderr += data
-            @output += data
-
-            debug_stderr(data) if debug?
-          end
-          channel.on_request("exit-status") do |_, data|
-            @exit_status = data.read_long
-
-            debug_exit(@exit_status) if debug?
-          end
-
-          if @stdin
-            channel.send_data(@stdin)
-            channel.eof!
-          end
-        end
-      end
-
-      # @return [Boolean]
-      def error?
-        !@exit_status.zero?
-      end
-
-      def debug?
-        @debug
-      end
-
-      def pastel
-        @pastel ||= Pastel.new(enabled: $stdout.tty?)
-      end
-
-      def debug_cmd(cmd, source: nil)
-        $stdout.write(INDENT + pastel.cyan("$ #{cmd}" + (source ? " < #{source}" : "")) + "\n")
-      end
-
-      def debug_stdout(data)
-        data.each_line do |line|
-          $stdout.write(INDENT + pastel.dim(line.to_s))
-        end
-      end
-
-      def debug_stderr(data)
-        data.each_line do |line|
-          # TODO: stderr is not line-buffered, this indents each write
-          $stdout.write(INDENT + pastel.red(line.to_s))
-        end
-      end
-
-      def debug_exit(exit_status)
-        $stdout.write(INDENT + pastel.yellow("! #{exit_status}") + "\n")
-      end
-    end
-
     class Client
       # @param host [Pharos::Configuration::Host]
       def self.for_host(host)
@@ -138,6 +25,8 @@ module Pharos
 
         @connections.values.map(&:disconnect)
       end
+
+      attr_reader :session
 
       def initialize(host, user = nil, opts = {})
         @host = host
@@ -158,32 +47,23 @@ module Pharos
       end
 
       # @param cmd [String] command to execute
-      # @return [Exec]
+      # @return [Pharos::Command::Result]
       def exec(cmd, **options)
         require_session!
-
-        logger.debug { "exec: #{cmd}" }
-
-        ex = Exec.new(cmd, **options)
-        ex.open(@session)
-        ex.wait
-        ex
+        RemoteCommand.new(self, cmd, **options).run
       end
 
       # @param cmd [String] command to execute
-      # @raise [ExecError]
+      # @raise [Pharos::SSH::RemoteCommand::ExecError]
       # @return [String] stdout
       def exec!(cmd, **options)
-        ex = exec(cmd, **options)
-
-        raise ExecError.new(cmd, ex.exit_status, ex.output) if ex.error?
-
-        ex.stdout
+        require_session!
+        RemoteCommand.new(self, cmd, **options).run!.stdout
       end
 
       # @param script [String] name of script
       # @param path [String] real path to file, defaults to script
-      # @raise [ExecError]
+      # @raise [Pharos::SSH::RemoteCommand::ExecError]
       # @return [String] stdout
       def exec_script!(name, env: {}, path: nil, **options)
         script = File.read(path || name)
@@ -193,22 +73,15 @@ module Pharos
           cmd << "#{e}=#{Shellwords.escape(value)}"
         end
 
-        cmd << 'sh'
-        cmd << '-x'
+        cmd.concat(%w(sh -x))
 
-        ex = exec(cmd.join(' '), stdin: script, debug_source: name, **options)
-
-        raise ExecError.new(name, ex.exit_status, ex.output) if ex.error?
-
-        ex.stdout
+        exec!(cmd.join(' '), stdin: script, debug_source: name, **options)
       end
 
       # @param cmd [String] command to execute
       # @return [Boolean]
-      def exec?(cmd, **options, &block)
-        ex = exec(cmd, **options, &block)
-
-        !ex.error?
+      def exec?(cmd, **options)
+        exec(cmd, **options).success?
       end
 
       # @param local_path [String]

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -85,9 +85,10 @@ module Pharos
       # @return [String] stdout
       def exec_script!(name, env: {}, path: nil, **options)
         script = File.read(path || name)
-        cmd = %w(sudo sh -x)
-        cmd.concat(env.map { |key, value| "#{key.shellescape}=#{value.shellescape}" })
-        exec!(cmd.join(' '), stdin: script, debug_source: name, **options)
+        cmd = %w(sudo)
+        env.each { |key, value| cmd << "#{key}=#{value.shellescape}" }
+        cmd.concat %w(sh -x)
+        exec!(cmd, stdin: script, debug_source: name, **options)
       end
 
       # @param cmd [String] command to execute

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -110,6 +110,8 @@ module Pharos
 
       private
 
+      attr_reader :pastel
+
       def initialize_debug
         if self.class.debug?
           @debug = true
@@ -121,10 +123,6 @@ module Pharos
 
       def debug?
         @debug
-      end
-
-      def pastel
-        @pastel
       end
 
       def debug_cmd(cmd, source: nil)

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module Pharos
+  module SSH
+    class RemoteCommand
+      Error = Class.new(StandardError)
+
+      class ExecError < Error
+        attr_reader :cmd, :exit_status, :output
+
+        def initialize(cmd, exit_status, output)
+          @cmd = cmd
+          @exit_status = exit_status
+          @output = output
+        end
+
+        def message
+          "SSH exec failed with code #{@exit_status}: #{@cmd}\n#{@output}"
+        end
+      end
+
+      class Result
+        attr_reader :stdin, :stdout, :stderr, :output
+        attr_accessor :exit_status
+
+        def initialize
+          @stdin = +''
+          @stdout = +''
+          @stderr = +''
+          @output = +''
+          @exit_status = -127
+        end
+
+        def success?
+          exit_status.zero?
+        end
+
+        def error?
+          !success?
+        end
+      end
+
+      INDENT = "    "
+
+      def self.debug?
+        ENV['DEBUG'].to_s == 'true'
+      end
+
+      attr_reader :cmd, :result
+
+      def initialize(client, cmd, stdin: nil, debug: self.class.debug?, debug_source: nil)
+        @client = client
+        @cmd = cmd
+        @stdin = stdin
+        @debug = debug
+        @debug_source = debug_source
+        @exit_status = nil
+      end
+
+      def run
+        @result = Result.new
+        open && wait
+        @result
+      end
+
+      def run!
+        run
+        raise ExecError.new(cmd, @result.exit_status, @result.output) if @result.error?
+        @result
+      end
+
+      def open
+        @channel = @client.session.open_channel do |channel|
+          start(channel)
+        end
+      end
+
+      def wait
+        @channel.wait
+      end
+
+      # @param channel [Net::SSH::Connection::Channel]
+      def start(channel)
+        debug_cmd(@cmd, source: @debug_source) if debug?
+
+        channel.exec @cmd do |_, success|
+          raise Error, "Failed to exec #{cmd}" unless success
+
+          channel.on_data do |_, data|
+            result.stdout << data
+            result.output << data
+
+            debug_stdout(data) if debug?
+          end
+
+          channel.on_extended_data do |_c, _type, data|
+            result.stderr << data
+            result.output << data
+
+            debug_stderr(data) if debug?
+          end
+
+          channel.on_request("exit-status") do |_, data|
+            result.exit_status = data.read_long
+
+            debug_exit(result.exit_status) if debug?
+          end
+
+          if @stdin
+            channel.send_data(@stdin)
+            channel.eof!
+          end
+        end
+      end
+
+      def debug?
+        @debug
+      end
+
+      def pastel
+        @pastel ||= Pastel.new
+      end
+
+      def debug_cmd(cmd, source: nil)
+        $stdout.write(INDENT + pastel.cyan("$ #{cmd}" + (source ? " < #{source}" : "")) + "\n")
+      end
+
+      def debug_stdout(data)
+        data.each_line do |line|
+          $stdout.write(INDENT + pastel.dim(line.to_s))
+        end
+      end
+
+      def debug_stderr(data)
+        data.each_line do |line|
+          # TODO: stderr is not line-buffered, this indents each write
+          $stdout.write(INDENT + pastel.red(line.to_s))
+        end
+      end
+
+      def debug_exit(exit_status)
+        $stdout.write(INDENT + pastel.yellow("! #{exit_status}") + "\n")
+      end
+    end
+  end
+end

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -59,7 +59,8 @@ module Pharos
 
       def run
         @result = Result.new
-        open && wait
+        open
+        wait
         @result
       end
 

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -51,7 +51,7 @@ module Pharos
       def initialize(client, cmd, stdin: nil, debug: self.class.debug?, debug_source: nil)
         @client = client
         @cmd = cmd.is_a?(Array) ? cmd.join(' ') : cmd
-        @stdin = stdin
+        @stdin = stdin.respond_to?(:read) ? stdin.read : stdin
         @debug = debug
         @debug_source = debug_source
         @exit_status = nil

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+
+module Pharos
+  module SSH
+    class RemoteFile
+      def initialize(client, path)
+        @client = client
+        @path = path.shellescape
+        freeze
+      end
+
+      def unlink
+        @client.exec!("rm #{@path}")
+      end
+
+      def write(content, sudo: true, append: false)
+        @client.exec!(
+          "#{'sudo ' if sudo}tee #{'--append ' if append}#{@path} > /dev/null",
+          stdin: content.respond_to?(:read) ? content : StringIO.new(content)
+        )
+      end
+
+      def append(content, sudo: true)
+        write(content, sudo: sudo, append: true)
+      end
+
+      def read
+        @client.exec!("sudo cat #{@path}")
+      end
+
+      def exist?
+        @client.exec?("[ -e #{@path} ]")
+      end
+
+      def with_existing
+        exist? && yield(self)
+      end
+
+      def download(local_path)
+        @session.download(@path, local_path)
+      end
+
+      def move(target)
+        @client.exec!("sudo mv #{@path} #{target.shellescape}")
+      end
+      alias mv move
+
+      def copy(target)
+        @client.exec!("sudo cp #{@path} #{target.shellescape}")
+      end
+      alias cp copy
+
+      def link(target)
+        @client.exec!("sudo ln -s #{@path} #{target.shellescape}")
+      end
+
+      def each_line
+        read.split(/[\r\n]/).each do |row|
+          yield row
+        end
+      end
+    end
+  end
+end

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -35,8 +35,8 @@ module Pharos
       def write(content)
         tmp = temp_file_path.shellescape
         @client.exec!(
-          "sudo cat > #{tmp} && (sudo mv #{tmp} #{escaped_path} || (sudo rm #{tmp}; exit 1)) || (sudo rm #{tmp}; exit 1)",
-          stdin: content.respond_to?(:read) ? content : StringIO.new(content)
+          "sudo tee #{tmp} > /dev/null && (sudo mv #{tmp} #{escaped_path} || (sudo rm #{tmp}; exit 1)) || (sudo rm #{tmp}; exit 1)",
+          stdin: content
         )
       end
 

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -78,7 +78,7 @@ module Pharos
       end
       alias cp copy
 
-      # Creates a symlink that points to the current file to target path
+      # Creates a symlink at the target path that points to the current file
       # @param target [String]
       def link(target)
         @client.exec!("sudo ln -s #{escaped_path} #{target.shellescape}")

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -35,7 +35,7 @@ module Pharos
       def write(content)
         tmp = temp_file_path.shellescape
         @client.exec!(
-          "sudo tee #{tmp} > /dev/null && (sudo mv #{tmp} #{escaped_path} || (sudo rm #{tmp}; exit 1)) || (sudo rm #{tmp}; exit 1)",
+          "cat > #{tmp} && (sudo mv #{tmp} #{escaped_path} || (rm #{tmp}; exit 1))",
           stdin: content
         )
       end

--- a/lib/pharos/ssh/tempfile.rb
+++ b/lib/pharos/ssh/tempfile.rb
@@ -32,7 +32,7 @@ module Pharos
       def write(content)
         @client.exec!(
           "sudo cat > #{@path.shellescape}",
-          stdin: content.respond_to?(:read) ? content : StringIO.new(content)
+          stdin: content
         )
       end
 

--- a/lib/pharos/ssh/tempfile.rb
+++ b/lib/pharos/ssh/tempfile.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Pharos
+  module SSH
+    # A temporary filename on a remote host
+    # Optionally uploads given content.
+    # When used with a block, removes the temporary file after execution.
+    class Tempfile
+      attr_reader :path
+      # @param client [Pharos::SSH::Client]
+      # @param prefix [String] Filename prefix, default "pharos"
+      # @param content [NilClass,String,IO] Content to upload to remote host
+      # @param file [NilClass,String] Path to a file to upload to remote host
+      # @yield [String] Temporary filename
+      # @example
+      #   Pharos::SSH::Tempfile.new(client) do |path|
+      #     client.exec("uname -a >> #{path}")
+      #   end
+      # @example
+      #   tempfile = Pharos::SSH::Tempfile.new(client)
+      #   client.exec("uname -a >> #{path}")
+      #   tempfile.unlink
+      def initialize(client, prefix: "pharos", content: nil, file: nil, &block)
+        @client = client
+        @path = File.join('/tmp', "#{prefix}.#{SecureRandom.hex(16)}")
+        raise ArgumentError, "Both file and content given" if content && file
+        upload_content(content) if content
+        upload_file(file) if file
+        run(&block) if block_given?
+      end
+
+      alias to_s path
+
+      # Upload content to remote tempfile
+      # @param content [IO,String]
+      # @param opts [Hash] options that are passed to scp.upload!
+      # @return [Integer] uploaded bytes
+      def upload_content(content, opts = {})
+        @client.upload(content.respond_to?(:read) ? content : StringIO.new(content), path, opts)
+      end
+
+      # Upload content to remote tempfile
+      # @param filename [String]
+      # @param opts [Hash] options that are passed to scp.upload!
+      # @return [Integer] uploaded bytes
+      def upload_file(filename, opts = {})
+        @client.upload(filename, path, opts)
+      end
+
+      # Tries to automatically detect the passed in object type
+      #
+      # Objects that respond to .read and strings that contain linefeeds
+      # are considered references to IO objects or strings representing
+      # uploaded content.
+      #
+      # Strings without linefeeds are considered paths to local files
+      # @param file_or_content [String,IO]
+      # @param opts [Hash] options that are passed to scp.upload!
+      def upload(file_or_content, opts = {})
+        if file_or_content.respond_to?(:read) || file_or_content.include?("\n")
+          upload_content(file_or_content, opts)
+        else
+          upload_file(file_or_content, opts)
+        end
+      end
+
+      # Remove remote tempfile
+      def unlink
+        @client.exec("rm #{path}")
+      end
+
+      private
+
+      def run
+        yield @path
+      ensure
+        unlink
+      end
+    end
+  end
+end

--- a/lib/pharos/ssh/tempfile.rb
+++ b/lib/pharos/ssh/tempfile.rb
@@ -31,7 +31,7 @@ module Pharos
 
       def write(content)
         @client.exec!(
-          "cat > #{@path.shellescape}",
+          "cat > #{escaped_path}",
           stdin: content
         )
       end

--- a/lib/pharos/ssh/tempfile.rb
+++ b/lib/pharos/ssh/tempfile.rb
@@ -45,6 +45,7 @@ module Pharos
         begin
           unlink
         rescue Pharos::SSH::RemoteCommand::ExecError
+          @client.logger.debug { "File did not exist in ensure" }
         end
       end
     end

--- a/lib/pharos/ssh/tempfile.rb
+++ b/lib/pharos/ssh/tempfile.rb
@@ -31,7 +31,7 @@ module Pharos
 
       def write(content)
         @client.exec!(
-          "sudo cat > #{@path.shellescape}",
+          "cat > #{@path.shellescape}",
           stdin: content
         )
       end


### PR DESCRIPTION
Combines #133 #142 and #143 (because merging any single one of them will make the others conflict).

- Extracts exec stuff into `Pharos::SSH::RemoteCommand`
- Extracts `with_tmpfile` stuff into `Pharos::SSH::Tempfile` 
- Extracts remote file operations into `Pharos::SSH::RemoteFile`

 