### PR TITLE
Disable only previously enabled addons

### DIFF
--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -18,12 +18,22 @@ module Pharos
     end
 
     # @param config [Pharos::Configuration]
-    def initialize(config)
+    # @param cluster_context [Hash]
+    def initialize(config, cluster_context)
       @config = config
+      @cluster_context = cluster_context
     end
 
     def configs
       @config.addons
+    end
+
+    def prev_configs
+      if config = @cluster_context['previous-config']
+        config.addons
+      else
+        {}
+      end
     end
 
     # @return [Array<Pharos::Addon>]
@@ -51,11 +61,11 @@ module Pharos
       with_enabled_addons do |addon_class, config_hash|
         config = addon_class.validate(config_hash)
 
-        yield addon_class.new(config, enabled: true, master: @master, **options)
+        yield addon_class.new(config, enabled: true, **options)
       end
 
       with_disabled_addons do |addon_class|
-        yield addon_class.new(nil, enabled: false, master: @master, **options)
+        yield addon_class.new(nil, enabled: false, **options)
       end
     end
 
@@ -71,11 +81,12 @@ module Pharos
     end
 
     def with_disabled_addons
-      addon_classes.each do |addon_class|
+      addon_classes.select { |addon_class|
+        prev_config = prev_configs[addon_class.name]
         config = configs[addon_class.name]
-        if config.nil? || !config["enabled"]
-          yield(addon_class)
-        end
+        prev_config && prev_config["enabled"] && (config.nil? || !config["enabled"])
+      }.each do |addon_class|
+        yield(addon_class)
       end
     end
   end

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -85,7 +85,6 @@ module Pharos
       apply_phase(Phases::ConfigureWeave, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'weave'
       apply_phase(Phases::ConfigureCalico, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'calico'
       apply_phase(Phases::ConfigureMetrics, [master_hosts.first], master: master_hosts.first)
-      apply_phase(Phases::StoreClusterYAML, [master_hosts.first], master: master_hosts.first)
       apply_phase(Phases::ConfigureBootstrap, [master_hosts.first], ssh: true) # using `kubeadm token`, not the kube API
 
       apply_phase(Phases::JoinNode, config.worker_hosts, ssh: true, parallel: true)
@@ -109,6 +108,11 @@ module Pharos
 
         addon.apply
       end
+    end
+
+    def save_config
+      master_host = sorted_master_hosts.first
+      apply_phase(Phases::StoreClusterYAML, [master_host], master: master_host)
     end
 
     def disconnect

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -11,6 +11,7 @@ module Pharos
     def initialize(config, pastel: Pastel.new)
       @config = config
       @pastel = pastel
+      @context = Hash.new
     end
 
     # @return [Pharos::SSH::Manager]
@@ -22,13 +23,14 @@ module Pharos
     def phase_manager
       @phase_manager = Pharos::PhaseManager.new(
         ssh_manager: ssh_manager,
-        config: @config
+        config: @config,
+        cluster_context: @context
       )
     end
 
     # @return [Pharos::AddonManager]
     def addon_manager
-      @addon_manager ||= Pharos::AddonManager.new(@config)
+      @addon_manager ||= Pharos::AddonManager.new(@config, @context)
     end
 
     # load phases/addons

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -11,7 +11,7 @@ module Pharos
     def initialize(config, pastel: Pastel.new)
       @config = config
       @pastel = pastel
-      @context = Hash.new
+      @context = {}
     end
 
     # @return [Pharos::SSH::Manager]

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -22,11 +22,12 @@ module Pharos
     # @param config [Pharos::Config]
     # @param ssh [Pharos::SSH::Client]
     # @param master [Pharos::Configuration::Host]
-    def initialize(host, config: nil, ssh: nil, master: nil)
+    def initialize(host, config: nil, ssh: nil, master: nil, cluster_context: nil)
       @host = host
       @config = config
       @ssh = ssh
       @master = master
+      @cluster_context = cluster_context
     end
 
     def logger
@@ -64,12 +65,7 @@ module Pharos
 
     # @return [Hash]
     def cluster_context
-      self.class.cluster_context
-    end
-
-    # @return [Hash]
-    def self.cluster_context
-      @@cluster_context ||= {} # rubocop:disable Style/ClassVars
+      @cluster_context
     end
   end
 end

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -18,6 +18,8 @@ module Pharos
       Pharos::Phases.register_component component
     end
 
+    attr_reader :cluster_context
+
     # @param host [Pharos::Configuration::Host]
     # @param config [Pharos::Config]
     # @param ssh [Pharos::SSH::Client]
@@ -61,11 +63,6 @@ module Pharos
 
     def parse_resource_file(path, vars = {})
       Pharos::YamlFile.new(resource_path(path)).read(vars)
-    end
-
-    # @return [Hash]
-    def cluster_context
-      @cluster_context
     end
   end
 end

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -5,18 +5,54 @@ module Pharos
     class ConfigureClient < Pharos::Phase
       title "Configure kube client"
 
+      REMOTE_FILE = "/etc/kubernetes/admin.conf"
+
       def call
+        save_config_locally
+        config_map = previous_config_map
+        if config_map
+          cluster_context['previous-config-map'] = config_map
+          cluster_context['previous-config'] = build_config(config_map)
+        end
+      end
+
+      def save_config_locally
         Dir.mkdir(config_dir, 0o700) unless Dir.exist?(config_dir)
-        config_file = File.join(config_dir, @host.api_address)
+
         logger.info { "Fetching kubectl config ..." }
-        config_data = @ssh.file("/etc/kubernetes/admin.conf").read
+        config_data = remote_config_file.read
         File.chmod(0o600, config_file) if File.exist?(config_file)
         File.write(config_file, config_data.gsub(%r{(server: https://)(.+)(:6443)}, "\\1#{@host.api_address}\\3"), perm: 0o600)
         logger.info { "Configuration saved to #{config_file}" }
       end
 
+      def remote_config_file
+        @ssh.file(REMOTE_FILE)
+      end
+
+      def config_file
+        File.join(config_dir, @host.api_address)
+      end
+
       def config_dir
         File.join(Dir.home, '.pharos')
+      end
+
+      # @param configmap [Kubeclient::Resource]
+      # @return [Pharos::Config]
+      def build_config(configmap)
+        cluster_config = YAML.safe_load(configmap.data['cluster.yml'])
+        cluster_config['hosts'] ||= []
+        data = Pharos::ConfigSchema.build.call(cluster_config)
+        Pharos::Config.new(data)
+      end
+
+      # @return [Kubeclient::Resource]
+      def previous_config_map
+        kube_client = Pharos::Kube.client(@host.api_address)
+        kube_client.get_config_map('pharos-config', 'kube-system')
+      rescue Kubeclient::ResourceNotFoundError
+        nil
       end
     end
   end

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -10,10 +10,10 @@ module Pharos
       def call
         save_config_locally
         config_map = previous_config_map
-        if config_map
-          cluster_context['previous-config-map'] = config_map
-          cluster_context['previous-config'] = build_config(config_map)
-        end
+        return unless config_map
+
+        cluster_context['previous-config-map'] = config_map
+        cluster_context['previous-config'] = build_config(config_map)
       end
 
       def save_config_locally

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -41,7 +41,7 @@ module Pharos
       # @param configmap [Kubeclient::Resource]
       # @return [Pharos::Config]
       def build_config(configmap)
-        cluster_config = YAML.safe_load(configmap.data['cluster.yml'])
+        cluster_config = Pharos::YamlFile.new(StringIO.new(configmap.data['cluster.yml']), override_filename: "#{@host}:cluster.yml").load
         cluster_config['hosts'] ||= []
         data = Pharos::ConfigSchema.build.call(cluster_config)
         Pharos::Config.new(data)

--- a/lib/pharos/phases/store_cluster_yaml.rb
+++ b/lib/pharos/phases/store_cluster_yaml.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Store cluster YAML"
 
       def call
-        logger.info { "Storing cluster configuration to configmap" }
+        logger.info { "Storing cluster configuration to configmap ..." }
         resource.apply
       end
 

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -103,6 +103,8 @@ module Pharos
       puts pastel.green("==> Configuring addons ...")
       manager.apply_addons
 
+      manager.save_config
+
       craft_time = Time.now - start_time
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    You can connect to the cluster with kubectl using:"

--- a/spec/pharos/phases/join_node_spec.rb
+++ b/spec/pharos/phases/join_node_spec.rb
@@ -14,11 +14,15 @@ describe Pharos::Phases::JoinNode do
   }
   let(:master) { double(:master) }
   let(:ssh) { double(:ssh) }
-  let(:subject) { described_class.new(host, ssh: ssh) }
+  let(:cluster_context) {
+    {
+      'join-command' => join_cmd
+    }
+  }
+  let(:subject) { described_class.new(host, ssh: ssh, cluster_context: cluster_context) }
   let(:join_cmd) { 'kubeadm join --token 531bb9.d1637f0a9b6af2ba 127.0.0.1:6443 --discovery-token-ca-cert-hash sha256:98d563efbb07a11cde93884394ba1d266912def377bfadc65d01a3bcc0ddd30d' }
 
   before(:each) do
-    described_class.cluster_context['join-command'] = join_cmd
     allow(subject).to receive(:already_joined?).and_return(false)
   end
 


### PR DESCRIPTION
It was annoying to see (and wait) "disabling addon ..." messages on every run. This PR adds a bit more logic to `AddonManager` so that we only disable addon if it was previously enabled.

PR also includes a bit more clean cluster context implementation.