### PR TITLE
Cleanup config_content

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -6,9 +6,11 @@ module Pharos
 
     attr_reader :config
 
-    def initialize(config, **opts)
+    # @param config [Pharos::Config]
+    # @param pastel [Pastel]
+    def initialize(config, pastel: Pastel.new)
       @config = config
-      @pastel = opts.fetch(:pastel) { Pastel.new }
+      @pastel = pastel
     end
 
     # @return [Pharos::SSH::Manager]

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -32,7 +32,6 @@ module Pharos
     def execute
       puts pastel.green("==> Reading instructions ...")
       config_hash = load_config
-      config_content = read_config
       if tf_json
         puts pastel.green("==> Importing configuration from Terraform ...")
         load_terraform(tf_json, config_hash)
@@ -42,7 +41,7 @@ module Pharos
       # so that the certs etc. can be referenced more easily
       Dir.chdir(config_yaml.dirname) do
         config = build_config(config_hash)
-        configure(config, config_content: config_content)
+        configure(config)
       end
     rescue StandardError => ex
       raise unless ENV['DEBUG'].to_s.empty?
@@ -53,11 +52,6 @@ module Pharos
     # @return [Hash] hash presentation of cluster.yml
     def load_config
       config_yaml.load(ENV.to_h)
-    end
-
-    # @return [String] raw cluster.yml
-    def read_config
-      config_yaml.read(ENV.to_h)
     end
 
     # @param file [String]
@@ -95,8 +89,8 @@ module Pharos
 
     # @param config [Pharos::Config]
     # @param config_content [String]
-    def configure(config, config_content:)
-      manager = ClusterManager.new(config, config_content: config_content, pastel: pastel)
+    def configure(config)
+      manager = ClusterManager.new(config, pastel: pastel)
       start_time = Time.now
 
       puts pastel.green("==> Sharpening tools ...")


### PR DESCRIPTION
No longer needed after #317, but it's still getting passed to the `ClusterManager`, which ignores it because it's not using keyword arguments.