### PR TITLE
Fix missing cpu/memory cgroups for the systemd services on CentOS

### DIFF
--- a/lib/pharos/host/el7/scripts/ensure-kubelet.sh
+++ b/lib/pharos/host/el7/scripts/ensure-kubelet.sh
@@ -6,7 +6,8 @@
 set -e
 
 mkdir -p /etc/systemd/system/kubelet.service.d
-    cat <<EOF >/etc/systemd/system/kubelet.service.d/05-pharos-kubelet.conf
+
+cat <<EOF >/etc/systemd/system/kubelet.service.d/05-pharos-kubelet.conf
 [Service]
 ExecStartPre=-/sbin/swapoff -a
 ExecStart=

--- a/lib/pharos/host/el7/scripts/ensure-kubelet.sh
+++ b/lib/pharos/host/el7/scripts/ensure-kubelet.sh
@@ -14,6 +14,17 @@ ExecStart=
 ExecStart=/usr/bin/kubelet ${KUBELET_ARGS} --cgroup-driver=systemd --pod-infra-container-image=${IMAGE_REPO}/pause-${ARCH}:3.1
 EOF
 
+cat <<EOF >/etc/systemd/system/kubelet.service.d/11-cgroups.conf
+[Service]
+
+# https://github.com/kontena/pharos-cluster/issues/440
+# the kubelet expects to find cpu+memory cgroups for the kubelet and docker services in order to report system container stats
+# have systemd create per-service cpu+memory cgroups for the kubelet.service
+# as a side effect, this will also create cpu+memory cgroups for all system.slice services, including docker.service
+CPUAccounting=true
+MemoryAccounting=true
+EOF
+
 yum_install_with_lock "kubelet" $KUBE_VERSION
 
 if ! systemctl is-active --quiet kubelet; then


### PR DESCRIPTION
Fixes #440

Enable `CPUAccounting` and `MemoryAccounting` for the `kubelet.service`, allowing systemd to create per-service cpu/memory cgroups for all `system.slice` services.