### PR TITLE
Configurable calico ipip_mode

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -44,6 +44,7 @@ module Pharos
             optional(:trusted_subnets).each(type?: String)
           end
           optional(:calico).schema do
+            optional(:ipip_mode).filled(included_in?: %(Always, CrossSubnet, Never))
           end
         end
         optional(:etcd).schema do

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -15,6 +15,8 @@ module Pharos
 
       class Calico < Dry::Struct
         constructor_type :schema
+
+        attribute :ipip_mode, Pharos::Types::String.default('Always')
       end
 
       attribute :provider, Pharos::Types::String.default('weave')

--- a/lib/pharos/phases/configure_calico.rb
+++ b/lib/pharos/phases/configure_calico.rb
@@ -31,6 +31,7 @@ module Pharos
           @master.api_address, 'calico',
           ipv4_pool_cidr: @config.network.pod_network_cidr,
           ipip_mode: @config.network.calico&.ipip_mode || 'Always',
+          ipip_enabled: @config.network.calico&.ipip_mode != 'Never',
           master_ip: @config.master_host.peer_address,
           version: CALICO_VERSION
         )

--- a/lib/pharos/phases/configure_calico.rb
+++ b/lib/pharos/phases/configure_calico.rb
@@ -30,6 +30,7 @@ module Pharos
         Pharos::Kube.apply_stack(
           @master.api_address, 'calico',
           ipv4_pool_cidr: @config.network.pod_network_cidr,
+          ipip_mode: @config.network.calico&.ipip_mode || 'Always',
           master_ip: @config.master_host.peer_address,
           version: CALICO_VERSION
         )

--- a/lib/pharos/resources/calico/daemonset.yml.erb
+++ b/lib/pharos/resources/calico/daemonset.yml.erb
@@ -85,7 +85,7 @@ spec:
               value: "<%= ipip_mode %>"
             # Enable IP-in-IP within Felix.
             - name: FELIX_IPINIPENABLED
-              value: "true"
+              value: "<%= ipip_enabled ? 'true' : 'false' %>"
             # Typha support: controlled by the ConfigMap.
             - name: FELIX_TYPHAK8SSERVICENAME
               value: "none"

--- a/lib/pharos/resources/calico/daemonset.yml.erb
+++ b/lib/pharos/resources/calico/daemonset.yml.erb
@@ -82,7 +82,7 @@ spec:
                   key: ipv4_pool_cidr
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
+              value: "<%= ipip_mode %>"
             # Enable IP-in-IP within Felix.
             - name: FELIX_IPINIPENABLED
               value: "true"


### PR DESCRIPTION
Fixes #315

Allow configuring `network.calico.ipip_mode` to `Never`, `CrossSubnet`, `Always` (default).

If configured to `Never`, then the `ipip` setup (`tunl0` iface) is disabled completely.

Changing the `ipip_mode` is not supported... it requires resetting the calico ipPool (`kubectl delete ippools.crd.projectcalico.org default-ipv4-ippool`) and restarting the calico-node pods.