### PR TITLE
Release v0.6.0-beta.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "0.5.0"
+  VERSION = "0.6.0-beta.1"
 end


### PR DESCRIPTION
- document open ports (required, monitoring, restricted) (#217)
- refactor SSH client (#223)
- refactor phases to run in parallel across nodes (#111, #245, #231, #253)
- polish up command humanize_duration output (#226)
- fix master upgrade regressions (#230)
- upgrade weave 2.3.0 (#232)
- report config errors to stderr (#233)
- update nginx-ingress to 0.12.0 (#234)
- load rbnacl-libsodium before rbnacl (#238)
- multi-master support (#222, #250)
- store pharos version to configmap (#246)
- set DEBIAN_FRONTEND=noninteractive in scripts (#251)
- handle 0.5 -> 0.6 migration (#247, #254, #255)
- refactor Pharos::Kube (#225)