### PR TITLE
Upgrade net-ssh dependency to 5.0.1

### DIFF
--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "clamp", "1.2.1"
   spec.add_runtime_dependency "pastel"
   spec.add_runtime_dependency "kubeclient"
-  spec.add_runtime_dependency "net-ssh", "5.0.0.beta2"
+  spec.add_runtime_dependency "net-ssh", "5.0.1"
   spec.add_runtime_dependency "ed25519", "1.2.4"
   spec.add_runtime_dependency "bcrypt_pbkdf", ">= 1.0", "< 2.0"
   spec.add_runtime_dependency "dry-types", "0.12.2"


### PR DESCRIPTION
Changes since 5.0.0beta2:

```
=== 5.0.1

  * default_keys were not loaded even if no keys or key_data options specified [#607]

=== 5.0.0

 * Verify_host_key options rename (true, false, :very, :secure depreacted new equivalents are :never, :accept_new_or_local_tunnel :accept_new :always) [Jared Beck, #595]
```

Doesn't look like breaking changes for pharos.
