### PR TITLE
Store component and addon versions to configmap

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -50,6 +50,10 @@ module Pharos
       end
     end
 
+    def self.to_h
+      { name: name, version: version, license: license }
+    end
+
     def self.schema(&block)
       @schema = Dry::Validation.Form(Schema, &block)
     end

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -112,7 +112,7 @@ module Pharos
 
     def save_config
       master_host = sorted_master_hosts.first
-      apply_phase(Phases::StoreClusterYAML, [master_host], master: master_host)
+      apply_phase(Phases::StoreClusterConfiguration, [master_host], master: master_host)
     end
 
     def disconnect

--- a/lib/pharos/phases.rb
+++ b/lib/pharos/phases.rb
@@ -17,6 +17,10 @@ module Pharos
 
         enabled.call(config)
       end
+
+      def to_h
+        super.tap { |s| s.delete(:enabled) }
+      end
     end
 
     # List of registered components

--- a/lib/pharos/phases/store_cluster_configuration.rb
+++ b/lib/pharos/phases/store_cluster_configuration.rb
@@ -24,13 +24,18 @@ module Pharos
           data: {
             'cluster.yml' => data.to_yaml,
             'pharos-version' => Pharos::VERSION,
-            'pharos-components' => components.to_yaml
+            'pharos-components' => components.to_yaml,
+            'pharos-addons' => addons.to_yaml
           }
         )
       end
 
       def components
         JSON.parse(Pharos::Phases.components_for_config(@config).sort_by(&:name).map(&:to_h).to_json)
+      end
+
+      def addons
+        JSON.parse(Pharos::Addon.descendants.map(&:to_h).select { |a| @config.addons.dig(a[:name], 'enabled') }.to_json)
       end
     end
   end

--- a/lib/pharos/phases/store_cluster_configuration.rb
+++ b/lib/pharos/phases/store_cluster_configuration.rb
@@ -2,8 +2,8 @@
 
 module Pharos
   module Phases
-    class StoreClusterYAML < Pharos::Phase
-      title "Store cluster YAML"
+    class StoreClusterConfiguration < Pharos::Phase
+      title "Store cluster configuration"
 
       def call
         logger.info { "Storing cluster configuration to configmap ..." }
@@ -23,9 +23,14 @@ module Pharos
           },
           data: {
             'cluster.yml' => data.to_yaml,
-            'pharos-version' => Pharos::VERSION
+            'pharos-version' => Pharos::VERSION,
+            'pharos-components' => components.to_yaml
           }
         )
+      end
+
+      def components
+        JSON.parse(Pharos::Phases.components_for_config(@config).sort_by(&:name).map(&:to_h).to_json)
       end
     end
   end

--- a/lib/pharos/phases/store_cluster_configuration.rb
+++ b/lib/pharos/phases/store_cluster_configuration.rb
@@ -24,8 +24,8 @@ module Pharos
           data: {
             'cluster.yml' => data.to_yaml,
             'pharos-version' => Pharos::VERSION,
-            'pharos-components' => components.to_yaml,
-            'pharos-addons' => addons.to_yaml
+            'pharos-components.yml' => components.to_yaml,
+            'pharos-addons.yml' => addons.to_yaml
           }
         )
       end


### PR DESCRIPTION
Fixes #324 

```console
$ kubectl -n kube-system get configmap/pharos-config -o json
```

```json
{
    "apiVersion": "v1",
    "data": {
        "cluster.yml": "---\nhosts:\n- address: 192.168.100.100\n  private_address: 192.168.100.100\n  user: vagrant\n  role: master\n  ssh_key_path: \"~/.vagrant.d/insecure_private_key\"\n- address: 192.168.100.101\n  user: vagrant\n  role: worker\n  ssh_key_path: \"~/.vagrant.d/insecure_private_key\"\n- address: 192.168.100.102\n  user: vagrant\n  role: worker\n  ssh_key_path: \"~/.vagrant.d/insecure_private_key\"\nnetwork:\n  pod_network_cidr: 10.32.0.0/16\naddons:\n  ingress-nginx:\n    enabled: true\n    configmap:\n      map-hash-bucket-size: '128'\n  kured:\n    enabled: false\n  host-upgrades:\n    enabled: true\n    interval: 7d\n",
        "pharos-addons.yml": "---\n- name: host-upgrades\n  version: 0.1.0\n  license: Apache License 2.0\n- name: ingress-nginx\n  version: 0.12.0\n  license: Apache License 2.0\n",
        "pharos-components.yml": "---\n- name: cfssl\n  version: '1.2'\n  license: MIT\n- name: docker\n  version: 1.13.1\n  license: Apache License 2.0\n- name: etcd\n  version: 3.1.12\n  license: Apache License 2.0\n- name: heapster\n  version: 1.5.1\n  license: Apache License 2.0\n- name: kubernetes\n  version: 1.10.1\n  license: Apache License 2.0\n- name: weave-net\n  version: 2.3.0\n  license: Apache License 2.0\n",
        "pharos-version": "1.0.0-beta.1"
    },
    "kind": "ConfigMap",
    "metadata": {
        "creationTimestamp": "2018-04-27T09:15:15Z",
        "name": "pharos-config",
        "namespace": "kube-system",
        "resourceVersion": "9121",
        "selfLink": "/api/v1/namespaces/kube-system/configmaps/pharos-config",
        "uid": "7f56f26d-49fb-11e8-a3f5-02f41f34da68"
    }
}
```
