### PR TITLE
Fix calico node IP address autodetection to use private addresses if available

### DIFF
--- a/lib/pharos/phases/configure_calico.rb
+++ b/lib/pharos/phases/configure_calico.rb
@@ -30,6 +30,7 @@ module Pharos
         Pharos::Kube.apply_stack(
           @master.api_address, 'calico',
           ipv4_pool_cidr: @config.network.pod_network_cidr,
+          master_ip: @config.master_host.peer_address,
           version: CALICO_VERSION
         )
       end

--- a/lib/pharos/resources/calico/daemonset.yml.erb
+++ b/lib/pharos/resources/calico/daemonset.yml.erb
@@ -94,9 +94,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Auto-detect the BGP IP address.
+            # Auto-detect the BGP IP address
             - name: IP
               value: "autodetect"
+            - name: IP_AUTODETECTION_METHOD
+              value: "can-reach=<%= master_ip %>"
             - name: FELIX_HEALTHENABLED
               value: "true"
           securityContext:


### PR DESCRIPTION
Fixes #316

Use [`IP_AUTODETECTION_METHOD=can-reach`](https://docs.projectcalico.org/v3.1/reference/node/configuration#ip-autodetection-methods) with the first master host's private address to have calico nodes use their private addresses for BGP peering and routing nexthop.

Alternative would be to override the `projectcalico.org/IPv4Address` annotation for each kube node, but that would get ugly when joining new nodes to the cluster.