### PR TITLE
Allow to pass addon config from terraform

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -114,13 +114,13 @@ module Pharos
 
     attr_reader :config, :cpu_arch, :cluster_config, :master
 
-    # @param config [Hash]
+    # @param config [Hash,Dry::Validation::Result]
     # @param enabled [Boolean]
     # @param master [Pharos::Configuration::Host,NilClass]
     # @param cpu_arch [String, NilClass]
     # @param cluster_config [Pharos::Config, NilClass]
     def initialize(config = nil, enabled: true, master:, cpu_arch:, cluster_config:)
-      @config = self.class.config? ? self.class.config.new(config) : RecursiveOpenStruct.new(config)
+      @config = self.class.config? ? self.class.config.new(config) : RecursiveOpenStruct.new(config.to_hash)
       @enabled = enabled
       @master = master
       @cpu_arch = cpu_arch

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -120,7 +120,7 @@ module Pharos
     # @param cpu_arch [String, NilClass]
     # @param cluster_config [Pharos::Config, NilClass]
     def initialize(config = nil, enabled: true, master:, cpu_arch:, cluster_config:)
-      @config = self.class.config? ? self.class.config.new(config) : RecursiveOpenStruct.new(config.to_hash)
+      @config = self.class.config? ? self.class.config.new(config) : RecursiveOpenStruct.new(Hash(config))
       @enabled = enabled
       @master = master
       @cpu_arch = cpu_arch

--- a/lib/pharos/terraform/json_parser.rb
+++ b/lib/pharos/terraform/json_parser.rb
@@ -31,6 +31,17 @@ module Pharos
         hosts
       end
 
+      # @return [Hash]
+      def addons
+        addons = {}
+        addons_hash = data.dig('pharos_addons', 'value') || {}
+        addons_hash.each do |name, array|
+          addons[name] = array.first
+        end
+
+        addons
+      end
+
       # @return [String,NilClass]
       def api
         @api ||= data.dig('pharos_api', 'value')

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -75,7 +75,11 @@ module Pharos
       config['addons'] ||= {}
       config['hosts'] += tf_parser.hosts
       config['api'].merge!(tf_parser.api) if tf_parser.api
-      config['addons'].merge!(tf_parser.addons) if tf_parser.addons
+      config['addons'].each do |name, conf|
+        if addon_config = tf_parser.addons[name]
+          conf.merge!(addon_config)
+        end
+      end
       config
     end
 

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -72,8 +72,10 @@ module Pharos
       tf_parser = Pharos::Terraform::JsonParser.new(File.read(file))
       config['hosts'] ||= []
       config['api'] ||= {}
+      config['addons'] ||= {}
       config['hosts'] += tf_parser.hosts
       config['api'].merge!(tf_parser.api) if tf_parser.api
+      config['addons'].merge!(tf_parser.addons) if tf_parser.addons
       config
     end
 

--- a/spec/fixtures/terraform/with_addons.json
+++ b/spec/fixtures/terraform/with_addons.json
@@ -1,0 +1,48 @@
+{
+    "pharos": {
+        "sensitive": false,
+        "type": "map",
+        "value": {
+            "masters": [
+                {
+                    "address": [
+                        "147.75.100.11"
+                    ],
+                    "private_address": [
+                        "10.80.4.139"
+                    ],
+                    "role": "master",
+                    "user": "root"
+                }
+            ],
+            "workers": [
+                {
+                    "address": [
+                        "147.75.102.245",
+                        "147.75.100.113",
+                        "147.75.100.9"
+                    ],
+                    "label": [
+                        {
+                            "foo": "bar"
+                        }
+                    ],
+                    "private_address": [
+                        "10.80.4.129",
+                        "10.80.4.145",
+                        "10.80.4.149"
+                    ],
+                    "role": "worker",
+                    "user": "ubuntu"
+                }
+            ]
+        }
+    },
+    "pharos_addons": {
+        "value": {
+            "addon1": [
+                { "foo": "bar", "bar": "baz" }
+            ]
+        }
+    }
+}

--- a/spec/pharos/terraform/json_parser_spec.rb
+++ b/spec/pharos/terraform/json_parser_spec.rb
@@ -21,4 +21,19 @@ describe Pharos::Terraform::JsonParser do
       }.to raise_error(described_class::ParserError)
     end
   end
+
+  describe '#addons' do
+    let(:subject) { described_class.new(fixture('terraform/with_addons.json')) }
+
+    it 'parses valid terraform json file' do
+      addons = subject.addons
+      expect(addons.keys.size).to eq(1)
+      expect(addons['addon1']).to eq({ "foo" => "bar", "bar" => "baz" })
+    end
+
+    it 'returns empty hash if no addons are defined' do
+      subject = described_class.new(fixture('terraform/tf.json'))
+      expect(subject.addons).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
For example:
```tf
output "pharos_addons" {
  value = {
    efs-provisioner = {
      efs_id = "${aws_efs_file_system.default.id}"
      dns_name = "${aws_efs_file_system.default.dns_name}"
      region = "${var.aws_region}"
    }
  }
}
```
will result in:
```yaml
addons:
  ingress-nginx:
    efs_id: "..."
    dns_name: "..."
    region: "..."
```