### PR TITLE
Release v1.0.0

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.0.0-rc.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
## Changes since 0.6.x

- update Kubernetes to 1.10.1 (#284, #299)
- support calico as an alternative network provider (#265)
- handle add/remove of master hosts (#293)
- allow to configure cloud-config (#289)
- allow configuring kube-proxy mode (#168)
- discover host private interface address (#303)
- prompt & show config (#327)
- store component and addon versions to configmap (#333)
- install nfs-common as part of configure-kube (#339)
- validate hostname uniqueness (#311)
- terraform packet.net example (#313)
- store complete cluster.yml to configmap (#317)
- create bootstrap token only if needed (#318)
- cleanup unused config_content (#319)
- calico: use IP_AUTODETECTION_METHOD=can-reach with a node's peer address (#321)
- calico: configurable ipip_mode (#322)
- disable only previously enabled addons (#323)
- scale ingress-nginx default backend (#320)
- pass cloud-config option to kube-controller-manager (#330)
- fix stack prune (#326)
- prevent role change for existing node (#331, #336)
- add pharos kubelet proxy component info (#335)
- fix MigrateWorker to be independent of the master host (#302)
- fix rbnacl warnings by upgrading Net::SSH (#271)
- drop Net::SCP (#285)
- handle kubelet manifests atomically in scripts (#291)
- use only one key for secrets encryption (#288)