### PR TITLE
Discover host private interface address

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -21,6 +21,7 @@ module Pharos
             schema do
               required(:address).filled
               optional(:private_address).filled
+              optional(:private_interface).filled
               required(:role).filled(included_in?: ['master', 'worker'])
               optional(:labels).filled
               optional(:user).filled

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -32,7 +32,6 @@ module Pharos
 
       def kubelet_args(local_only: false)
         args = []
-        node_ip = private_address.nil? ? address : private_address
 
         if crio?
           args << '--container-runtime=remote'
@@ -47,7 +46,7 @@ module Pharos
           args << "--address=127.0.0.1"
         else
           args << '--read-only-port=0'
-          args << "--node-ip=#{node_ip}"
+          args << "--node-ip=#{peer_address}"
           args << "--hostname-override=#{hostname}"
         end
 

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -10,13 +10,14 @@ module Pharos
 
       attribute :address, Pharos::Types::Strict::String
       attribute :private_address, Pharos::Types::Strict::String
+      attribute :private_interface, Pharos::Types::Strict::String
       attribute :role, Pharos::Types::Strict::String
       attribute :labels, Pharos::Types::Strict::Hash
       attribute :user, Pharos::Types::Strict::String.default('ubuntu')
       attribute :ssh_key_path, Pharos::Types::Strict::String.default('~/.ssh/id_rsa')
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
 
-      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint
+      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address
 
       def to_s
         address
@@ -27,7 +28,7 @@ module Pharos
       end
 
       def peer_address
-        private_address || address
+        private_address || private_interface_address || address
       end
 
       def kubelet_args(local_only: false)

--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -19,7 +19,7 @@ module Pharos
         peer_index = @config.etcd_hosts.find_index { |h| h == @host }
         exec_script(
           'configure-etcd-certs.sh',
-          PEER_IP: @host.private_address || @host.address,
+          PEER_IP: @host.peer_address,
           PEER_NAME: "etcd#{peer_index + 1}",
           ARCH: @host.cpu_arch.name
         )
@@ -27,7 +27,7 @@ module Pharos
         logger.info(@host.address) { 'Configuring etcd ...' }
         exec_script(
           'configure-etcd.sh',
-          PEER_IP: @host.private_address || @host.address,
+          PEER_IP: @host.peer_address,
           INITIAL_CLUSTER: initial_cluster.join(','),
           ETCD_VERSION: Pharos::ETCD_VERSION,
           KUBE_VERSION: Pharos::KUBE_VERSION,

--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -39,7 +39,7 @@ module Pharos
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
-            CRIO_STREAM_ADDRESS: @host.private_address ? @host.private_address : @host.address,
+            CRIO_STREAM_ADDRESS: @host.peer_address,
             CPU_ARCH: @host.cpu_arch.name
           )
         else

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -146,6 +146,7 @@ module Pharos
         extra_sans = Set.new(['localhost'])
         extra_sans << @host.address
         extra_sans << @host.private_address if @host.private_address
+        extra_sans << @host.private_interface_address if @host.private_interface_address
         extra_sans << @host.api_endpoint if @host.api_endpoint
 
         extra_sans.to_a

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -29,7 +29,7 @@ module Pharos
       end
 
       def find_node
-        internal_ip = @host.private_address || @host.address
+        internal_ip = @host.peer_address
         node = nil
         retries = 0
         while node.nil? && retries < 10

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -36,6 +36,7 @@ module Pharos
         @host.os_release = os_release
         @host.cpu_arch = cpu_arch
         @host.hostname = hostname
+        @host.private_interface_address = private_interface_address(@host.private_interface) if @host.private_interface
       end
 
       # @return [String]
@@ -73,6 +74,19 @@ module Pharos
         Pharos::Configuration::CpuArch.new(
           id: cpu['Architecture']
         )
+      end
+
+      # @param interface [String]
+      # @return [String]
+      def private_interface_address(interface)
+        @ssh.exec!("ip -o addr show dev #{interface} scope global | awk '{ print $4 }'").each_line do |line|
+          ip, prefixlen = line.split('/')
+
+          next if ip == @host.address
+
+          return ip
+        end
+        return nil
       end
     end
   end


### PR DESCRIPTION
Fixes #127 

Support `private_interface` as an alternative to `private_address`.

The `ValidateHost` phase discovers the private Ip using `ip addr`. This will fail if the interface does not exist, or continue without a private IP if the interface is not configured.