### PR TITLE
Configurable node taints

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -42,6 +42,7 @@ module Pharos
 
   module Configuration
     autoload :Host, 'pharos/configuration/host'
+    autoload :Taint, 'pharos/configuration/taint'
   end
 
   module Etcd

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -43,6 +43,13 @@ module Pharos
               optional(:private_interface).filled
               required(:role).filled(included_in?: ['master', 'worker'])
               optional(:labels).filled
+              optional(:taints).each do
+                schema do
+                  optional(:key).filled(:str?)
+                  optional(:value).filled(:str?)
+                  required(:effect).filled(included_in?: ['NoSchedule', 'NoExecute'])
+                end
+              end
               optional(:user).filled
               optional(:ssh_key_path).filled
               optional(:container_runtime).filled(included_in?: ['docker', 'cri-o'])

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -13,6 +13,7 @@ module Pharos
       attribute :private_interface, Pharos::Types::Strict::String
       attribute :role, Pharos::Types::Strict::String
       attribute :labels, Pharos::Types::Strict::Hash
+      attribute :taints, Pharos::Types::Strict::Array.of(Pharos::Configuration::Taint)
       attribute :user, Pharos::Types::Strict::String.default('ubuntu')
       attribute :ssh_key_path, Pharos::Types::Strict::String.default('~/.ssh/id_rsa')
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')

--- a/lib/pharos/configuration/taint.rb
+++ b/lib/pharos/configuration/taint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Configuration
+    class Taint < Dry::Struct
+      constructor_type :schema
+
+      attribute :key, Pharos::Types::String
+      attribute :value, Pharos::Types::String
+      attribute :effect, Pharos::Types::String
+    end
+  end
+end

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -126,7 +126,7 @@ module Pharos
           'controllerManagerExtraArgs' => {
             'horizontal-pod-autoscaler-use-rest-clients' => 'false'
           },
-          'noTaintMaster' => !!@host.taints && !@host.taints.any?{|taint| taint.key == 'node-role.kubernetes.io/master' && taint.effect == 'NoSchedule' },
+          'noTaintMaster' => !!@host.taints && @host.taints.none?{ |taint| taint.key == 'node-role.kubernetes.io/master' && taint.effect == 'NoSchedule' }
         }
 
         if @host.container_runtime == 'cri-o'

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -22,7 +22,7 @@ module Pharos
       def taints
         return [] unless @host.taints
 
-        @host.taints.map{|taint| taint.to_h }
+        @host.taints.map(&:to_h)
       end
 
       # @param node [Kubeclient::Resource]

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -6,16 +6,23 @@ module Pharos
       title "Label nodes"
 
       def call
-        unless @host.labels
-          logger.info { "No labels set ... " }
+        unless @host.labels || @host.taints
+          logger.info { "No labels or taints set ... " }
           return
         end
 
         node = find_node
         raise Pharos::Error, "Cannot set labels, node not found" if node.nil?
 
-        logger.info { "Configuring node labels ... " }
+        logger.info { "Configuring node labels and taints ... " }
         patch_node(node)
+      end
+
+      # @return [Array{Hash}]
+      def taints
+        return [] unless @host.taints
+
+        @host.taints.map{|taint| taint.to_h }
       end
 
       # @param node [Kubeclient::Resource]
@@ -23,7 +30,10 @@ module Pharos
         kube.patch_node(
           node.metadata.name,
           metadata: {
-            labels: @host.labels
+            labels: @host.labels || {}
+          },
+          spec: {
+            taints: taints
           }
         )
       end

--- a/spec/pharos/phases/configure_master_spec.rb
+++ b/spec/pharos/phases/configure_master_spec.rb
@@ -259,6 +259,42 @@ describe Pharos::Phases::ConfigureMaster do
         )
       end
     end
+
+    describe 'noTaintMaster' do
+      it 'taints the master by default' do
+        expect(subject.generate_config['noTaintMaster']).to eq false
+      end
+
+      context 'with empty host taints' do
+        let(:master) { Pharos::Configuration::Host.new(
+          address: 'test',
+          private_address: 'private',
+          role: 'master',
+          taints: [],
+        ) }
+
+        it 'does not taint the master' do
+          expect(subject.generate_config['noTaintMaster']).to eq true
+
+        end
+      end
+
+      context 'with master taint' do
+        let(:master) { Pharos::Configuration::Host.new(
+          address: 'test',
+          private_address: 'private',
+          role: 'master',
+          taints: [
+            Pharos::Configuration::Taint.new(key: 'node-role.kubernetes.io/master', effect: 'NoSchedule'),
+            Pharos::Configuration::Taint.new(key: 'test', effect: 'NoSchedule'),
+          ],
+        ) }
+
+        it 'does not taint the master' do
+          expect(subject.generate_config['noTaintMaster']).to eq false
+        end
+      end
+    end
   end
 
   describe '#generate_authentication_token_webhook_config' do

--- a/spec/pharos/phases/label_node_spec.rb
+++ b/spec/pharos/phases/label_node_spec.rb
@@ -1,16 +1,18 @@
 require 'pharos/phases/label_node'
 
 describe Pharos::Phases::LabelNode do
-  let(:master) { Pharos::Configuration::Host.new(address: '1.1.1.1') }
-  let(:worker) { Pharos::Configuration::Host.new(address: '2.2.2.2', labels: {foo: 'bar'}) }
-  let(:subject) { described_class.new(worker, master: master) }
+  let(:master) { Pharos::Configuration::Host.new(address: '192.0.2.1') }
+  let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.2', labels: { foo: 'bar' } ) }
+  let(:subject) { described_class.new(host, master: master) }
 
+  let(:kube) { double(:kube) }
+
+  before(:each) do
+    allow(subject).to receive(:kube).and_return(kube)
+  end
 
   describe '#find_node' do
-    let(:kube) { double(:kube) }
-
     before(:each) do
-      allow(subject).to receive(:kube).and_return(kube)
       allow(subject).to receive(:sleep)
     end
 
@@ -19,7 +21,7 @@ describe Pharos::Phases::LabelNode do
         Kubeclient::Resource.new({
           status: {
             addresses: [
-              { type: 'InternalIP', address: worker.address }
+              { type: 'InternalIP', address: host.address }
             ]
           }
         })
@@ -42,24 +44,72 @@ describe Pharos::Phases::LabelNode do
   end
 
   describe '#call' do
-    it 'does nothing if node does not have labels' do
-      allow(worker).to receive(:labels).and_return(nil)
-      expect(subject).not_to receive(:find_node)
-      subject.call
-    end
+    let(:node) { double(:kube_node, metadata: double(name: 'test')) }
 
-    it 'patches node if node has labels and it exist in kube api' do
-      node = double(:node)
+    before do
       allow(subject).to receive(:find_node).and_return(node)
-      expect(subject).to receive(:patch_node).with(node)
-      subject.call
     end
 
-    it 'raises error if node not found' do
-      allow(subject).to receive(:find_node).and_return(nil)
-      expect {
+    context 'without any host labels' do
+      let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.2') }
+
+      it 'does nothing' do
+        expect(subject).not_to receive(:find_node)
+
         subject.call
-      }.to raise_error(Pharos::Error)
+      end
+    end
+
+    context 'without kube node' do
+      before do
+        allow(subject).to receive(:find_node).and_return(nil)
+      end
+
+      it 'raises error if node not found' do
+        expect{subject.call}.to raise_error(Pharos::Error)
+      end
+    end
+
+    context 'with labels' do
+      let(:host) { Pharos::Configuration::Host.new(
+        address: '192.0.2.2',
+        labels: {foo: 'bar'},
+      ) }
+
+      it 'patches node' do
+        expect(kube).to receive(:patch_node).with('test',
+          metadata: {
+            labels: { :foo => 'bar' },
+          },
+          spec: {
+            taints: [ ],
+          }
+        )
+
+        subject.call
+      end
+    end
+
+    context 'with taints' do
+      let(:host) { Pharos::Configuration::Host.new(
+        address: '192.0.2.2',
+        taints: [
+          Pharos::Configuration::Taint.new(key: 'node-role.kubernetes.io/master', effect: 'NoSchedule'),
+        ]
+      ) }
+
+      it 'patches node' do
+        expect(kube).to receive(:patch_node).with('test',
+          metadata: {
+            labels: { },
+          },
+          spec: {
+            taints: [ { key: 'node-role.kubernetes.io/master', value: nil, effect: 'NoSchedule' } ],
+          }
+        )
+
+        subject.call
+      end
     end
   end
 end


### PR DESCRIPTION
Docs https://github.com/kontena/pharos-cluster/pull/366

A master node gets the kubeadm managed master taints by default. If configured with `taints: []`, then it will disable the kubeadm managed master taints. If you want to add extra taints to the master, then you need to include the default master taint in the `taints: ...` array.

Example syntax:

```yaml
hosts:
  - address: 167.99.39.233
    user: root
    role: master
    taints: []
  - address: 188.166.118.151
    user: root
    role: worker
    taints:
    - key: test
      effect: NoSchedule
```

This also seems to work to add/remove taints when using kube PATCH. I assume this replaces any taints otherwise configured on the kube nodes.

The master taint is configured as part of the `ConfigureMaster` phase, and the remaining master/worker node taints are configured as part of the `LabelNode` phase. This happens immediately after joining new nodes, before applying any addons. The core components will already have their daemonsets/deployments set up at the time the worker nodes are joined, so the taints may not apply to those.