### PR TITLE
Fix stack prune

### DIFF
--- a/lib/pharos/kube/client.rb
+++ b/lib/pharos/kube/client.rb
@@ -71,6 +71,17 @@ module Pharos
 
         get_entity(definition.resource_name, resource.metadata.name, resource.metadata.namespace)
       end
+
+      # @param resource [Kubeclient::Resource]
+      def delete_resource(resource, propagationPolicy: 'Foreground')
+        definition = entity_for_resource(resource)
+
+        delete_entity(definition.resource_name, resource.metadata.name, resource.metadata.namespace, delete_options: {
+          apiVersion: 'v1',
+          kind: 'DeleteOptions',
+          propagationPolicy: propagationPolicy
+        })
+      end
     end
   end
 end

--- a/lib/pharos/kube/client.rb
+++ b/lib/pharos/kube/client.rb
@@ -73,14 +73,19 @@ module Pharos
       end
 
       # @param resource [Kubeclient::Resource]
-      def delete_resource(resource, propagationPolicy: 'Foreground')
+      def delete_resource(resource, propagation_policy: 'Foreground')
         definition = entity_for_resource(resource)
 
-        delete_entity(definition.resource_name, resource.metadata.name, resource.metadata.namespace, delete_options: {
-          apiVersion: 'v1',
-          kind: 'DeleteOptions',
-          propagationPolicy: propagationPolicy
-        })
+        delete_entity(
+          definition.resource_name,
+          resource.metadata.name,
+          resource.metadata.namespace,
+          delete_options: {
+            apiVersion: 'v1',
+            kind: 'DeleteOptions',
+            propagationPolicy: propagation_policy
+          }
+        )
       end
     end
   end

--- a/lib/pharos/kube/resource.rb
+++ b/lib/pharos/kube/resource.rb
@@ -51,24 +51,12 @@ module Pharos
         Resource.new(@session, @client.get_resource(@resource))
       end
 
-      # Deletes the resource from kube. Returns false if the resource
-      # does not exist.
+      # Deletes the resource from kube.
+      # Returns false if the resource does not exist.
+      #
       # @return [Kubeclient::Resource,FalseClass]
-      def delete
-        if attributes.metadata.selfLink
-          api_group = attributes.metadata.selfLink.split('/')[1]
-          path = attributes.metadata.selfLink.gsub("/#{api_group}/#{@api_version}", '')
-          @client.rest_client[path].delete
-        else
-          definition = entity_definition
-          @client.get_entity(definition.resource_name, metadata.name, metadata.namespace)
-          @client.delete_entity(
-            definition.resource_name, metadata.name, metadata.namespace,
-            kind: 'DeleteOptions',
-            apiVersion: 'v1',
-            propagationPolicy: 'Foreground'
-          )
-        end
+      def delete(**options)
+        @client.delete_resource(@resource, **options)
       rescue Kubeclient::ResourceNotFoundError
         false
       end
@@ -86,16 +74,6 @@ module Pharos
 
       def respond_to_missing?(meth, include_private = false)
         attributes.respond_to?(meth, include_private) || super
-      end
-
-      private
-
-      def underscored_entity
-        Kubeclient::ClientMixin.underscore_entity(kind)
-      end
-
-      def entity_definition
-        @client.entities[underscored_entity]
       end
     end
   end

--- a/lib/pharos/kube/session.rb
+++ b/lib/pharos/kube/session.rb
@@ -26,9 +26,18 @@ module Pharos
         Stack.new(self, name, vars)
       end
 
-      # List of api groups available for the session
-      def api_groups
-        resource_client('').apis.groups
+      # Discover preferred api group/version strings for this session
+      # @return [Array<String>] group/version or version
+      def api_versions
+        api_versions = []
+
+        resource_client('').apis.groups.each do |api_group|
+          api_versions << api_group.preferredVersion.groupVersion
+        end
+
+        api_versions << 'v1'
+
+        api_versions
       end
 
       # A Pharos::Kube::Client instance for the session's host and

--- a/lib/pharos/kube/stack.rb
+++ b/lib/pharos/kube/stack.rb
@@ -58,6 +58,7 @@ module Pharos
             next if method_name.end_with?('_review')
             next if api_version == 'v1' && entity.resource_name == 'bindings' # XXX: the entity definition does not have the list verb... but kubeclient does not expose that
             next if api_version == 'v1' && entity.resource_name == 'componentstatuses' # apiserver ignores the ?labelSelector query
+            next if api_version == 'v1' && entity.resource_name == 'endpoints' # inherits stack labels from service, does not have any ownerReference...
 
             resources = client.get_entities(entity.entity_type, entity.resource_name, label_selector: "#{RESOURCE_LABEL}=#{@name}")
             resources = resources.select do |obj|

--- a/lib/pharos/kube/stack.rb
+++ b/lib/pharos/kube/stack.rb
@@ -15,7 +15,6 @@ module Pharos
         @name = name
         @resource_path = RESOURCE_PATH.join(name).freeze
         @vars = vars
-        freeze
       end
 
       # A list of .yml and yml.erb files in the stacks resource directory
@@ -83,8 +82,12 @@ module Pharos
 
       private
 
+      def random_checksum
+        SecureRandom.hex(16)
+      end
+
       def with_pruning
-        checksum = SecureRandom.hex(16)
+        checksum = random_checksum
         result = yield checksum
         prune(checksum)
         result

--- a/spec/pharos/kube/stack_spec.rb
+++ b/spec/pharos/kube/stack_spec.rb
@@ -19,7 +19,7 @@ describe Pharos::Kube::Stack do
   end
 
   describe '#apply' do
-    let(:session) { double(api_groups: []) }
+    let(:session) { double(api_versions: []) }
 
     before do
       allow(session).to receive(:resource).with(an_instance_of(Hash)).at_least(:once).and_return(resource)

--- a/spec/pharos/kube/stack_spec.rb
+++ b/spec/pharos/kube/stack_spec.rb
@@ -19,14 +19,23 @@ describe Pharos::Kube::Stack do
   end
 
   describe '#apply' do
-    let(:session) { double(api_versions: []) }
+    let(:resource1) { double(:resource1, metadata: OpenStruct.new) }
+    let(:resources) { [resource1] }
+    let(:random_checksum) { '42' }
 
     before do
-      allow(session).to receive(:resource).with(an_instance_of(Hash)).at_least(:once).and_return(resource)
+      allow(subject).to receive(:resources).and_return(resources)
+      allow(subject).to receive(:random_checksum).and_return(random_checksum)
     end
 
     it 'applies all resources' do
-      expect(resource).to receive(:apply)
+      expect(resource1).to receive(:apply) do
+        expect(resource1.metadata.labels['pharos.kontena.io/stack']).to eq 'ingress-nginx'
+        expect(resource1.metadata.annotations['pharos.kontena.io/stack-checksum']).to eq random_checksum
+      end
+
+      expect(subject).to receive(:prune).with(random_checksum)
+
       subject.apply
     end
   end


### PR DESCRIPTION
Fixes  #18

* `Pharos::Kube::Stack#prune` was not enumerating the core `v1` api resources
* `Pharos::Kube::Resource#delete` was not setting any `DeleteOptions` `propagationPolicy` if the resource had the `metadata.selfLink`

Change the `Pharos::Kube::Stack#prune` to enumerate each API resource type in turn, fixing up the resource list items to include the correct `apiVersion` and `kind`, such that the `selfLink` is no longer required.

The stack prune now also enumerates all of the core API resource types at the end, which also means that stack prunes now takes even longer.