### PR TITLE
Set DEBIAN_FRONTEND=noninteractive in scripts

### DIFF
--- a/lib/pharos/scripts/configure-cri-o.sh
+++ b/lib/pharos/scripts/configure-cri-o.sh
@@ -9,7 +9,7 @@ Environment='CRIO_STORAGE_OPTIONS=--cgroup-manager=cgroupfs --stream-address=$CR
 ExecStartPre=/sbin/sysctl -w net.ipv4.ip_forward=1
 EOF
 
-apt-get install -y cri-o-$CRIO_VERSION
+DEBIAN_FRONTEND=noninteractive apt-get install -y cri-o-$CRIO_VERSION
 systemctl enable crio
 # remove unnecessary cni plugins
 rm /etc/cni/net.d/100-crio-bridge.conf /etc/cni/net.d/200-loopback.conf || true

--- a/lib/pharos/scripts/configure-docker.sh
+++ b/lib/pharos/scripts/configure-docker.sh
@@ -17,7 +17,7 @@ cat <<EOF >/etc/docker/daemon.json
 }
 EOF
 
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 apt-mark unhold $DOCKER_PACKAGE
 apt-get install -y $DOCKER_PACKAGE=$DOCKER_VERSION

--- a/lib/pharos/scripts/configure-docker.sh
+++ b/lib/pharos/scripts/configure-docker.sh
@@ -17,6 +17,8 @@ cat <<EOF >/etc/docker/daemon.json
 }
 EOF
 
+DEBIAN_FRONTEND=noninteractive
+
 apt-mark unhold $DOCKER_PACKAGE
 apt-get install -y $DOCKER_PACKAGE=$DOCKER_VERSION
 apt-mark hold $DOCKER_PACKAGE

--- a/lib/pharos/scripts/configure-essentials.sh
+++ b/lib/pharos/scripts/configure-essentials.sh
@@ -3,7 +3,7 @@
 set -e
 
 if ! dpkg -l apt-transport-https software-properties-common > /dev/null; then
-    DEBIAN_FRONTEND=noninteractive
+    export DEBIAN_FRONTEND=noninteractive
     apt-get update -y
     apt-get install -y apt-transport-https software-properties-common
 fi

--- a/lib/pharos/scripts/configure-essentials.sh
+++ b/lib/pharos/scripts/configure-essentials.sh
@@ -3,6 +3,7 @@
 set -e
 
 if ! dpkg -l apt-transport-https software-properties-common > /dev/null; then
+    DEBIAN_FRONTEND=noninteractive
     apt-get update -y
     apt-get install -y apt-transport-https software-properties-common
 fi

--- a/lib/pharos/scripts/configure-kube.sh
+++ b/lib/pharos/scripts/configure-kube.sh
@@ -14,6 +14,7 @@ if [ -e /etc/systemd/system/kubelet.service.d/5-pharos-kubelet-proxy.conf ]; the
     systemctl daemon-reload
 fi
 
+DEBIAN_FRONTEND=noninteractive
 apt-mark unhold kubelet kubectl kubeadm
 apt-get install -y kubelet=${KUBE_VERSION}-00 kubectl=${KUBE_VERSION}-00 kubeadm=${KUBEADM_VERSION}-00
 apt-mark hold kubelet kubectl kubeadm

--- a/lib/pharos/scripts/configure-kube.sh
+++ b/lib/pharos/scripts/configure-kube.sh
@@ -14,7 +14,7 @@ if [ -e /etc/systemd/system/kubelet.service.d/5-pharos-kubelet-proxy.conf ]; the
     systemctl daemon-reload
 fi
 
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 apt-mark unhold kubelet kubectl kubeadm
 apt-get install -y kubelet=${KUBE_VERSION}-00 kubectl=${KUBE_VERSION}-00 kubeadm=${KUBEADM_VERSION}-00
 apt-mark hold kubelet kubectl kubeadm

--- a/lib/pharos/scripts/configure-kubelet-proxy.sh
+++ b/lib/pharos/scripts/configure-kubelet-proxy.sh
@@ -32,7 +32,7 @@ ExecStart=
 ExecStart=/usr/bin/kubelet --pod-manifest-path=/etc/kubernetes/manifests/ --read-only-port=0 --cadvisor-port=0 --address=127.0.0.1
 EOF
 
-    DEBIAN_FRONTEND=noninteractive
+    export DEBIAN_FRONTEND=noninteractive
     apt-mark unhold kubelet
     apt-get install -y kubelet=${KUBE_VERSION}-00
     apt-mark hold kubelet

--- a/lib/pharos/scripts/configure-kubelet-proxy.sh
+++ b/lib/pharos/scripts/configure-kubelet-proxy.sh
@@ -32,6 +32,7 @@ ExecStart=
 ExecStart=/usr/bin/kubelet --pod-manifest-path=/etc/kubernetes/manifests/ --read-only-port=0 --cadvisor-port=0 --address=127.0.0.1
 EOF
 
+    DEBIAN_FRONTEND=noninteractive
     apt-mark unhold kubelet
     apt-get install -y kubelet=${KUBE_VERSION}-00
     apt-mark hold kubelet

--- a/lib/pharos/scripts/install-kubeadm.sh
+++ b/lib/pharos/scripts/install-kubeadm.sh
@@ -7,6 +7,7 @@ if [ $(kubeadm version -o short) = "v${VERSION}" ]; then
 fi
 
 cd /tmp
+DEBIAN_FRONTEND=noninteractive
 apt-get download kubeadm=${VERSION}-00
 dpkg -i --ignore-depends=kubelet kubeadm_${VERSION}*.deb
 rm -f kubeadm_${VERSION}*.deb

--- a/lib/pharos/scripts/install-kubeadm.sh
+++ b/lib/pharos/scripts/install-kubeadm.sh
@@ -7,7 +7,7 @@ if [ $(kubeadm version -o short) = "v${VERSION}" ]; then
 fi
 
 cd /tmp
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 apt-get download kubeadm=${VERSION}-00
 dpkg -i --ignore-depends=kubelet kubeadm_${VERSION}*.deb
 rm -f kubeadm_${VERSION}*.deb

--- a/lib/pharos/scripts/repos/update.sh
+++ b/lib/pharos/scripts/repos/update.sh
@@ -2,5 +2,5 @@
 
 set -eu
 
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 apt-get update -y

--- a/lib/pharos/scripts/repos/update.sh
+++ b/lib/pharos/scripts/repos/update.sh
@@ -2,4 +2,5 @@
 
 set -eu
 
+DEBIAN_FRONTEND=noninteractive
 apt-get update -y


### PR DESCRIPTION
Removes these errors/warnings:

```
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
```
