### PR TITLE
Download cfssl from pharos repository

### DIFF
--- a/lib/pharos/scripts/configure-cfssl.sh
+++ b/lib/pharos/scripts/configure-cfssl.sh
@@ -2,15 +2,5 @@
 
 set -e
 
-if [ "${ARCH}" = "amd64" ]; then
-    MIRROR="http://mirrors.kernel.org/ubuntu"
-else
-    MIRROR="http://ports.ubuntu.com"
-fi
-
-CFSSL_URL="${MIRROR}/pool/universe/g/golang-github-cloudflare-cfssl/golang-cfssl_1.2.0+git20160825.89.7fb22c8-3_${ARCH}.deb"
-
-if [ ! -e  /usr/bin/cfssl ]; then
-    curl -sL -o /tmp/cfssl.deb ${CFSSL_URL}
-    dpkg -i /tmp/cfssl.deb && rm /tmp/cfssl.deb
-fi
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y golang-cfssl


### PR DESCRIPTION
Ubuntu Xenial does not have golang-cfssl package. This PR switches golang-cfssl download/install to pharos deb repository.