### PR TITLE
Release v1.2.0-beta.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.1.0"
+  VERSION = "1.2.0-beta.1"
 end


### PR DESCRIPTION
## Changes since v1.1.1

- support for multiple operating systems (#362)
- CentOS/RHEL7 support (#410, #425)
- Ubuntu 18.04 support (#362)
- fix global --version etc by making RootCommand inherit from Pharos::Command (#423)
- handle migration from 1.1.x to 1.2.x (#424)

### Known issues

- `host-upgrades` & `kured` addons don't work with CentOS/RHEL 7