### PR TITLE
rubocop: forget about Lint/SplatKeywordArguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,10 +53,5 @@ Naming/UncommunicativeMethodParamName:
   AllowedNames:
     - cn
 
-# new in 0.56, seems to give false-positivies
-# https://github.com/bbatsov/rubocop/issues/5887
-Lint/SplatKeywordArguments:
-  Enabled: false
-
 Metrics/BlockLength:
   Enabled: false


### PR DESCRIPTION
Fixes warning:

```
Warning: unrecognized cop Lint/SplatKeywordArguments found in .rubocop.yml
```

See https://github.com/rubocop-hq/rubocop/pull/5892