### PR TITLE
Improve etcd-ca host selection syntax readability

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -45,7 +45,7 @@ module Pharos
       apply_phase(Phases::MigrateMaster, config.master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureCfssl, config.etcd_hosts, ssh: true, parallel: true)
-      apply_phase(Phases::ConfigureEtcdCa, config.etcd_hosts[0...1], ssh: true, parallel: false)
+      apply_phase(Phases::ConfigureEtcdCa, [config.etcd_hosts.first].compact, ssh: true, parallel: false)
       apply_phase(Phases::ConfigureEtcd, config.etcd_hosts, ssh: true, parallel: true)
 
       apply_phase(Phases::ConfigureSecretsEncryption, config.master_hosts, ssh: true, parallel: false)


### PR DESCRIPTION
Changes:
```ruby
config.etcd_hosts[0...1]  # <-- three dots. will return [] or [config.etcd_hosts[0]]
```

To more explicit:
```ruby
[config_etcd_hosts.first].compact
```

Possible alternatives:

```ruby
config.etcd_hosts.first(1)
Array.new(config.etcd_hosts.first)
config.etcd_hosts.empty? ? [] : [config_etcd_hosts.first]
```
