### PR TITLE
Fix Pharos::Masters::SetupMaster to use correct class for kubeadm

### DIFF
--- a/lib/pharos/phases/setup_master.rb
+++ b/lib/pharos/phases/setup_master.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Setup master configuration files"
 
       def kubeadm
-        Pharos::Kubeadm.new(@config, @host)
+        Pharos::Kubeadm::ConfigGenerator.new(@config, @host)
       end
 
       def call


### PR DESCRIPTION
Fixes #397 