### PR TITLE
Update crio to 1.10 and fix it

### DIFF
--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -32,7 +32,8 @@ module Pharos
           ETCD_VERSION: Pharos::ETCD_VERSION,
           KUBE_VERSION: Pharos::KUBE_VERSION,
           ARCH: @host.cpu_arch.name,
-          PEER_NAME: "etcd#{peer_index + 1}"
+          PEER_NAME: "etcd#{peer_index + 1}",
+          KUBELET_ARGS: @host.kubelet_args(local_only: true).join(" ")
         )
       end
 

--- a/lib/pharos/scripts/configure-etcd.sh
+++ b/lib/pharos/scripts/configure-etcd.sh
@@ -74,7 +74,7 @@ if [ ! -e /etc/kubernetes/kubelet.conf ]; then
 [Service]
 ExecStartPre=-/sbin/swapoff -a
 ExecStart=
-ExecStart=/usr/bin/kubelet --pod-manifest-path=/etc/kubernetes/manifests/ --read-only-port=0 --cadvisor-port=0 --address=127.0.0.1
+ExecStart=/usr/bin/kubelet ${KUBELET_ARGS}
 EOF
 
   apt-mark unhold kubelet

--- a/lib/pharos/scripts/configure-kubelet-proxy.sh
+++ b/lib/pharos/scripts/configure-kubelet-proxy.sh
@@ -32,7 +32,7 @@ if [ ! -e /etc/kubernetes/kubelet.conf ]; then
 [Service]
 ExecStartPre=-/sbin/swapoff -a
 ExecStart=
-ExecStart=/usr/bin/kubelet --pod-manifest-path=/etc/kubernetes/manifests/ --read-only-port=0 --cadvisor-port=0 --address=127.0.0.1
+ExecStart=/usr/bin/kubelet ${KUBELET_ARGS}
 EOF
 
     export DEBIAN_FRONTEND=noninteractive

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -8,7 +8,7 @@ require_relative "pharos/error"
 require_relative "pharos/root_command"
 
 module Pharos
-  CRIO_VERSION = '1.9'
+  CRIO_VERSION = '1.10'
   KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.1' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.1.12' }


### PR DESCRIPTION
cri-o setup was totally broken, caused by etcd & kubelet proxy dropins.

Moved the kubelet args logic into `Configuration::Host` so that it can easily be re-used in different phases doing kubelet configs & "one-shot" runs.

