### PR TITLE
Add config option to enable kubelet read-only port

### DIFF
--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -10,6 +10,7 @@ require_relative 'configuration/authentication'
 require_relative 'configuration/cloud'
 require_relative 'configuration/audit'
 require_relative 'configuration/kube_proxy'
+require_relative 'configuration/kubelet'
 
 module Pharos
   class Config < Dry::Struct
@@ -25,6 +26,7 @@ module Pharos
     attribute :cloud, Pharos::Configuration::Cloud
     attribute :authentication, Pharos::Configuration::Authentication
     attribute :audit, Pharos::Configuration::Audit
+    attribute :kubelet, Pharos::Configuration::Kubelet
     attribute :addons, Pharos::Types::Hash.default({})
 
     attr_accessor :data

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -89,6 +89,9 @@ module Pharos
           optional(:mode).filled(included_in?: %w(userspace iptables ipvs))
         end
         optional(:addons).value(type?: Hash)
+        optional(:kubelet).schema do
+          optional(:read_only_port).filled(:bool?)
+        end
 
         validate(network_dns_replicas: [:network, :hosts]) do |network, hosts|
           if network && network[:dns_replicas]

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -42,11 +42,9 @@ module Pharos
 
         if local_only
           args << "--pod-manifest-path=/etc/kubernetes/manifests/"
-          args << "--read-only-port=0"
           args << "--cadvisor-port=0"
           args << "--address=127.0.0.1"
         else
-          args << '--read-only-port=0'
           args << "--node-ip=#{peer_address}"
           args << "--hostname-override=#{hostname}"
         end

--- a/lib/pharos/configuration/kubelet.rb
+++ b/lib/pharos/configuration/kubelet.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Configuration
+    class Kubelet < Dry::Struct
+      constructor_type :schema
+
+      attribute :read_only_port, Pharos::Types::Bool.default(false)
+    end
+  end
+end

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -94,7 +94,12 @@ module Pharos
 
       # @return [Array<String>]
       def kubelet_extra_args
-        args = @host.kubelet_args
+        args = []
+        unless @config.kubelet.read_only_port
+          args << "--read-only-port=0"
+        end
+        args += @host.kubelet_args
+
         args << "--cloud-provider=#{@config.cloud.provider}" if @config.cloud
         args << "--cloud-config=#{CLOUD_CONFIG_FILE}" if @config.cloud&.config
         args

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -16,7 +16,6 @@ describe Pharos::Phases::ConfigureKubelet do
 
   describe '#build_systemd_dropin' do
     it "returns a systemd unit" do
-      #puts config.inspect
       expect(subject.build_systemd_dropin).to eq <<~EOM
         [Service]
         Environment='KUBELET_EXTRA_ARGS=--read-only-port=0 --node-ip=192.168.42.1 --hostname-override='


### PR DESCRIPTION
Introduces new top level `kubelet` config key to collec all possible future kubelet specific configs.

With
```
kubelet:
  read_only_port: true
```
it enables kubelet read-only port (`10255`), disables it by default.

fixes #344 