### PR TITLE
Fix master upgrade regressions

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -48,9 +48,8 @@ module Pharos
       apply_phase(Phases::ValidateHost, config.hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
 
-      apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true) # TODO: also run this phase in parallel for the master nodes, if not doing an upgrade?
-
       apply_phase(Phases::ConfigureMaster, config.master_hosts, ssh: true, parallel: false)
+      apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true) # TODO: also run this phase in parallel for the master nodes, if not doing an upgrade?
       apply_phase(Phases::ConfigureClient, config.master_hosts, ssh: true, parallel: true)
 
       # master is now configured and can be used

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -244,7 +244,7 @@ module Pharos
         )
 
         cfg = generate_config
-        @ssh.with_tmpfile(cfg.to_yaml) do |tmp_file|
+        @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
           @ssh.exec!("sudo kubeadm upgrade apply #{Pharos::KUBE_VERSION} -y --allow-experimental-upgrades --config #{tmp_file}")
         end
         logger.info { "Control plane upgrade succeeded!" }


### PR DESCRIPTION
Fixes #229 use of `@ssh.tempfile`

Fixes #111 only upgrade worker node kubelets after master upgrade 

