### PR TITLE
Remove broken ConfiureEtcd --name migration logic

### DIFF
--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -5,7 +5,6 @@ module Pharos
     class ConfigureEtcd < Pharos::Phase
       title 'Configure etcd'
       CA_PATH = '/etc/pharos/pki'
-      POD_MANIFEST_PATH = '/etc/kubernetes/manifests/pharos-etcd.yml'
 
       register_component(
         name: 'etcd', version: Pharos::ETCD_VERSION, license: 'Apache License 2.0',
@@ -47,12 +46,7 @@ module Pharos
       # @param peer [Pharos::Configuration::Host]
       # @return [String]
       def peer_name(peer)
-        file = @ssh.file(POD_MANIFEST_PATH)
-        if file.exist? && match = file.read.match(/--name=(\w+)/)
-          match[1]
-        else
-          peer.hostname.split('.')[0]
-        end
+        peer.hostname.split('.')[0]
       end
 
       def sync_ca


### PR DESCRIPTION
Fixes #371
Fixes #372

The `ConfigureEtcd#peer_name` logic for preserving the existing etcd member `--name` from the pod manifest was broken in several ways, and was also being incorrectly used for the `INITIAL_CLUSTER` member names.

Remove it entirely, because it seems like etcd will handle changes to its local member `--name` by updating the cluster members, which means that we don't need the migration logic?