### PR TITLE
Refactor phase component registration

### DIFF
--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -19,8 +19,7 @@ module Pharos
     # @param version [String]
     # @param license [String]
     def self.register_component(name, version:, license:)
-      slug = name.gsub(/[^a-z0-9]+/, '_')
-      Pharos::Phases.components[slug] = Pharos::Phases::Component.new(
+      Pharos::Phases.components[name] = Pharos::Phases::Component.new(
         name: name,
         version: version,
         license: license

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -14,8 +14,17 @@ module Pharos
       "#{self.class.title} @ #{@host}"
     end
 
-    def self.register_component(component)
-      Pharos::Phases.register_component component
+    # Register a component to the Pharos::Phases component registry
+    # @param name [String]
+    # @param version [String]
+    # @param license [String]
+    def self.register_component(name, version:, license:)
+      slug = name.gsub(/[^a-z0-9]+/, '_')
+      Pharos::Phases.components[slug] = Pharos::Phases::Component.new(
+        name: name.to_s,
+        version: version,
+        license: license
+      )
     end
 
     # @param host [Pharos::Configuration::Host]
@@ -70,6 +79,12 @@ module Pharos
     # @return [Hash]
     def self.cluster_context
       @@cluster_context ||= {} # rubocop:disable Style/ClassVars
+    end
+
+    private
+
+    def components
+      Pharos::Phases.components
     end
   end
 end

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -21,7 +21,7 @@ module Pharos
     def self.register_component(name, version:, license:)
       slug = name.gsub(/[^a-z0-9]+/, '_')
       Pharos::Phases.components[slug] = Pharos::Phases::Component.new(
-        name: name.to_s,
+        name: name,
         version: version,
         license: license
       )

--- a/lib/pharos/phases.rb
+++ b/lib/pharos/phases.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'dry-struct'
-require 'ostruct'
 
 module Pharos
   module Phases
@@ -13,9 +12,9 @@ module Pharos
       attribute :license, Pharos::Types::String
     end
 
-    class ComponentRegistry < OpenStruct
+    class ComponentRegistry < Hash
       def sort_by(&block)
-        @table.values.sort_by(&block)
+        values.sort_by(&block)
       end
     end
 

--- a/lib/pharos/phases.rb
+++ b/lib/pharos/phases.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry-struct'
+require 'ostruct'
 
 module Pharos
   module Phases
@@ -12,22 +13,16 @@ module Pharos
       attribute :license, Pharos::Types::String
     end
 
-    # List of registered components
-    # @return [Set]
-    def self.components
-      @components ||= Set.new
-    end
-
-    def self.register_component(component)
-      components << component
-    end
-
-    # Finds a component using arguments provided in a sym: value hash
-    # @param [Hash] search_argument For example { name: 'kubernetes' }
-    def self.find_component(search_arg)
-      components.find do |component|
-        search_arg.all? { |k, v| component.send(k) == v }
+    class ComponentRegistry < OpenStruct
+      def sort_by(&block)
+        @table.values.sort_by(&block)
       end
+    end
+
+    # List of registered components
+    # @return [ComponentRegistry]
+    def self.components
+      @components ||= ComponentRegistry.new
     end
   end
 end

--- a/lib/pharos/phases/configure_cfssl.rb
+++ b/lib/pharos/phases/configure_cfssl.rb
@@ -12,7 +12,7 @@ module Pharos
         exec_script(
           'configure-cfssl.sh',
           ARCH: @host.cpu_arch.name,
-          VERSION: components.cfssl.version
+          VERSION: components['cfssl'].version
         )
       end
     end

--- a/lib/pharos/phases/configure_cfssl.rb
+++ b/lib/pharos/phases/configure_cfssl.rb
@@ -5,17 +5,14 @@ module Pharos
     class ConfigureCfssl < Pharos::Phase
       title "Configure cfssl"
 
-      register_component(
-        Pharos::Phases::Component.new(
-          name: 'cfssl', version: '1.2', license: 'MIT'
-        )
-      )
+      register_component 'cfssl', version: '1.2.0+git20160825.89.7fb22c8-3', license: 'MIT'
 
       def call
         logger.info { 'Installing cfssl ...' }
         exec_script(
           'configure-cfssl.sh',
-          ARCH: @host.cpu_arch.name
+          ARCH: @host.cpu_arch.name,
+          VERSION: components.cfssl.version
         )
       end
     end

--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -25,8 +25,8 @@ module Pharos
           'configure-etcd.sh',
           PEER_IP: @host.private_address || @host.address,
           INITIAL_CLUSTER: initial_cluster.join(','),
-          ETCD_VERSION: components.etcd.version,
-          KUBE_VERSION: components.kubernetes.version,
+          ETCD_VERSION: components['etcd'].version,
+          KUBE_VERSION: components['kubernetes'].version,
           ARCH: @host.cpu_arch.name,
           PEER_NAME: "etcd#{peer_index + 1}"
         )

--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -6,11 +6,7 @@ module Pharos
       title 'Configure etcd'
       CA_PATH = '/etc/pharos/pki'
 
-      register_component(
-        Pharos::Phases::Component.new(
-          name: 'etcd', version: Pharos::ETCD_VERSION, license: 'Apache License 2.0'
-        )
-      )
+      register_component 'etcd', version: Pharos::ETCD_VERSION, license: 'Apache License 2.0'
 
       def call
         sync_ca
@@ -29,8 +25,8 @@ module Pharos
           'configure-etcd.sh',
           PEER_IP: @host.private_address || @host.address,
           INITIAL_CLUSTER: initial_cluster.join(','),
-          ETCD_VERSION: Pharos::ETCD_VERSION,
-          KUBE_VERSION: Pharos::KUBE_VERSION,
+          ETCD_VERSION: components.etcd.version,
+          KUBE_VERSION: components.kubernetes.version,
           ARCH: @host.cpu_arch.name,
           PEER_NAME: "etcd#{peer_index + 1}"
         )

--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -23,13 +23,13 @@ module Pharos
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{components.docker.version}-0ubuntu1~16.04.2"
+            DOCKER_VERSION: "#{components['docker'].version}-0ubuntu1~16.04.2"
           )
         elsif crio?
           logger.info { "Configuring container runtime (cri-o) packages ..." }
           exec_script(
             'configure-cri-o.sh',
-            CRIO_VERSION: components.cri_o.version,
+            CRIO_VERSION: components['cri_o'].version,
             CRIO_STREAM_ADDRESS: @host.private_address ? @host.private_address : @host.address,
             CPU_ARCH: @host.cpu_arch.name
           )

--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -5,17 +5,8 @@ module Pharos
     class ConfigureHost < Pharos::Phase
       title "Configure hosts"
 
-      register_component(
-        Pharos::Phases::Component.new(
-          name: 'docker', version: Pharos::DOCKER_VERSION, license: 'Apache License 2.0'
-        )
-      )
-
-      register_component(
-        Pharos::Phases::Component.new(
-          name: 'cri-o', version: Pharos::CRIO_VERSION, license: 'Apache License 2.0'
-        )
-      )
+      register_component 'docker', version: Pharos::DOCKER_VERSION, license: 'Apache License 2.0'
+      register_component 'cri-o', version: Pharos::CRIO_VERSION, license: 'Apache License 2.0'
 
       def call
         logger.info { "Configuring essential packages ..." }
@@ -32,13 +23,13 @@ module Pharos
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{Pharos::DOCKER_VERSION}-0ubuntu1~16.04.2"
+            DOCKER_VERSION: "#{components.docker.version}-0ubuntu1~16.04.2"
           )
         elsif crio?
           logger.info { "Configuring container runtime (cri-o) packages ..." }
           exec_script(
             'configure-cri-o.sh',
-            CRIO_VERSION: Pharos::CRIO_VERSION,
+            CRIO_VERSION: components.cri_o.version,
             CRIO_STREAM_ADDRESS: @host.private_address ? @host.private_address : @host.address,
             CPU_ARCH: @host.cpu_arch.name
           )

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -5,11 +5,8 @@ module Pharos
     class ConfigureKubelet < Pharos::Phase
       title "Configure kubelet"
 
-      register_component(
-        Pharos::Phases::Component.new(
-          name: 'kubernetes', version: Pharos::KUBE_VERSION, license: 'Apache License 2.0'
-        )
-      )
+      register_component 'kubernetes', version: Pharos::KUBE_VERSION, license: 'Apache License 2.0'
+      register_component 'kubeadm', version: Pharos::KUBEADM_VERSION, license: 'Apache License 2.0'
 
       DROPIN_PATH = "/etc/systemd/system/kubelet.service.d/5-pharos.conf"
 
@@ -35,7 +32,7 @@ module Pharos
       def configure_kubelet_proxy
         exec_script(
           'configure-kubelet-proxy.sh',
-          KUBE_VERSION: Pharos::KUBE_VERSION,
+          KUBE_VERSION: components.kubernetes.version,
           ARCH: @host.cpu_arch.name,
           MASTER_HOSTS: @config.master_hosts.map(&:peer_address).join(',')
         )
@@ -45,8 +42,8 @@ module Pharos
         logger.info { "Configuring Kubernetes packages ..." }
         exec_script(
           'configure-kube.sh',
-          KUBE_VERSION: Pharos::KUBE_VERSION,
-          KUBEADM_VERSION: Pharos::KUBEADM_VERSION,
+          KUBE_VERSION: components.kubernetes.version,
+          KUBEADM_VERSION: components.kubeadm.version,
           ARCH: @host.cpu_arch.name
         )
       end

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -32,7 +32,7 @@ module Pharos
       def configure_kubelet_proxy
         exec_script(
           'configure-kubelet-proxy.sh',
-          KUBE_VERSION: components.kubernetes.version,
+          KUBE_VERSION: components['kubernetes'].version,
           ARCH: @host.cpu_arch.name,
           MASTER_HOSTS: @config.master_hosts.map(&:peer_address).join(',')
         )
@@ -42,8 +42,8 @@ module Pharos
         logger.info { "Configuring Kubernetes packages ..." }
         exec_script(
           'configure-kube.sh',
-          KUBE_VERSION: components.kubernetes.version,
-          KUBEADM_VERSION: components.kubeadm.version,
+          KUBE_VERSION: components['kubernetes'].version,
+          KUBEADM_VERSION: components['kubeadm'].version,
           ARCH: @host.cpu_arch.name
         )
       end

--- a/lib/pharos/phases/configure_metrics.rb
+++ b/lib/pharos/phases/configure_metrics.rb
@@ -19,7 +19,7 @@ module Pharos
         logger.info { "Configuring heapster ..." }
         Pharos::Kube.apply_stack(
           @master.address, 'heapster',
-          version: components.heapster.version,
+          version: components['heapster'].version,
           arch: @host.cpu_arch,
           client_cert: cert.to_pem
         )

--- a/lib/pharos/phases/configure_metrics.rb
+++ b/lib/pharos/phases/configure_metrics.rb
@@ -5,11 +5,7 @@ module Pharos
     class ConfigureMetrics < Pharos::Phase
       title "Configure metrics"
 
-      register_component(
-        Pharos::Phases::Component.new(
-          name: 'heapster', version: '1.5.1', license: 'Apache License 2.0'
-        )
-      )
+      register_component 'heapster', version: '1.5.1', license: 'Apache License 2.0'
 
       def call
         configure_heapster
@@ -23,7 +19,7 @@ module Pharos
         logger.info { "Configuring heapster ..." }
         Pharos::Kube.apply_stack(
           @master.address, 'heapster',
-          version: '1.5.1',
+          version: components.heapster.version,
           arch: @host.cpu_arch,
           client_cert: cert.to_pem
         )

--- a/lib/pharos/phases/configure_network.rb
+++ b/lib/pharos/phases/configure_network.rb
@@ -39,7 +39,7 @@ module Pharos
           trusted_subnets: trusted_subnets,
           ipalloc_range: @config.network.pod_network_cidr,
           arch: @host.cpu_arch,
-          version: components.weave_net.version
+          version: components['weave-net'].version
         )
       end
 

--- a/lib/pharos/phases/configure_network.rb
+++ b/lib/pharos/phases/configure_network.rb
@@ -5,13 +5,7 @@ module Pharos
     class ConfigureNetwork < Pharos::Phase
       title "Configure network"
 
-      WEAVE_VERSION = '2.3.0'
-
-      register_component(
-        Pharos::Phases::Component.new(
-          name: 'weave-net', version: WEAVE_VERSION, license: 'Apache License 2.0'
-        )
-      )
+      register_component 'weave-net', version: '2.3.0', license: 'Apache License 2.0'
 
       def call
         ensure_passwd
@@ -45,7 +39,7 @@ module Pharos
           trusted_subnets: trusted_subnets,
           ipalloc_range: @config.network.pod_network_cidr,
           arch: @host.cpu_arch,
-          version: WEAVE_VERSION
+          version: components.weave_net.version
         )
       end
 

--- a/lib/pharos/scripts/configure-cfssl.sh
+++ b/lib/pharos/scripts/configure-cfssl.sh
@@ -8,7 +8,7 @@ else
     MIRROR="http://ports.ubuntu.com"
 fi
 
-CFSSL_URL="${MIRROR}/pool/universe/g/golang-github-cloudflare-cfssl/golang-cfssl_1.2.0+git20160825.89.7fb22c8-3_${ARCH}.deb"
+CFSSL_URL="${MIRROR}/pool/universe/g/golang-github-cloudflare-cfssl/golang-cfssl_${VERSION?"Need to set VERSION"}_${ARCH}.deb"
 
 if [ ! -e  /usr/bin/cfssl ]; then
     curl -sL -o /tmp/cfssl.deb ${CFSSL_URL}

--- a/lib/pharos/scripts/configure-cfssl.sh
+++ b/lib/pharos/scripts/configure-cfssl.sh
@@ -8,7 +8,7 @@ else
     MIRROR="http://ports.ubuntu.com"
 fi
 
-CFSSL_URL="${MIRROR}/pool/universe/g/golang-github-cloudflare-cfssl/golang-cfssl_${VERSION?"Need to set VERSION"}_${ARCH}.deb"
+CFSSL_URL="${MIRROR}/pool/universe/g/golang-github-cloudflare-cfssl/golang-cfssl_${VERSION:?"Need to set VERSION"}_${ARCH}.deb"
 
 if [ ! -e  /usr/bin/cfssl ]; then
     curl -sL -o /tmp/cfssl.deb ${CFSSL_URL}

--- a/lib/pharos/scripts/configure-cfssl.sh
+++ b/lib/pharos/scripts/configure-cfssl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ue
 
 if [ "${ARCH}" = "amd64" ]; then
     MIRROR="http://mirrors.kernel.org/ubuntu"
@@ -8,7 +8,7 @@ else
     MIRROR="http://ports.ubuntu.com"
 fi
 
-CFSSL_URL="${MIRROR}/pool/universe/g/golang-github-cloudflare-cfssl/golang-cfssl_${VERSION:?"Need to set VERSION"}_${ARCH}.deb"
+CFSSL_URL="${MIRROR}/pool/universe/g/golang-github-cloudflare-cfssl/golang-cfssl_${VERSION}_${ARCH}.deb"
 
 if [ ! -e  /usr/bin/cfssl ]; then
     curl -sL -o /tmp/cfssl.deb ${CFSSL_URL}


### PR DESCRIPTION
`Pharos::Phases.components` shouldn't contain anything but `Pharos::Phases::Component`s, so:

```ruby
      register_component(	
        Pharos::Phases::Component.new(	
          name: 'cri-o', version: Pharos::CRIO_VERSION, license: 'Apache License 2.0'	
        )	
      )
```

can become:

```ruby
      register_component 'cri-o', version: Pharos::CRIO_VERSION, license: 'Apache License 2.0'
```

Also noticed `kubeadm` wasn't registered and cfssl version was hardcoded in the shell script and registered separately in the configure cfssl phase.

