### PR TITLE
[WIP] Add openebs add-on

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -131,5 +131,7 @@ module Pharos
     def prune_stack
       Pharos::Kube.prune_stack(@master.address, self.class.name, '-')
     end
+
+    def validate; end
   end
 end

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -61,8 +61,9 @@ module Pharos
     def each
       with_enabled_addons do |addon_class, config_hash|
         config = addon_class.validate(config_hash)
-
-        yield addon_class.new(config, enabled: true, **options)
+        addon = addon_class.new(config, enabled: true, **options)
+        addon.validate
+        yield addon
       end
 
       with_disabled_addons do |addon_class|

--- a/lib/pharos/addons/open_ebs.rb
+++ b/lib/pharos/addons/open_ebs.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Addons
+    class OpenEbs < Pharos::Addon
+      name 'openebs'
+      version '0.5.3'
+      license 'Apache License 2.0'
+
+      struct {
+        attribute :default_replicas, Pharos::Types::Int
+        attribute :default_capacity, Pharos::Types::String
+      }
+
+      schema {
+        optional(:default_replicas).filled(:int?)
+        optional(:default_capacity).filled(:str?)
+      }
+
+      def validate
+        super
+        raise Pharos::InvalidAddonError, "Cannot set more replicas than workers" if config.default_replicas && config.default_replicas > cluster_config.worker_hosts.count
+      end
+
+      def default_replica_count
+        cluster_config.worker_hosts.count < 3 ? cluster_config.worker_hosts.count : 3
+      end
+
+      def install
+        apply_stack(
+          default_replicas: config.default_replicas || default_replica_count,
+          default_capacity: config.default_capacity || '5G'
+        )
+      end
+    end
+  end
+end

--- a/lib/pharos/error.rb
+++ b/lib/pharos/error.rb
@@ -3,4 +3,5 @@
 module Pharos
   class Error < StandardError; end
   class InvalidHostError < Error; end
+  class InvalidAddonError < Error; end
 end

--- a/lib/pharos/kube/stack.rb
+++ b/lib/pharos/kube/stack.rb
@@ -3,6 +3,8 @@
 module Pharos
   module Kube
     class Stack
+      include Pharos::Logging
+
       RESOURCE_LABEL = 'pharos.kontena.io/stack'
       RESOURCE_ANNOTATION = 'pharos.kontena.io/stack-checksum'
       RESOURCE_PATH = Pathname.new(File.expand_path(File.join(__dir__, '..', 'resources'))).freeze
@@ -36,6 +38,7 @@ module Pharos
       def apply
         with_pruning do |checksum|
           resources.map do |resource|
+            logger.debug { "Applying resource: #{resource.kind}/#{resource.metadata['name']}" }
             metadata = resource.metadata
             metadata.labels ||= {}
             metadata.annotations ||= {}

--- a/lib/pharos/resources/openebs/00_cluster_role.yml
+++ b/lib/pharos/resources/openebs/00_cluster_role.yml
@@ -1,0 +1,25 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-maya-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes","nodes/proxy"]
+  verbs: ["get","list","watch","create","update"]
+- apiGroups: ["*"]
+  resources: ["namespaces","services","pods","deployments", "events", "endpoints"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["persistentvolumes","persistentvolumeclaims"]
+  verbs: ["*"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create" ]
+- apiGroups: ["openebs.io"]
+  resources: ["storagepools"]
+  verbs: ["get", "list"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/lib/pharos/resources/openebs/01-service-account.yml
+++ b/lib/pharos/resources/openebs/01-service-account.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: default

--- a/lib/pharos/resources/openebs/02-cluster-role-binding.yml
+++ b/lib/pharos/resources/openebs/02-cluster-role-binding.yml
@@ -1,0 +1,17 @@
+# Bind the Service Account with the Role Privileges.
+# TODO: Check if default account also needs to be there
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-maya-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: default
+- kind: User
+  name: system:serviceaccount:default:default
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: openebs-maya-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/lib/pharos/resources/openebs/10-api-server-deployment.yml.erb
+++ b/lib/pharos/resources/openebs/10-api-server-deployment.yml.erb
@@ -1,0 +1,28 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: maya-apiserver
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: maya-apiserver
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: maya-apiserver
+        imagePullPolicy: Always
+        image: openebs/m-apiserver:<%= version %>
+        ports:
+        - containerPort: 5656
+        env:
+        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+          value: "openebs/jiva:<%= version %>"
+        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+          value: "openebs/jiva:<%= version %>"
+        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "openebs/m-exporter:<%= version %>"
+        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+          value: "<%= default_replicas %>"

--- a/lib/pharos/resources/openebs/11-api-server-service.yml
+++ b/lib/pharos/resources/openebs/11-api-server-service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: maya-apiserver-service
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 5656
+    protocol: TCP
+    targetPort: 5656
+  selector:
+    name: maya-apiserver
+  sessionAffinity: None

--- a/lib/pharos/resources/openebs/12-provisioner-deployment.yml.erb
+++ b/lib/pharos/resources/openebs/12-provisioner-deployment.yml.erb
@@ -1,0 +1,28 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: openebs-provisioner
+  namespace: default
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: openebs-provisioner
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: openebs-provisioner
+        imagePullPolicy: Always
+        image: openebs/openebs-k8s-provisioner:<%= version %>
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OPENEBS_MONITOR_URL
+          value: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
+        - name: OPENEBS_MONITOR_VOLKEY
+          value: "&var-OpenEBS"
+        - name: MAYA_PORTAL_URL
+          value: "https://mayaonline.io/"

--- a/lib/pharos/resources/openebs/20-crd-storage-pool-claim.yml
+++ b/lib/pharos/resources/openebs/20-crd-storage-pool-claim.yml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepoolclaims.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepoolclaims
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepoolclaim
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePoolClaim
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - spc

--- a/lib/pharos/resources/openebs/21-crd-storage-pool.yml
+++ b/lib/pharos/resources/openebs/21-crd-storage-pool.yml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepools.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepools
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepool
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - sp

--- a/lib/pharos/resources/openebs/22-storage-class.yml.erb
+++ b/lib/pharos/resources/openebs/22-storage-class.yml.erb
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: openebs-standard
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "<%= default_replicas %>"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: <%= default_capacity %>

--- a/lib/pharos/resources/openebs/23-crd-volume-policy.yml
+++ b/lib/pharos/resources/openebs/23-crd-volume-policy.yml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: volumepolicies.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: volumepolicies
+    # singular name to be used as an alias on the CLI and for display
+    singular: volumepolicy
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: VolumePolicy
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - vp

--- a/lib/pharos/resources/openebs/30-default-storage-pool.yml
+++ b/lib/pharos/resources/openebs/30-default-storage-pool.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: openebs.io/v1alpha1
+kind: StoragePool
+metadata:
+  name: default
+  type: hostdir
+spec:
+  path: "/var/openebs"
+  nodes: [ "all" ]
+  #maxVolSize: 10G #Max Volume Size
+  #maxAllocatedSize: 100G #Max Total Space allocated from this directory/mount
+---

--- a/spec/pharos/addons/openebs_spec.rb
+++ b/spec/pharos/addons/openebs_spec.rb
@@ -1,0 +1,51 @@
+require "pharos/addons/open_ebs"
+
+describe Pharos::Addons::OpenEbs do
+  let(:cluster_config) { Pharos::Config.new(
+    hosts: [Pharos::Configuration::Host.new(role: 'worker')],
+    network: {},
+    addons: {},
+    etcd: {}
+  ) }
+  let(:cpu_arch) { double(:cpu_arch ) }
+  let(:master) { double(:host, address: '1.1.1.1') }
+
+  describe '#validate' do
+    context 'with more replicas than workers' do
+      it 'raises' do
+        config = {default_replicas: 5}
+        subject = described_class.new(config, enabled: true, master: master, cpu_arch: cpu_arch, cluster_config: cluster_config)
+        expect { subject.validate }.to raise_error Pharos::InvalidAddonError
+      end
+    end
+
+    context 'with more replicas than workers' do
+      it 'does not raise' do
+        config = {default_replicas: 1}
+        subject = described_class.new(config, enabled: true, master: master, cpu_arch: cpu_arch, cluster_config: cluster_config)
+        subject.validate
+      end
+    end
+  end
+
+  describe '#default_replica_count' do
+    context 'with 2 workers' do
+      it 'returns number of workers' do
+        cluster_config.hosts << Pharos::Configuration::Host.new(role: 'worker')
+        subject = described_class.new({}, enabled: true, master: master, cpu_arch: cpu_arch, cluster_config: cluster_config)
+        expect(subject.default_replica_count).to eq(2)
+      end
+    end
+
+    context 'with 5 workers' do
+      it 'returns 3' do
+        4.times do
+          cluster_config.hosts << Pharos::Configuration::Host.new(role: 'worker')
+        end
+        subject = described_class.new({}, enabled: true, master: master, cpu_arch: cpu_arch, cluster_config: cluster_config)
+        expect(subject.default_replica_count).to eq(3)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Still bit of WIP. 

Need to figure out how to make the stack apply to withstand re-runs. Currently it fails with:
```
Kubeclient::HttpError : StorageClass.storage.k8s.io "openebs-standard" is invalid: parameters: Forbidden: updates to parameters are forbidden.
```

Not sure on the namespace we should put this into. `default` feels just plain wrong, maybe `kube-system` would be better for this kind of "infra" things.

fixes #171