### PR TITLE
Handle kubelet manifests atomically in scripts

### DIFF
--- a/lib/pharos/scripts/configure-etcd.sh
+++ b/lib/pharos/scripts/configure-etcd.sh
@@ -3,7 +3,8 @@
 set -e
 
 mkdir -p /etc/kubernetes/manifests
-cat <<EOF >/etc/kubernetes/manifests/pharos-etcd.yaml
+mkdir -p /etc/kubernetes/tmp
+cat  >/etc/kubernetes/tmp/pharos-etcd.yaml <<EOF && mv /etc/kubernetes/tmp/pharos-etcd.yaml /etc/kubernetes/manifests/pharos-etcd.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -65,6 +66,7 @@ spec:
       type: DirectoryOrCreate
     name: etcd-certs
 EOF
+
 
 if [ ! -e /etc/kubernetes/kubelet.conf ]; then
   mkdir -p /etc/systemd/system/kubelet.service.d

--- a/lib/pharos/scripts/configure-kubelet-proxy.sh
+++ b/lib/pharos/scripts/configure-kubelet-proxy.sh
@@ -3,7 +3,8 @@
 set -eu
 
 mkdir -p /etc/kubernetes/manifests
-cat <<EOF >/etc/kubernetes/manifests/pharos-proxy.yaml
+mkdir -p /etc/kubernetes/tmp
+cat >/etc/kubernetes/tmp/pharos-proxy.yaml <<EOF && mv /etc/kubernetes/tmp/pharos-proxy.yaml /etc/kubernetes/manifests/pharos-proxy.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -23,6 +24,7 @@ spec:
         value: "${MASTER_HOSTS}"
   hostNetwork: true
 EOF
+
 
 if [ ! -e /etc/kubernetes/kubelet.conf ]; then
     mkdir -p /etc/systemd/system/kubelet.service.d


### PR DESCRIPTION
Kubelet manifest heredocs are the only ones needed to be handled atomically. All other heredocs are safe, there's explicit control how they get used. (systemd, cfssl, etc.)

fixes #252 