### PR TITLE
Fix encryption secrets to use the same keys on all master nodes

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -48,6 +48,7 @@ module Pharos
       apply_phase(Phases::ConfigureEtcdCa, [config.etcd_host], ssh: true, parallel: false)
       apply_phase(Phases::ConfigureEtcd, config.etcd_hosts, ssh: true, parallel: true)
 
+      apply_phase(Phases::ConfigureSecretsEncryption, config.master_hosts, ssh: true, parallel: false)
       apply_phase(Phases::ConfigureMaster, config.master_hosts, ssh: true, parallel: false)
       apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: config.master_host)
       apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true) # TODO: also run this phase in parallel for the master nodes, if not doing an upgrade?

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -34,8 +34,6 @@ module Pharos
       end
 
       def upgrade?
-        return true
-
         manifest = File.join(KUBE_DIR, 'manifests', 'kube-apiserver.yaml')
         file = @ssh.file(manifest)
         return false unless file.exist?

--- a/lib/pharos/phases/configure_secrets_encryption.rb
+++ b/lib/pharos/phases/configure_secrets_encryption.rb
@@ -47,7 +47,7 @@ module Pharos
 
         {
           'key1' => Base64.strict_encode64(SecureRandom.random_bytes(32)),
-          'key2' => Base64.strict_encode64(SecureRandom.random_bytes(32)),
+          'key2' => Base64.strict_encode64(SecureRandom.random_bytes(32))
         }
       end
 

--- a/lib/pharos/phases/configure_secrets_encryption.rb
+++ b/lib/pharos/phases/configure_secrets_encryption.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module Pharos
+  module Phases
+    class ConfigureSecretsEncryption < Pharos::Phase
+      title "Configure secrets encryption"
+
+      PHAROS_DIR = '/etc/pharos'
+      SECRETS_CFG_DIR = (PHAROS_DIR + '/secrets-encryption').freeze
+      SECRETS_CFG_FILE = (SECRETS_CFG_DIR + '/config.yml').freeze
+
+      def call
+        keys = cluster_context['secrets_encryption'] || read_config_keys || generate_keys
+
+        ensure_config(keys)
+
+        cluster_context['secrets_encryption'] = keys
+      end
+
+      # @return [Hash, nil]
+      def read_config_keys
+        logger.debug { "Checking if secrets encryption is already configured ..." }
+        file = @ssh.file(SECRETS_CFG_FILE)
+        return nil unless file.exist?
+
+        logger.debug { "Reusing existing encryption keys ..." }
+        config = Pharos::YamlFile.new(file).load
+
+        keys = {}
+        config['resources'].each do |resource|
+          resource['providers'].each do |provider|
+            next unless provider['aescbc']
+
+            provider['aescbc']['keys'].each do |key|
+              keys[key['name']] = key['secret']
+            end
+          end
+        end
+        keys
+      end
+
+      # @return [Hash]
+      def generate_keys
+        logger.info { "Generating new encryption keys ..." }
+
+        {
+          'key1' => Base64.strict_encode64(SecureRandom.random_bytes(32)),
+          'key2' => Base64.strict_encode64(SecureRandom.random_bytes(32)),
+        }
+      end
+
+      def ensure_config(keys)
+        cfg_file = @ssh.file(SECRETS_CFG_FILE)
+        return if cfg_file.exist?
+
+        logger.info { "Creating secrets encryption configuration ..." }
+        @ssh.exec!("test -d #{SECRETS_CFG_DIR} || sudo install -m 0700 -d #{SECRETS_CFG_DIR}")
+        cfg_file.write(parse_resource_file('secrets/encryption-config.yml.erb', keys))
+        cfg_file.chmod('0700')
+      end
+    end
+  end
+end

--- a/spec/pharos/phases/configure_encryption_secrets_spec.rb
+++ b/spec/pharos/phases/configure_encryption_secrets_spec.rb
@@ -1,0 +1,43 @@
+require "pharos/phases/configure_secrets_encryption"
+
+describe Pharos::Phases::ConfigureSecretsEncryption do
+  let(:master) { Pharos::Configuration::Host.new(address: 'test', private_address: 'private', role: 'master') }
+  let(:config_hosts_count) { 1 }
+
+  let(:config) { Pharos::Config.new(
+      hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new(role: 'worker') },
+      network: {
+        service_cidr: '1.2.3.4/16',
+        pod_network_cidr: '10.0.0.0/16'
+      },
+      addons: {},
+      etcd: {}
+  ) }
+
+  let(:ssh) { instance_double(Pharos::SSH::Client) }
+  subject { described_class.new(master, config: config, ssh: ssh) }
+
+    describe '#read_config_keys' do
+      let(:file) { instance_double(Pharos::SSH::RemoteFile) }
+
+      before do
+        allow(ssh).to receive(:file).with('/etc/pharos/secrets-encryption/config.yml').and_return(file)
+      end
+
+      it 'returns nil if no config file existing' do
+        expect(file).to receive(:exist?).and_return(false)
+
+        expect(subject.read_config_keys).to be_nil
+      end
+
+      it 'returns aescbc keys if configured' do
+        expect(file).to receive(:exist?).and_return(true)
+        expect(file).to receive(:read).and_return(fixture("secrets_cfg.yaml"))
+
+        expect(subject.read_config_keys).to eq({
+          'key1' => 's6Xm3BlhHWkD0/5mW5tcks5kcdeWxE3qWkx/gA6hlcI=',
+          'key2' => '23VanHzmFuMQgfnVQrp9oJf0lLa82mThTBVDXd8Uw0s=',
+        })
+      end
+    end
+  end

--- a/spec/pharos/phases/configure_master_spec.rb
+++ b/spec/pharos/phases/configure_master_spec.rb
@@ -251,33 +251,4 @@ describe Pharos::Phases::ConfigureMaster do
       end
     end
   end
-
-  describe '#secrets_encryption_exist' do
-
-    subject { described_class.new(ssh: ssh) }
-
-    let(:ssh) { instance_double(Pharos::SSH::Client, :file => remote_file) }
-
-    let(:remote_file) { double }
-
-    it 'returns false if no config file existing' do
-      subject.instance_variable_set(:@ssh, ssh)
-      expect(remote_file).to receive(:exist?).and_return(false)
-      expect(subject.secrets_encryption_exist?).to be_falsey
-    end
-
-    it 'returns false if aescbc not configured' do
-      subject.instance_variable_set(:@ssh, ssh)
-      expect(remote_file).to receive(:exist?).and_return(true)
-      expect(remote_file).to receive(:read).and_return(fixture("secrets_cfg_no_encryption.yaml"))
-      expect(subject.secrets_encryption_exist?).to be_falsey
-    end
-
-    it 'returns true if aescbc already configured' do
-      subject.instance_variable_set(:@ssh, ssh)
-      expect(remote_file).to receive(:exist?).and_return(true)
-      expect(remote_file).to receive(:read).and_return(fixture("secrets_cfg.yaml"))
-      expect(subject.secrets_encryption_exist?).to be_truthy
-    end
-  end
 end


### PR DESCRIPTION
Fixes #260 

This is the naive approach that only works assuming that you can successfully run the `ConfigureMaster` phase across all master hosts in one go. If one of the hosts fails and you re-run `pharos-cluster up` to install the rest, then you'll get the wrong keys on the remaining nodes.