### PR TITLE
Fix host role checks to skip unconfigured hosts

### DIFF
--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -43,8 +43,9 @@ module Pharos
       end
 
       def check_role
+        return if !@host.checks['kubelet_configured']
         return if @host.master? && @host.checks['ca_exists'] == true
-        return if @host.worker? && @host.checks['kubelet_configured'] && @host.checks['ca_exists'] != true
+        return if @host.worker? && @host.checks['ca_exists'] != true
 
         raise Pharos::InvalidHostError, "Cannot change role of an existing node"
       end

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -44,10 +44,12 @@ module Pharos
 
       def check_role
         return if !@host.checks['kubelet_configured']
-        return if @host.master? && @host.checks['ca_exists'] == true
-        return if @host.worker? && @host.checks['ca_exists'] != true
 
-        raise Pharos::InvalidHostError, "Cannot change role of an existing node"
+        if @host.master? && !@host.checks['ca_exists']
+          raise Pharos::InvalidHostError, "Cannot change worker host role to master"
+        elsif @host.worker? && @host.checks['ca_exists']
+          raise Pharos::InvalidHostError, "Cannot change master host role to worker"
+        end
       end
 
       # @return [String]

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -45,11 +45,10 @@ module Pharos
       def check_role
         return if !@host.checks['kubelet_configured']
 
-        if @host.master? && !@host.checks['ca_exists']
-          raise Pharos::InvalidHostError, "Cannot change worker host role to master"
-        elsif @host.worker? && @host.checks['ca_exists']
-          raise Pharos::InvalidHostError, "Cannot change master host role to worker"
-        end
+        raise Pharos::InvalidHostError, "Cannot change worker host role to master" if @host.master? && !@host.checks['ca_exists']
+        raise Pharos::InvalidHostError, "Cannot change master host role to worker" if @host.worker? && @host.checks['ca_exists']
+
+        logger.debug { "#{@host.role} role matches" }
       end
 
       # @return [String]

--- a/spec/pharos/phases/validate_host_spec.rb
+++ b/spec/pharos/phases/validate_host_spec.rb
@@ -53,6 +53,36 @@ describe Pharos::Phases::ValidateHost do
   end
 
   describe '#check_role' do
+    it 'does not raise if unconfigured -> worker' do
+      worker = Pharos::Configuration::Host.new(
+        address: '192.0.2.1',
+        role: 'worker'
+      )
+      worker.checks = {
+        'ca_exists' => false,
+        'api_healthy' => false,
+        'kubelet_configured' => false
+      }
+
+      subject = described_class.new(worker, config: config, ssh: ssh)
+      expect{ subject.check_role }.not_to raise_error
+    end
+
+    it 'does not raise if unconfigured -> master' do
+      worker = Pharos::Configuration::Host.new(
+        address: '192.0.2.1',
+        role: 'master'
+      )
+      worker.checks = {
+        'ca_exists' => false,
+        'api_healthy' => false,
+        'kubelet_configured' => false
+      }
+
+      subject = described_class.new(worker, config: config, ssh: ssh)
+      expect{ subject.check_role }.not_to raise_error
+    end
+
     it 'does not raise if master -> master' do
       config.hosts[0].checks = {
         'ca_exists' => true,
@@ -68,7 +98,8 @@ describe Pharos::Phases::ValidateHost do
       )
       worker.checks = {
         'ca_exists' => true,
-        'api_healthy' => true
+        'api_healthy' => true,
+        'kubelet_configured' => true
       }
       subject = described_class.new(worker, config: config, ssh: ssh)
       expect{ subject.check_role }.to raise_error

--- a/spec/pharos/phases/validate_host_spec.rb
+++ b/spec/pharos/phases/validate_host_spec.rb
@@ -79,7 +79,7 @@ describe Pharos::Phases::ValidateHost do
         } }
 
         it 'does not raise' do
-          expect{ subject.check_role }.to_not raise_error(Pharos::InvalidHostError)
+          expect{ subject.check_role }.to_not raise_error
         end
       end
 
@@ -91,7 +91,7 @@ describe Pharos::Phases::ValidateHost do
         } }
 
         it 'does not raise' do
-          expect{ subject.check_role }.to_not raise_error(Pharos::InvalidHostError)
+          expect{ subject.check_role }.to_not raise_error
         end
       end
 
@@ -119,7 +119,7 @@ describe Pharos::Phases::ValidateHost do
         } }
 
         it 'does not raise' do
-          expect{ subject.check_role }.to_not raise_error(Pharos::InvalidHostError)
+          expect{ subject.check_role }.to_not raise_error
         end
       end
 
@@ -143,7 +143,7 @@ describe Pharos::Phases::ValidateHost do
         } }
 
         it 'does not raise' do
-          expect{ subject.check_role }.to_not raise_error(Pharos::InvalidHostError)
+          expect{ subject.check_role }.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
Fixes #332

Minimal fix to skip the role checks if the kubelet was not yet configured. Tested to worker for `role` changes after a succesfull `pharos-cluster up`.