### PR TITLE
Fix global --version etc to work in the root command level 

### DIFF
--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -4,7 +4,7 @@ require_relative 'up_command'
 require_relative 'version_command'
 
 module Pharos
-  class RootCommand < Clamp::Command
+  class RootCommand < Pharos::Command
     banner "pharos-cluster - Kontena Pharos cluster manager"
 
     subcommand ["build", "up"], "Initialize/upgrade cluster", UpCommand


### PR DESCRIPTION
…by making `Pharos::RootCommand` inherit from `Pharos::Command` instead of `Clamp::Command`.

Makes `pharos-cluster --version` work as expected.
