### PR TITLE
Fix MigrateWorker to be independent of the master host

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -50,7 +50,7 @@ module Pharos
 
       apply_phase(Phases::ConfigureSecretsEncryption, config.master_hosts, ssh: true, parallel: false)
       apply_phase(Phases::ConfigureMaster, config.master_hosts, ssh: true, parallel: false)
-      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: config.master_host)
+      apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureKubelet, config.worker_hosts, ssh: true, parallel: true) # TODO: also run this phase in parallel for the master nodes, if not doing an upgrade?
       apply_phase(Phases::ConfigureClient, [config.master_host], ssh: true, parallel: false)
 

--- a/lib/pharos/phases/migrate_worker.rb
+++ b/lib/pharos/phases/migrate_worker.rb
@@ -17,10 +17,7 @@ module Pharos
 
       def migrate_0_5_to_0_6
         logger.info { 'Migrating from 0.5 to 0.6 ...' }
-        exec_script(
-          'migrations/migrate_worker_05_to_06.sh',
-          PEER_IP: @master.peer_address
-        )
+        exec_script('migrations/migrate_worker_05_to_06.sh')
       end
     end
   end

--- a/lib/pharos/scripts/migrations/migrate_worker_05_to_06.sh
+++ b/lib/pharos/scripts/migrations/migrate_worker_05_to_06.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-set -e
+set -ue
 
-if grep -q "${PEER_IP}:6443" /etc/kubernetes/kubelet.conf; then
-  # reconfigure
-  sed -i "s/${PEER_IP}/localhost/g" /etc/kubernetes/kubelet.conf
-  sed -i "s/${PEER_IP}/localhost/g" /etc/kubernetes/bootstrap-kubelet.conf
+SERVER=${SERVER:-localhost:6443}
+
+if ! grep -qF "server: https://$SERVER" /etc/kubernetes/kubelet.conf; then
+  sed -i "s/server: .*/server: https:\/\/$SERVER/g" /etc/kubernetes/kubelet.conf /etc/kubernetes/bootstrap-kubelet.conf
   systemctl restart kubelet
 fi


### PR DESCRIPTION
The `@master.peer_address` is not really needed for rewriting the worker host's `kubelet.conf` `server` to use `localhost' instead. This simplifies the migration phase.