### PR TITLE
Use only one key for secrets encryption

### DIFF
--- a/lib/pharos/phases/configure_secrets_encryption.rb
+++ b/lib/pharos/phases/configure_secrets_encryption.rb
@@ -46,8 +46,7 @@ module Pharos
         logger.info { "Generating new encryption keys ..." }
 
         {
-          'key1' => Base64.strict_encode64(SecureRandom.random_bytes(32)),
-          'key2' => Base64.strict_encode64(SecureRandom.random_bytes(32))
+          'key1' => Base64.strict_encode64(SecureRandom.random_bytes(32))
         }
       end
 

--- a/lib/pharos/resources/secrets/encryption-config.yml.erb
+++ b/lib/pharos/resources/secrets/encryption-config.yml.erb
@@ -8,6 +8,4 @@ resources:
         keys:
         - name: key1
           secret: "<%= key1 %>"
-        - name: key2
-          secret: "<%= key2 %>"
     - identity: {}


### PR DESCRIPTION
No need to use two keys for secrets encryption.

Multiple keys should be used only when rotating keys.

fixes #262 