### PR TITLE
Secrets encryption config for api server

### DIFF
--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -326,16 +326,16 @@ module Pharos
       end
 
       def secrets_encryption_exist?
-        logger.debug { "Checking if secrets encryption is already configured" }
+        logger.debug { "Checking if secrets encryption is already configured ..." }
         cfg_file = @ssh.file(SECRETS_CFG_FILE)
         return false unless cfg_file.exist?
         return false unless cfg_file.read.match?(/aescbc/)
-
+        logger.debug { "Secrets encryption is already configured ..." }
         true
       end
 
       def configure_secrets_encryption
-        logger.info { "Creating secrets encryption configuration" }
+        logger.info { "Creating secrets encryption configuration ..." }
         @ssh.exec!("sudo install -m 0700 -d #{SECRETS_CFG_DIR}")
         # Generate keys
         key1 = Base64.strict_encode64(SecureRandom.random_bytes(32))

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -344,8 +344,9 @@ module Pharos
           'key1' => key1,
           'key2' => key2
         }
-
-        @ssh.file(SECRETS_CFG_FILE).write(parse_resource_file('secrets/encryption-config.yml.erb', key1: key1, key2: key2))
+        cfg_file = @ssh.file(SECRETS_CFG_FILE)
+        cfg_file.write(parse_resource_file('secrets/encryption-config.yml.erb', key1: key1, key2: key2))
+        cfg_file.chmod('0700')
       end
 
       def upgrade

--- a/lib/pharos/resources/secrets/encryption-config.yml.erb
+++ b/lib/pharos/resources/secrets/encryption-config.yml.erb
@@ -1,0 +1,12 @@
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: key1
+          secret: "<%= key1 %>"
+        - name: key2
+          secret: "<%= key2 %>"

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -40,6 +40,10 @@ module Pharos
         )
       end
 
+      def chmod(mode)
+        @client.exec!("sudo chmod #{mode} #{escaped_path}")
+      end
+
       # Returns remote jfile content
       # @return [String]
       def read

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -104,6 +104,13 @@ module Pharos
 
       puts pastel.green("==> Starting to craft cluster ...")
       manager.apply_phases
+      if Phase.cluster_context['secrets_encryption']
+        puts pastel.red("==> Configured secrets encryption with keys:")
+        puts pastel.red("    Key1:#{Phase.cluster_context['secrets_encryption']['key1']}")
+        puts pastel.red("    Key2:#{Phase.cluster_context['secrets_encryption']['key2']}")
+        puts pastel.red("    Keep these safe!")
+        puts pastel.red("    NOTE: These values are base64 encoded already!")
+      end
 
       puts pastel.green("==> Configuring addons ...")
       manager.apply_addons

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -104,13 +104,6 @@ module Pharos
 
       puts pastel.green("==> Starting to craft cluster ...")
       manager.apply_phases
-      if Phase.cluster_context['secrets_encryption']
-        puts pastel.red("==> Configured secrets encryption with keys:")
-        puts pastel.red("    Key1:#{Phase.cluster_context['secrets_encryption']['key1']}")
-        puts pastel.red("    Key2:#{Phase.cluster_context['secrets_encryption']['key2']}")
-        puts pastel.red("    Keep these safe!")
-        puts pastel.red("    NOTE: These values are base64 encoded already!")
-      end
 
       puts pastel.green("==> Configuring addons ...")
       manager.apply_addons

--- a/spec/fixtures/secrets_cfg.yaml
+++ b/spec/fixtures/secrets_cfg.yaml
@@ -7,7 +7,7 @@ resources:
     - aescbc:
         keys:
         - name: key1
-          secret: "<%= key1 %>"
+          secret: "s6Xm3BlhHWkD0/5mW5tcks5kcdeWxE3qWkx/gA6hlcI="
         - name: key2
-          secret: "<%= key2 %>"
+          secret: "23VanHzmFuMQgfnVQrp9oJf0lLa82mThTBVDXd8Uw0s="
     - identity: {}

--- a/spec/fixtures/secrets_cfg_no_encryption.yaml
+++ b/spec/fixtures/secrets_cfg_no_encryption.yaml
@@ -1,0 +1,7 @@
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - identity: {}

--- a/spec/pharos/phases/configure_master_spec.rb
+++ b/spec/pharos/phases/configure_master_spec.rb
@@ -73,6 +73,15 @@ describe Pharos::Phases::ConfigureMaster do
       expect(config.dig('etcd', 'version')).to be_nil
     end
 
+    it 'comes with secrets encryption config' do
+      config = subject.generate_config
+      expect(config.dig('apiServerExtraArgs', 'experimental-encryption-provider-config')).to eq(described_class::SECRETS_CFG_FILE)
+      expect(config['apiServerExtraVolumes']).to include({'name' => 'k8s-secrets-config',
+        'hostPath' => described_class::SECRETS_CFG_DIR,
+        'mountPath' => described_class::SECRETS_CFG_DIR
+      })
+    end
+
     context 'with etcd endpoint configuration' do
       let(:config) { Pharos::Config.new(
         hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
@@ -151,7 +160,7 @@ describe Pharos::Phases::ConfigureMaster do
           }
         ]
         config = subject.generate_config
-        expect(config['apiServerExtraVolumes']).to eq(valid_volume_mounts)
+        expect(config['apiServerExtraVolumes']).to include(valid_volume_mounts[0], valid_volume_mounts[1])
       end
     end
 

--- a/spec/pharos/phases/configure_master_spec.rb
+++ b/spec/pharos/phases/configure_master_spec.rb
@@ -251,4 +251,33 @@ describe Pharos::Phases::ConfigureMaster do
       end
     end
   end
+
+  describe '#secrets_encryption_exist' do
+
+    subject { described_class.new(ssh: ssh) }
+
+    let(:ssh) { instance_double(Pharos::SSH::Client, :file => remote_file) }
+
+    let(:remote_file) { double }
+
+    it 'returns false if no config file existing' do
+      subject.instance_variable_set(:@ssh, ssh)
+      expect(remote_file).to receive(:exist?).and_return(false)
+      expect(subject.secrets_encryption_exist?).to be_falsey
+    end
+
+    it 'returns false if aescbc not configured' do
+      subject.instance_variable_set(:@ssh, ssh)
+      expect(remote_file).to receive(:exist?).and_return(true)
+      expect(remote_file).to receive(:read).and_return(fixture("secrets_cfg_no_encryption.yaml"))
+      expect(subject.secrets_encryption_exist?).to be_falsey
+    end
+
+    it 'returns true if aescbc already configured' do
+      subject.instance_variable_set(:@ssh, ssh)
+      expect(remote_file).to receive(:exist?).and_return(true)
+      expect(remote_file).to receive(:read).and_return(fixture("secrets_cfg.yaml"))
+      expect(subject.secrets_encryption_exist?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
A bit rough on the edges still.

Need to figure out proper way to get the generated keys from the phase up to the command and output there. Outputting this kind of info to user from phases is really ugly

After this enabled, the secrets get encrypted in etcd like:
```
/ # ETCDCTL_API=3 etcdctl get /registry/secrets/default/secret1
/registry/secrets/default/secret1
k8s:enc:aescbc:v1:key1:??[?Ӈ&?H???ݻ?lPw?=?*?????Y??3?M?MDNKuO??<?S?~x?O??43??~?? ??Lq???؏C????Gda=#ܶ?^S??B	???C?I⏧?M???E??Ҕ??,?y???(??g?[????9??$S?}
```

fixes #177 