### PR TITLE
Update kube to 1.10.2

### DIFF
--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -9,7 +9,7 @@ require_relative "pharos/root_command"
 
 module Pharos
   CRIO_VERSION = '1.10'
-  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.1' }
+  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.2' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.1.12' }
   DOCKER_VERSION = '1.13.1'


### PR DESCRIPTION
fixes #340 

After:
```
$ kubectl get nodes
NAME      STATUS    ROLES     AGE       VERSION
host-00   Ready     master    22h       v1.10.2
host-01   Ready     <none>    22h       v1.10.2
host-02   Ready     <none>    22h       v1.10.2

```