### PR TITLE
Improve version command output

### DIFF
--- a/lib/pharos/version_command.rb
+++ b/lib/pharos/version_command.rb
@@ -3,33 +3,35 @@
 module Pharos
   class VersionCommand < Pharos::Command
     def execute
-      puts "pharos-cluster version #{Pharos::VERSION}"
-      manager = ClusterManager.new(Pharos::Config.new({}), pastel: false)
-      manager.load
+      puts "Kontena Pharos:"
+      puts "  - pharos-cluster version #{Pharos::VERSION}"
+      ClusterManager.new(Pharos::Config.new({}), pastel: false).load
       Pharos::HostConfigManager.load_configs
 
-      puts "3rd party versions:"
-      grouped_phases = phases.group_by { |c|
-        if c.os_release
-          "#{c.os_release.id} #{c.os_release.version}"
-        end
-      }
-      grouped_phases.each do |os, phases|
-        puts "  #{os || 'all host operating systems'}:"
+      phases.each do |os, phases|
+        title = (os || 'Common').capitalize
+        puts "#{title}:"
         phases.each do |c|
-          puts "    - #{c.name} #{c.version} (#{c.license})"
+          puts "  - #{c.name} #{c.version} (#{c.license})"
         end
       end
-      puts "Addon versions:"
+      puts "Add-ons:"
       addons.each do |c|
         puts "  - #{c.addon_name} #{c.version} (#{c.license})"
       end
     end
 
+    # @return [Array<Pharos::Phases::Component>]
     def phases
-      Pharos::Phases.components.sort_by(&:name)
+      phases = Pharos::Phases.components.sort_by(&:name)
+      phases.group_by { |c|
+        if c.os_release
+          "#{c.os_release.id} #{c.os_release.version}"
+        end
+      }
     end
 
+    # @return [Array<Pharos::Addon>]
     def addons
       Pharos::AddonManager.addons.sort_by(&:name)
     end


### PR DESCRIPTION
```
$ pharos-cluster version
Kontena Pharos:
  - pharos-cluster version 1.1.0
Common:
  - calico-cni 3.1.0 (Apache License 2.0)
  - calico-node 3.1.0 (Apache License 2.0)
  - etcd 3.1.12 (Apache License 2.0)
  - heapster 1.5.1 (Apache License 2.0)
  - kubernetes 1.10.4 (Apache License 2.0)
  - pharos-kubelet-proxy 0.3.6 (Apache License 2.0)
  - weave-net 2.3.0 (Apache License 2.0)
Ubuntu 16.04:
  - cfssl 1.2 (MIT)
  - cri-o 1.10 (Apache License 2.0)
  - docker 1.13.1 (Apache License 2.0)
Rhel 7.5:
  - cfssl 1.2 (MIT)
  - docker 1.13.1 (Apache License 2.0)
Centos 7:
  - cfssl 1.2 (MIT)
  - docker 1.13.1 (Apache License 2.0)
Ubuntu 18.04:
  - cfssl 1.2 (MIT)
  - docker 17.12.1 (Apache License 2.0)
Add-ons:
  - cert-manager 0.2.3 (Apache License 2.0)
  - host-upgrades 0.1.0 (Apache License 2.0)
  - ingress-nginx 0.15.0 (Apache License 2.0)
  - kubernetes-dashboard 1.8.3 (Apache License 2.0)
  - kured master-b27aaa1 (Apache License 2.0)
  - openebs 0.5.3 (Apache License 2.0)
```