### PR TITLE
Cleanup autoload modules

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -34,12 +34,6 @@ module Pharos
     autoload :JsonParser, 'pharos/terraform/json_parser'
   end
 
-  module Addons
-  end
-
-  module Phases
-  end
-
   module Configuration
     autoload :Host, 'pharos/configuration/host'
   end


### PR DESCRIPTION
`Phases` trigger loading of `phases.rb` (idk why) ... which triggers `dry-struct` etc. `Addons` is not needed here.