### PR TITLE
Pretty formatting for the node list when running parallel

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -6,7 +6,7 @@ module Pharos
 
     # XXX: should be in some kind of output helper?
     def pastel
-      @pastel ||= Pastel.new(enabled: $stdout.tty?)
+      @pastel ||= Pastel.new
     end
 
     attr_reader :config

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -6,7 +6,7 @@ module Pharos
 
     # XXX: should be in some kind of output helper?
     def pastel
-      @pastel ||= Pastel.new
+      @pastel ||= Pastel.new(enabled: $stdout.tty?)
     end
 
     attr_reader :config
@@ -66,7 +66,7 @@ module Pharos
     end
 
     def apply_phase(phase_class, hosts, **options)
-      puts pastel.cyan("==> #{phase_class.title} @ #{hosts.join(' ')}")
+      puts pastel.cyan("==> #{phase_class.title} @ #{format_hosts(hosts)}")
 
       phase_manager.apply(phase_class, hosts, **options)
     end
@@ -81,6 +81,23 @@ module Pharos
 
     def disconnect
       ssh_manager.disconnect_all
+    end
+
+    def format_hosts(hosts)
+      return hosts.join(' ') if logger.debug?
+      case hosts.size
+      when 0
+        '<unknown>'
+      when 1..3
+        hosts.join(' ')
+      else
+        grouped = hosts.group_by { |h| h.split('.').first(2).join('.') + '.*' }
+        if grouped.size > 3
+          "#{hosts.size} hosts"
+        else
+          grouped.map { |prefix, group| group.size == 1 ? group.first : "#{prefix} (#{group.size} hosts)" }.join(' ')
+        end
+      end
     end
   end
 end

--- a/spec/pharos/cluster_manager_spec.rb
+++ b/spec/pharos/cluster_manager_spec.rb
@@ -1,0 +1,23 @@
+describe Pharos::ClusterManager do
+  context '#format_hosts' do
+    subject { described_class.new('', config_content: '') }
+    let(:hosts) do
+      [
+        '10.2.3.4', '10.2.3.56', '192.168.100.4', '192.168.23.254',
+        '172.15.23.51', '83.123.12.2', '100.100.100.100', '32.2.1.2'
+      ]
+    end
+
+    it 'displays just the count of hosts when there are many' do
+      expect(subject.format_hosts(hosts)).to eq "#{hosts.size} hosts"
+    end
+
+    it 'displays the full list of nodes when there are just a few' do
+      expect(subject.format_hosts(hosts.first(3))).to eq "10.2.3.4, 10.2.3.56, 192.168.100.4"
+    end
+
+    it 'displays a grouped list of nodes when the group count is suitable' do
+      expect(subject.format_hosts(hosts.first(5))).to eq "10.2.* (2 hosts), 192.168.* (2 hosts), 172.15.23.51"
+    end
+  end
+end

--- a/spec/pharos/cluster_manager_spec.rb
+++ b/spec/pharos/cluster_manager_spec.rb
@@ -13,11 +13,11 @@ describe Pharos::ClusterManager do
     end
 
     it 'displays the full list of nodes when there are just a few' do
-      expect(subject.format_hosts(hosts.first(3))).to eq "10.2.3.4, 10.2.3.56, 192.168.100.4"
+      expect(subject.format_hosts(hosts.first(3))).to eq "10.2.3.4 10.2.3.56 192.168.100.4"
     end
 
     it 'displays a grouped list of nodes when the group count is suitable' do
-      expect(subject.format_hosts(hosts.first(5))).to eq "10.2.* (2 hosts), 192.168.* (2 hosts), 172.15.23.51"
+      expect(subject.format_hosts(hosts.first(5))).to eq "10.2.* (2 hosts) 192.168.* (2 hosts) 172.15.23.51"
     end
   end
 end


### PR DESCRIPTION
Applies the fancy formatting from #111 review comment to the node list in phase headers:

```ruby
hosts = ['10.2.3.4', '10.2.3.56', '192.168.100.4', '192.168.23.254', '172.15.23.51', '83.123.12.2', '100.100.100.100', '32.2.1.2']

Pharos::ClusterManager.new('foo', config_content: 'foo').format_hosts(hosts)
=> "8 hosts"

Pharos::ClusterManager.new('foo', config_content: 'foo').format_hosts(hosts.first(5))
=> "10.2.* (2 hosts) 192.168.* (2 hosts) 172.15.23.51"

Pharos::ClusterManager.new('foo', config_content: 'foo').format_hosts(hosts.first(3))
=> "10.2.3.4 10.2.3.56 192.168.100.4"
```
