### PR TITLE
Upgrade weave 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following ports serve unauthenticated monitoring/debugging information, and 
 | Protocol    | Port        | Service               | Hosts   | Status          | Notes
 |-------------|-------------|-----------------------|---------|-----------------|-------
 | TCP         | 6781        | weave-npc metrics     | All     | **OPEN**        | unauthenticated `/metrics`
-| TCP         | 6782        | weave status          | All     | localhost-only  | unauthenticated read-only weave `/status`, `/metrics` and `/report`
+| TCP         | 6782        | weave metrics         | All     | **OPEN**        | unauthenticated `/metrics`
 | TCP         | 10255       | kubelet read-only     | All     | *disabled*      | unauthenticated read-only `/pods`, various stats metrics
 | TCP         | 10248       | kubelet               | All     | localhost-only  | ?
 | TCP         | 10249       | kube-proxy metrics    | All     | localhost-only  | ?

--- a/lib/pharos/phases/configure_network.rb
+++ b/lib/pharos/phases/configure_network.rb
@@ -5,7 +5,7 @@ module Pharos
     class ConfigureNetwork < Pharos::Phase
       title "Configure network"
 
-      WEAVE_VERSION = '2.2.1'
+      WEAVE_VERSION = '2.3.0'
 
       register_component(
         Pharos::Phases::Component.new(

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -38,9 +38,6 @@ spec:
                 secretKeyRef:
                   name: weave-passwd
                   key: weave-passwd
-            # defaults to 0.0.0.0:6782, limit to block public access
-            - name: WEAVE_STATUS_ADDR
-              value: 127.0.0.1:6782
           image: 'docker.io/weaveworks/weave-kube-<%= arch.name %>:<%= version %>'
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Fixes  #224 Upgrade Weave Net to 2.3.0
Revert #189 `WEAVE_STATUS_ADDR` changes and update docs to match

The weave router now only exposes `/metrics` on port 6782, leaving it in the same category of prometheus metrics endpoints that we already leave exposed.