### PR TITLE
Handle add/remove of master hosts

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -37,4 +37,8 @@ module Pharos
   module Configuration
     autoload :Host, 'pharos/configuration/host'
   end
+
+  module Etcd
+    autoload :Client, 'pharos/etcd/client'
+  end
 end

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -42,12 +42,12 @@ module Pharos
 
     # @return [Array<Pharos::Configuration::Host>]
     def sorted_master_hosts
-      config.master_hosts.sort_by { |h| h.master_sort_score }
+      config.master_hosts.sort_by(&:master_sort_score)
     end
 
     # @return [Array<Pharos::Configuration::Host>]
     def sorted_etcd_hosts
-      config.etcd_hosts.sort_by { |h| h.etcd_sort_score }
+      config.etcd_hosts.sort_by(&:etcd_sort_score)
     end
 
     def apply_phases

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -44,9 +44,12 @@ module Pharos
       apply_phase(Phases::ValidateHost, config.hosts, ssh: true, parallel: true)
       apply_phase(Phases::MigrateMaster, config.master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
-      apply_phase(Phases::ConfigureCfssl, config.etcd_hosts, ssh: true, parallel: true)
-      apply_phase(Phases::ConfigureEtcdCa, config.etcd_hosts[0...1], ssh: true, parallel: false)
-      apply_phase(Phases::ConfigureEtcd, config.etcd_hosts, ssh: true, parallel: true)
+      unless @config.etcd&.hosts
+        apply_phase(Phases::ConfigureCfssl, config.etcd_hosts, ssh: true, parallel: true)
+        apply_phase(Phases::ConfigureEtcdCa, config.etcd_hosts[0...1], ssh: true, parallel: false)
+        apply_phase(Phases::ConfigureEtcdChanges, config.etcd_hosts[0...1], ssh: true, parallel: false)
+        apply_phase(Phases::ConfigureEtcd, config.etcd_hosts, ssh: true, parallel: true)
+      end
 
       apply_phase(Phases::ConfigureSecretsEncryption, config.master_hosts, ssh: true, parallel: false)
       apply_phase(Phases::ConfigureMaster, config.master_hosts, ssh: true, parallel: false)

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -40,35 +40,74 @@ module Pharos
       addon_manager.validate
     end
 
+    # @return [Array<Pharos::Configuration::Host>]
+    def sorted_master_hosts
+      @sorted_master_hosts ||= config.master_hosts.sort_by { |h| master_sort_score(h) }
+    end
+
+    # @param host [Pharos::Configuration::Host]
+    # @return [Integer]
+    def master_sort_score(host)
+      score = 0
+      return score if host.checks['api_healthy']
+      score += 1
+      return score if host.checks['kubelet_configured']
+
+      score + 1
+    end
+
+    # @return [Array<Pharos::Configuration::Host>]
+    def sorted_etcd_hosts
+      @sorted_etcd_hosts ||= config.etcd_hosts.sort_by { |h| etcd_sort_score(h) }
+    end
+
+    # @param host [Pharos::Configuration::Host]
+    # @return [Integer]
+    def etcd_sort_score(host)
+      score = 0
+      return score if host.checks['etcd_healthy']
+      score += 1
+      return score if host.checks['etcd_ca_exists']
+
+      score + 1
+    end
+
     def apply_phases
       apply_phase(Phases::ValidateHost, config.hosts, ssh: true, parallel: true)
-      apply_phase(Phases::MigrateMaster, config.master_hosts, ssh: true, parallel: true)
+
+      master_hosts = sorted_master_hosts
+
+      apply_phase(Phases::MigrateMaster, master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
+
       unless @config.etcd&.hosts
-        apply_phase(Phases::ConfigureCfssl, config.etcd_hosts, ssh: true, parallel: true)
-        apply_phase(Phases::ConfigureEtcdCa, config.etcd_hosts[0...1], ssh: true, parallel: false)
-        apply_phase(Phases::ConfigureEtcdChanges, config.etcd_hosts[0...1], ssh: true, parallel: false)
-        apply_phase(Phases::ConfigureEtcd, config.etcd_hosts, ssh: true, parallel: true)
+        etcd_hosts = sorted_etcd_hosts
+        apply_phase(Phases::ConfigureCfssl, etcd_hosts, ssh: true, parallel: true)
+        apply_phase(Phases::ConfigureEtcdCa, [etcd_hosts.first], ssh: true, parallel: false)
+        apply_phase(Phases::ConfigureEtcdChanges, [etcd_hosts.first], ssh: true, parallel: false)
+        apply_phase(Phases::ConfigureEtcd, etcd_hosts, ssh: true, parallel: true)
       end
 
-      apply_phase(Phases::ConfigureSecretsEncryption, config.master_hosts, ssh: true, parallel: false)
-      apply_phase(Phases::ConfigureMaster, config.master_hosts, ssh: true, parallel: false)
-      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: config.master_host)
-      apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true) # TODO: also run this phase in parallel for the master nodes, if not doing an upgrade?
-      apply_phase(Phases::ConfigureClient, [config.master_host], ssh: true, parallel: false)
+      apply_phase(Phases::ConfigureSecretsEncryption, master_hosts, ssh: true, parallel: false)
+      apply_phase(Phases::ConfigureMaster, master_hosts, ssh: true, parallel: false)
+      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: master_hosts.first)
+      apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true)
+      apply_phase(Phases::ConfigureClient, [master_hosts.first], ssh: true, parallel: false)
 
       # master is now configured and can be used
-      apply_phase(Phases::ConfigureDNS, [config.master_host], master: config.master_host)
-      apply_phase(Phases::ConfigureNetwork, [config.master_host], master: config.master_host)
-      apply_phase(Phases::ConfigureMetrics, [config.master_host], master: config.master_host)
-      apply_phase(Phases::StoreClusterYAML, [config.master_host], master: config.master_host, config_content: @config_content)
-      apply_phase(Phases::ConfigureBootstrap, [config.master_host], ssh: true) # using `kubeadm token`, not the kube API
+      apply_phase(Phases::ConfigureDNS, [master_hosts.first], master: master_hosts.first)
+      apply_phase(Phases::ConfigureNetwork, [master_hosts.first], master: master_hosts.first)
+      apply_phase(Phases::ConfigureMetrics, [master_hosts.first], master: master_hosts.first)
+      apply_phase(Phases::StoreClusterYAML, [master_hosts.first], master: master_hosts.first, config_content: @config_content)
+      apply_phase(Phases::ConfigureBootstrap, [master_hosts.first], ssh: true) # using `kubeadm token`, not the kube API
 
       apply_phase(Phases::JoinNode, config.worker_hosts, ssh: true, parallel: true)
 
-      apply_phase(Phases::LabelNode, config.hosts, master: config.master_host, ssh: false, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
+      apply_phase(Phases::LabelNode, config.hosts, master: master_hosts.first, ssh: false, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
     end
 
+    # @param phase_class [Pharos::Phase]
+    # @param hosts [Array<Pharos::Configuration::Host>]
     def apply_phase(phase_class, hosts, **options)
       return if hosts.empty?
 

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -53,12 +53,16 @@ module Pharos
     def apply_phases
       apply_phase(Phases::ValidateHost, config.hosts, ssh: true, parallel: true)
 
+      # we need to use sorted masters because phases expects that first one has
+      # ca etc config files
       master_hosts = sorted_master_hosts
 
       apply_phase(Phases::MigrateMaster, master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
 
       unless @config.etcd&.hosts
+        # we need to use sorted etcd hosts because phases expects that first one has
+        # ca etc config files
         etcd_hosts = sorted_etcd_hosts
         apply_phase(Phases::ConfigureCfssl, etcd_hosts, ssh: true, parallel: true)
         apply_phase(Phases::ConfigureEtcdCa, [etcd_hosts.first], ssh: true, parallel: false)

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -42,34 +42,12 @@ module Pharos
 
     # @return [Array<Pharos::Configuration::Host>]
     def sorted_master_hosts
-      @sorted_master_hosts ||= config.master_hosts.sort_by { |h| master_sort_score(h) }
-    end
-
-    # @param host [Pharos::Configuration::Host]
-    # @return [Integer]
-    def master_sort_score(host)
-      score = 0
-      return score if host.checks['api_healthy']
-      score += 1
-      return score if host.checks['kubelet_configured']
-
-      score + 1
+      config.master_hosts.sort_by { |h| h.master_sort_score }
     end
 
     # @return [Array<Pharos::Configuration::Host>]
     def sorted_etcd_hosts
-      @sorted_etcd_hosts ||= config.etcd_hosts.sort_by { |h| etcd_sort_score(h) }
-    end
-
-    # @param host [Pharos::Configuration::Host]
-    # @return [Integer]
-    def etcd_sort_score(host)
-      score = 0
-      return score if host.checks['etcd_healthy']
-      score += 1
-      return score if host.checks['etcd_ca_exists']
-
-      score + 1
+      config.etcd_hosts.sort_by { |h| h.etcd_sort_score }
     end
 
     def apply_phases

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -40,7 +40,21 @@ module Pharos
       addon_manager.validate
     end
 
+    # @return [Pharos::Configuration::Host]
+    def preferred_master_host
+      master = config.master_hosts.find { |h|
+        ssh = ssh_manager.client_for(h)
+        ssh.file('/etc/kubernetes/kubelet.conf').exist?
+      }
+      if master
+        master
+      else
+        config.master_host
+      end
+    end
+
     def apply_phases
+      master = preferred_master_host
       apply_phase(Phases::ValidateHost, config.hosts, ssh: true, parallel: true)
       apply_phase(Phases::MigrateMaster, config.master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
@@ -53,20 +67,20 @@ module Pharos
 
       apply_phase(Phases::ConfigureSecretsEncryption, config.master_hosts, ssh: true, parallel: false)
       apply_phase(Phases::ConfigureMaster, config.master_hosts, ssh: true, parallel: false)
-      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: config.master_host)
+      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: master)
       apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true) # TODO: also run this phase in parallel for the master nodes, if not doing an upgrade?
-      apply_phase(Phases::ConfigureClient, [config.master_host], ssh: true, parallel: false)
+      apply_phase(Phases::ConfigureClient, [master], ssh: true, parallel: false)
 
       # master is now configured and can be used
-      apply_phase(Phases::ConfigureDNS, [config.master_host], master: config.master_host)
-      apply_phase(Phases::ConfigureNetwork, [config.master_host], master: config.master_host)
-      apply_phase(Phases::ConfigureMetrics, [config.master_host], master: config.master_host)
-      apply_phase(Phases::StoreClusterYAML, [config.master_host], master: config.master_host, config_content: @config_content)
-      apply_phase(Phases::ConfigureBootstrap, [config.master_host], ssh: true) # using `kubeadm token`, not the kube API
+      apply_phase(Phases::ConfigureDNS, [master], master: master)
+      apply_phase(Phases::ConfigureNetwork, [master], master: master)
+      apply_phase(Phases::ConfigureMetrics, [master], master: master)
+      apply_phase(Phases::StoreClusterYAML, [master], master: master, config_content: @config_content)
+      apply_phase(Phases::ConfigureBootstrap, [master], ssh: true) # using `kubeadm token`, not the kube API
 
       apply_phase(Phases::JoinNode, config.worker_hosts, ssh: true, parallel: true)
 
-      apply_phase(Phases::LabelNode, config.hosts, master: config.master_host, ssh: false, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
+      apply_phase(Phases::LabelNode, config.hosts, master: master, ssh: false, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
     end
 
     def apply_phase(phase_class, hosts, **options)

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -40,21 +40,7 @@ module Pharos
       addon_manager.validate
     end
 
-    # @return [Pharos::Configuration::Host]
-    def preferred_master_host
-      master = config.master_hosts.find { |h|
-        ssh = ssh_manager.client_for(h)
-        ssh.file('/etc/kubernetes/kubelet.conf').exist?
-      }
-      if master
-        master
-      else
-        config.master_host
-      end
-    end
-
     def apply_phases
-      master = preferred_master_host
       apply_phase(Phases::ValidateHost, config.hosts, ssh: true, parallel: true)
       apply_phase(Phases::MigrateMaster, config.master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
@@ -67,20 +53,20 @@ module Pharos
 
       apply_phase(Phases::ConfigureSecretsEncryption, config.master_hosts, ssh: true, parallel: false)
       apply_phase(Phases::ConfigureMaster, config.master_hosts, ssh: true, parallel: false)
-      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: master)
+      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: config.master_host)
       apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true) # TODO: also run this phase in parallel for the master nodes, if not doing an upgrade?
-      apply_phase(Phases::ConfigureClient, [master], ssh: true, parallel: false)
+      apply_phase(Phases::ConfigureClient, [config.master_host], ssh: true, parallel: false)
 
       # master is now configured and can be used
-      apply_phase(Phases::ConfigureDNS, [master], master: master)
-      apply_phase(Phases::ConfigureNetwork, [master], master: master)
-      apply_phase(Phases::ConfigureMetrics, [master], master: master)
-      apply_phase(Phases::StoreClusterYAML, [master], master: master, config_content: @config_content)
-      apply_phase(Phases::ConfigureBootstrap, [master], ssh: true) # using `kubeadm token`, not the kube API
+      apply_phase(Phases::ConfigureDNS, [config.master_host], master: config.master_host)
+      apply_phase(Phases::ConfigureNetwork, [config.master_host], master: config.master_host)
+      apply_phase(Phases::ConfigureMetrics, [config.master_host], master: config.master_host)
+      apply_phase(Phases::StoreClusterYAML, [config.master_host], master: config.master_host, config_content: @config_content)
+      apply_phase(Phases::ConfigureBootstrap, [config.master_host], ssh: true) # using `kubeadm token`, not the kube API
 
       apply_phase(Phases::JoinNode, config.worker_hosts, ssh: true, parallel: true)
 
-      apply_phase(Phases::LabelNode, config.hosts, master: master, ssh: false, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
+      apply_phase(Phases::LabelNode, config.hosts, master: config.master_host, ssh: false, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
     end
 
     def apply_phase(phase_class, hosts, **options)

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -96,7 +96,7 @@ module Pharos
 
       # master is now configured and can be used
       apply_phase(Phases::ConfigureDNS, [master_hosts.first], master: master_hosts.first)
- 
+
       apply_phase(Phases::ConfigureWeave, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'weave'
       apply_phase(Phases::ConfigureCalico, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'calico'
       apply_phase(Phases::ConfigureMetrics, [master_hosts.first], master: master_hosts.first)

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -16,7 +16,7 @@ module Pharos
       attribute :ssh_key_path, Pharos::Types::Strict::String.default('~/.ssh/id_rsa')
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
 
-      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint
+      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :checks
 
       def to_s
         address

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -57,6 +57,28 @@ module Pharos
       def crio?
         container_runtime == 'cri-o'
       end
+
+      # @return [Integer]
+      def master_sort_score
+        if checks['api_healthy']
+          0
+        elsif checks['kubelet_configured']
+          1
+        else
+          2
+        end
+      end
+
+      # @return [Integer]
+      def etcd_sort_score
+        if checks['etcd_healthy']
+          0
+        elsif checks['etcd_ca_exists']
+          1
+        else
+          2
+        end
+      end
     end
   end
 end

--- a/lib/pharos/etcd/client.rb
+++ b/lib/pharos/etcd/client.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'json'
+
+module Pharos
+  module Etcd
+    class Client
+      CURL = 'sudo curl -s --connect-timeout 2 --cacert /etc/pharos/pki/ca.pem --cert /etc/pharos/pki/etcd/client.pem --key /etc/pharos/pki/etcd/client-key.pem https://localhost:2379'
+
+      def initialize(ssh)
+        @ssh = ssh
+      end
+
+      def healthy?
+        response = @ssh.exec!("#{CURL}/health")
+        response.stdout == '{"health": "true"}'
+      rescue
+        false
+      end
+
+      # @return [Array<Hash>]
+      def members
+        result = @ssh.exec("#{CURL}/v2/members")
+        JSON.parse(result.stdout)['members']
+      rescue JSON::ParserError
+        []
+      end
+
+      # @param host [Pharos::Configuration::Host]
+      def add_member(host)
+        @ssh.exec!("#{CURL}/v2/members -X POST -H 'Content-Type: application/json' -d '{\"peerURLs\":[\"https://#{host.peer_address}:2380\"]}'")
+      end
+    end
+  end
+end

--- a/lib/pharos/etcd/client.rb
+++ b/lib/pharos/etcd/client.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'json'
 
 module Pharos
@@ -37,9 +38,9 @@ module Pharos
         @ssh.exec!("#{CURL}/v2/members -X POST -H 'Content-Type: application/json' -d @-", stdin: JSON.dump(data))
       end
 
-      # @param id [String] etcd member id
-      def remove_member(id)
-        @ssh.exec!("#{CURL}/v2/members/#{id} -X DELETE")
+      # @param member_id [String] etcd member id
+      def remove_member(member_id)
+        @ssh.exec!("#{CURL}/v2/members/#{member_id} -X DELETE")
       end
     end
   end

--- a/lib/pharos/etcd/client.rb
+++ b/lib/pharos/etcd/client.rb
@@ -36,6 +36,11 @@ module Pharos
         }
         @ssh.exec!("#{CURL}/v2/members -X POST -H 'Content-Type: application/json' -d @-", stdin: JSON.dump(data))
       end
+
+      # @param id [String] etcd member id
+      def remove_member(id)
+        @ssh.exec!("#{CURL}/v2/members/#{id} -X DELETE")
+      end
     end
   end
 end

--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -19,7 +19,7 @@ module Pharos
         logger.info(@host.address) { 'Configuring etcd certs ...' }
         exec_script(
           'configure-etcd-certs.sh',
-          PEER_IP: @host.peer_address
+          PEER_IP: @host.peer_address,
           PEER_NAME: peer_name(@host),
           ARCH: @host.cpu_arch.name
         )

--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -32,7 +32,7 @@ module Pharos
           KUBE_VERSION: Pharos::KUBE_VERSION,
           ARCH: @host.cpu_arch.name,
           PEER_NAME: peer_name(@host),
-          INITIAL_CLUSTER_STATE: initial_cluster_state
+          INITIAL_CLUSTER_STATE: initial_cluster_state,
           KUBELET_ARGS: @host.kubelet_args(local_only: true).join(" ")
         )
       end

--- a/lib/pharos/phases/configure_etcd_changes.rb
+++ b/lib/pharos/phases/configure_etcd_changes.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'json'
+
+module Pharos
+  module Phases
+    class ConfigureEtcdChanges < Pharos::Phase
+      title 'Configure etcd member changes'
+
+      def call
+        store_initial_cluster_state
+
+        if etcd.healthy?
+          add_new_members if initial_cluster_state == 'existing'
+        end
+      end
+
+      def store_initial_cluster_state
+        return if cluster_context['etcd-initial-cluster-state']
+
+        if @ssh.file('/etc/kubernetes/manifests/pharos-etcd.yaml').exist?
+          cluster_context['etcd-initial-cluster-state'] = 'existing'
+        else
+          cluster_context['etcd-initial-cluster-state'] = 'new'
+        end
+      end
+
+      def add_new_members
+        member_list = etcd.members
+        new_members = @config.etcd_hosts.select { |h|
+          !member_list.find { |m|
+            m['name'] == peer_name(h) && m['peerURLs'] == ["https://#{h.peer_address}:2380"]
+          }
+        }
+        new_members.each do |h|
+          logger.info { "Adding new etcd peer #{peer_name(h)}, https://#{h.peer_address}:2380 ..." }
+          etcd.add_member(h)
+        end
+      end
+
+      # @return [Pharos::Etcd::Client]
+      def etcd
+        @etcd ||= Pharos::Etcd::Client.new(@ssh)
+      end
+
+      # @param peer [Pharos::Configuration::Host]
+      # @return [String]
+      def peer_name(peer)
+        peer_index = @config.etcd_hosts.find_index { |h| h == peer }
+        "etcd#{peer_index + 1}"
+      end
+
+      # @return [Boolean]
+      def first_peer?
+        @config.etcd_hosts[0] == @host
+      end
+
+      # @return [String,NilClass]
+      def initial_cluster_state
+        cluster_context['etcd-initial-cluster-state']
+      end
+    end
+  end
+end

--- a/lib/pharos/phases/configure_etcd_changes.rb
+++ b/lib/pharos/phases/configure_etcd_changes.rb
@@ -11,7 +11,7 @@ module Pharos
 
         if initial_cluster_state == 'existing' && etcd.healthy?
           removed = remove_old_members
-          sleep 10 if removed > 0
+          sleep 10 if removed > 0 # try to be gentle
           add_new_members
         end
       end
@@ -37,7 +37,7 @@ module Pharos
           fail "Cannot add multiple etcd peers at once"
         end
         new_members.each do |h|
-          logger.info { "Adding new etcd peer #{peer_name(h)}, https://#{h.peer_address}:2380 ..." }
+          logger.info { "Adding new etcd peer https://#{h.peer_address}:2380 ..." }
           etcd.add_member(h)
         end
 
@@ -55,7 +55,7 @@ module Pharos
           fail "Cannot remove majority of etcd peers"
         end
         remove_members.each do |m|
-          logger.info { "Remove old etcd peer #{m['name']}, #{m['peerURLs'].join(', ')} ..." }
+          logger.info { "Remove old etcd peer #{m['peerURLs'].join(', ')} ..." }
           etcd.remove_member(m['id'])
         end
 
@@ -65,13 +65,6 @@ module Pharos
       # @return [Pharos::Etcd::Client]
       def etcd
         @etcd ||= Pharos::Etcd::Client.new(@ssh)
-      end
-
-      # @param peer [Pharos::Configuration::Host]
-      # @return [String]
-      def peer_name(peer)
-        peer_index = @config.etcd_hosts.find_index { |h| h == peer }
-        "etcd#{peer_index + 1}"
       end
 
       # @return [String,NilClass]

--- a/lib/pharos/phases/configure_etcd_changes.rb
+++ b/lib/pharos/phases/configure_etcd_changes.rb
@@ -55,7 +55,7 @@ module Pharos
           fail "Cannot remove majority of etcd peers"
         end
         remove_members.each do |m|
-          logger.info { "Remove old etcd peer #{m['peerURLs'].join(', ')} ..." }
+          logger.info { "Removing old etcd peer #{m['peerURLs'].join(', ')} ..." }
           etcd.remove_member(m['id'])
         end
 

--- a/lib/pharos/phases/configure_etcd_changes.rb
+++ b/lib/pharos/phases/configure_etcd_changes.rb
@@ -49,11 +49,6 @@ module Pharos
         "etcd#{peer_index + 1}"
       end
 
-      # @return [Boolean]
-      def first_peer?
-        @config.etcd_hosts[0] == @host
-      end
-
       # @return [String,NilClass]
       def initial_cluster_state
         cluster_context['etcd-initial-cluster-state']

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -44,20 +44,8 @@ module Pharos
 
       def install
         configure_kubelet
-
         cfg = generate_config
-
-        # Copy etcd certs over if needed
-        if @config.etcd&.certificate
-          logger.info { "Pushing external etcd certificates ..." }
-          copy_external_etcd_certs
-        end
-
-        push_audit_config if @config.audit&.server
-
-        # Generate and upload authentication token webhook config file if needed
-        push_authentication_token_webhook_config if @config.authentication&.token_webhook
-
+        push_configs
         copy_kube_certs
 
         logger.info { "Initializing control plane ..." }
@@ -71,6 +59,49 @@ module Pharos
         logger.info { "Initialization of control plane succeeded!" }
         @ssh.exec!('install -m 0700 -d ~/.kube')
         @ssh.exec!('sudo install -o $USER -m 0600 /etc/kubernetes/admin.conf ~/.kube/config')
+      end
+
+      def configure
+        copy_kube_certs
+        push_configs
+        cfg = generate_config
+        @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
+          @ssh.exec!("sudo kubeadm alpha phase controlplane all --config #{tmp_file}")
+        end
+        cache_kube_certs
+        configure_kubelet
+      end
+
+      def upgrade
+        logger.info { "Upgrading control plane ..." }
+        exec_script(
+          "install-kubeadm.sh",
+          VERSION: Pharos::KUBEADM_VERSION,
+          ARCH: @host.cpu_arch.name
+        )
+        copy_kube_certs
+        push_configs
+        cfg = generate_config
+        @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
+          @ssh.exec!("sudo kubeadm upgrade apply #{Pharos::KUBE_VERSION} -y --ignore-preflight-errors=all --allow-experimental-upgrades --config #{tmp_file}")
+        end
+        logger.info { "Control plane upgrade succeeded!" }
+
+        cache_kube_certs
+        configure_kubelet
+      end
+
+      def push_configs
+        # Copy etcd certs over if needed
+        if @config.etcd&.certificate
+          logger.info { "Pushing external etcd certificates ..." }
+          copy_external_etcd_certs
+        end
+
+        push_audit_config if @config.audit&.server
+
+        # Generate and upload authentication token webhook config file if needed
+        push_authentication_token_webhook_config if @config.authentication&.token_webhook
       end
 
       def generate_config
@@ -310,22 +341,6 @@ module Pharos
         @ssh.file(PHAROS_DIR + '/token_webhook/key.pem').write(File.open(File.expand_path(webhook_config[:user][:client_key]))) if webhook_config[:user][:client_key]
       end
 
-      def upgrade
-        logger.info { "Upgrading control plane ..." }
-        exec_script(
-          "install-kubeadm.sh",
-          VERSION: Pharos::KUBEADM_VERSION,
-          ARCH: @host.cpu_arch.name
-        )
-        cfg = generate_config
-        @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
-          @ssh.exec!("sudo kubeadm upgrade apply #{Pharos::KUBE_VERSION} -y --ignore-preflight-errors=all --allow-experimental-upgrades --config #{tmp_file}")
-        end
-        logger.info { "Control plane upgrade succeeded!" }
-
-        configure_kubelet
-      end
-
       def push_audit_config
         logger.info { "Pushing audit configs to master ..." }
         @ssh.exec!("sudo mkdir -p #{AUDIT_CFG_DIR}")
@@ -343,15 +358,6 @@ module Pharos
         upload_authentication_token_webhook_config(auth_token_webhook_config)
         logger.info { "Pushing token authentication webhook certificates ..." }
         upload_authentication_token_webhook_certs(webhook_config)
-      end
-
-      def configure
-        cfg = generate_config
-        @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
-          @ssh.exec!("sudo kubeadm alpha phase certs all --config #{tmp_file}")
-          @ssh.exec!("sudo kubeadm alpha phase controlplane all --config #{tmp_file}")
-        end
-        configure_kubelet
       end
 
       def configure_kubelet

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -346,6 +346,11 @@ module Pharos
       end
 
       def configure
+        cfg = generate_config
+        @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
+          @ssh.exec!("sudo kubeadm alpha phase certs all --config #{tmp_file}")
+          @ssh.exec!("sudo kubeadm alpha phase controlplane all --config #{tmp_file}")
+        end
         configure_kubelet
       end
 

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -36,11 +36,7 @@ module Pharos
         @host.os_release = os_release
         @host.cpu_arch = cpu_arch
         @host.hostname = hostname
-        if @host.role == 'master'
-          @host.checks = master_checks
-        else
-          @host.checks = worker_checks
-        end
+        @host.checks = @host.role == 'master' ? master_checks : worker_checks
       end
 
       # @return [String]

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -87,7 +87,7 @@ module Pharos
         unless @config.etcd&.endpoints
           etcd = Pharos::Etcd::Client.new(@ssh)
           data['etcd_healthy'] = etcd.healthy?
-          data['etcd_ca_exists'] = @ssh.file('/etc/pharos/pki/etcd/ca-key.pem').exist?
+          data['etcd_ca_exists'] = @ssh.file('/etc/pharos/pki/ca-key.pem').exist?
         end
 
         data.merge(worker_checks)

--- a/lib/pharos/scripts/configure-etcd.sh
+++ b/lib/pharos/scripts/configure-etcd.sh
@@ -35,7 +35,7 @@ spec:
     - --peer-client-cert-auth=true
     - --initial-cluster=${INITIAL_CLUSTER}
     - --initial-cluster-token=pharos-etcd-token
-    - --initial-cluster-state=new
+    - --initial-cluster-state=${INITIAL_CLUSTER_STATE}
 
     image: k8s.gcr.io/etcd-${ARCH}:${ETCD_VERSION}
     livenessProbe:
@@ -84,7 +84,12 @@ fi
 
 echo "Waiting etcd to launch on port 2380..."
 
-while ! nc -z ${PEER_IP} 2380; do
+etcd_healthy() {
+  response=$(curl -s --cacert /etc/pharos/pki/ca.pem --cert /etc/pharos/pki/etcd/client.pem --key /etc/pharos/pki/etcd/client-key.pem https://${PEER_IP}:2379/health)
+  [ "${response}" = '{"health": "true"}' ]
+}
+
+while ! etcd_healthy; do
   sleep 1
 done
 

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -53,7 +53,7 @@ module Pharos
       # True if the file exists. Assumes a bash-like shell.
       # @return [Boolean]
       def exist?
-        @client.exec?("[ -e #{escaped_path} ]")
+        @client.exec!("sudo sh -c 'test -e #{escaped_path} && echo true || echo false'").strip == "true"
       end
 
       # Performs the block if the remote file exists, otherwise returns false

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -111,7 +111,7 @@ module Pharos
       craft_time = Time.now - start_time
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    You can connect to the cluster with kubectl using:"
-      puts "    export KUBECONFIG=~/.pharos/#{config.master_host.api_address}"
+      puts "    export KUBECONFIG=~/.pharos/#{manager.sorted_master_hosts.first.api_address}"
 
       manager.disconnect
     end


### PR DESCRIPTION
Adds logic for adding/removing masters. It allows to grow number of masters one-by-one (reason for this is internal etcd clustering). Multiple masters can be removed  at the same time from cluster if majority is kept in place. These rules do not apply if cluster.yml is configured to use external etcd endpoints.

Fixes #240 