### PR TITLE
rubocop: Disable Lint/SplatKeywordArguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,3 +52,8 @@ Style/BeginBlock:
 Naming/UncommunicativeMethodParamName:
   AllowedNames:
     - cn
+
+# new in 0.56, seems to give false-positivies
+# https://github.com/bbatsov/rubocop/issues/5887
+Lint/SplatKeywordArguments:
+  Enabled: false


### PR DESCRIPTION
Rubocop 0.56 introduced warnings for usages of `foo(..., **options)`: https://github.com/bbatsov/rubocop/issues/5887

```
lib/pharos/kube/resource.rb:59:44: W: Lint/SplatKeywordArguments: Do not use splat keyword arguments as a single Hash.
        @client.delete_resource(@resource, **options)
                                           ^^^^^^^^^
lib/pharos/ssh/client.rb:52:38: W: Lint/SplatKeywordArguments: Do not use splat keyword arguments as a single Hash.
        RemoteCommand.new(self, cmd, **options).run
                                     ^^^^^^^^^
```

However, this check seems to be too simplistic, and covers things that are not warnings in Ruby 2.6: https://github.com/bbatsov/rubocop/issues/5887