### PR TITLE
Allow disabling master node taint 

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -26,6 +26,7 @@ module Pharos
               optional(:user).filled
               optional(:ssh_key_path).filled
               optional(:container_runtime).filled(included_in?: ['docker', 'cri-o'])
+              optional(:no_taint_master).filled(:bool?)
             end
           end
         end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -15,6 +15,7 @@ module Pharos
       attribute :user, Pharos::Types::Strict::String.default('ubuntu')
       attribute :ssh_key_path, Pharos::Types::Strict::String.default('~/.ssh/id_rsa')
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
+      attribute :no_taint_master, Pharos::Types::Strict::Bool
 
       attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint
 

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -93,6 +93,8 @@ module Pharos
           }
         }
 
+        config['noTaintMaster'] = true if @host.no_taint_master
+
         if @host.container_runtime == 'cri-o'
           config['criSocket'] = '/var/run/crio/crio.sock'
         end


### PR DESCRIPTION
Useful for a minimal cluster with three master nodes, allowing workload pods to run on the master nodes.

