### PR TITLE
Detect systemd-resolved stub resolver at localhost and bypass using kubelet --resolv-conf

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -45,6 +45,7 @@ module Pharos
   module Configuration
     autoload :Host, 'pharos/configuration/host'
     autoload :Taint, 'pharos/configuration/taint'
+    autoload :OsRelease, 'pharos/configuration/os_release'
   end
 
   module Etcd

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -20,7 +20,7 @@ module Pharos
       attribute :http_proxy, Pharos::Types::Strict::String
 
       attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks
-      attr_accessor :resolv_localhost
+      attr_accessor :resolv_localhost, :systemd_resolved_stub
 
       def to_s
         address

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -8,6 +8,11 @@ module Pharos
     class Host < Dry::Struct
       constructor_type :schema
 
+      class ResolvConf < Dry::Struct
+        attribute :nameserver_localhost, Pharos::Types::Strict::Bool
+        attribute :systemd_resolved_stub, Pharos::Types::Strict::Bool
+      end
+
       attribute :address, Pharos::Types::Strict::String
       attribute :private_address, Pharos::Types::Strict::String
       attribute :private_interface, Pharos::Types::Strict::String
@@ -19,8 +24,7 @@ module Pharos
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
       attribute :http_proxy, Pharos::Types::Strict::String
 
-      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks
-      attr_accessor :resolv_localhost, :systemd_resolved_stub
+      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks, :resolvconf
 
       def to_s
         address

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -20,6 +20,7 @@ module Pharos
       attribute :http_proxy, Pharos::Types::Strict::String
 
       attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks
+      attr_accessor :resolv_localhost
 
       def to_s
         address

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -102,7 +102,10 @@ module Pharos
           "--cluster-domain=cluster.local"
         ]
 
-        if @host.resolv_localhost
+        if @host.systemd_resolved_stub
+          # use usptream resolvers instead of systemd stub resolver at localhost for `dnsPolicy: Default` pods
+          args << '--resolv-conf=/run/systemd/resolve/resolv.conf'
+        elsif @host.resolv_localhost
           fail "Host has /etc/resolv.conf configured with localhost as a resolver"
         end
 

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -97,10 +97,16 @@ module Pharos
 
       # @return [Array<String>]
       def kubelet_dns_args
-        [
+        args = [
           "--cluster-dns=#{@config.network.dns_service_ip}",
           "--cluster-domain=cluster.local"
         ]
+
+        if @host.resolv_localhost
+          fail "Host has /etc/resolv.conf configured with localhost as a resolver"
+        end
+
+        args
       end
 
       # @return [Array<String>]

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -102,10 +102,10 @@ module Pharos
           "--cluster-domain=cluster.local"
         ]
 
-        if @host.systemd_resolved_stub
+        if @host.resolvconf.systemd_resolved_stub
           # use usptream resolvers instead of systemd stub resolver at localhost for `dnsPolicy: Default` pods
           args << '--resolv-conf=/run/systemd/resolve/resolv.conf'
-        elsif @host.resolv_localhost
+        elsif @host.resolvconf.nameserver_localhost
           fail "Host has /etc/resolv.conf configured with localhost as a resolver"
         end
 

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -146,8 +146,8 @@ module Pharos
       # Host /etc/resolv.conf is configured to use a nameserver at localhost in the host network namespace
       # @return [Boolean]
       def check_resolv_localhost
-        resolvers = read_resolv_nameservers.map{|ip| IPAddr.new(ip) }
-        resolvers.any? {|ip| LOCALNET.include?(ip) }
+        resolvers = read_resolv_nameservers.map{ |ip| IPAddr.new(ip) }
+        resolvers.any? { |ip| LOCALNET.include?(ip) }
       end
 
       # Host /etc/resolv.conf is configured to use the systemd-resolved stub resolver at 127.0.0.53

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -44,10 +44,7 @@ module Pharos
         @host.hostname = hostname
         @host.checks = host_checks
         @host.private_interface_address = private_interface_address(@host.private_interface) if @host.private_interface
-        @host.resolvconf = Pharos::Configuration::Host::ResolvConf.new(
-          nameserver_localhost: check_resolvconf_nameserver_localhost,
-          systemd_resolved_stub: check_resolvconf_systemd_resolved_stub,
-        )
+        @host.resolvconf = get_resolvconf
       end
 
       def check_role
@@ -157,6 +154,14 @@ module Pharos
       def check_resolvconf_systemd_resolved_stub
         symlink = @ssh.file('/etc/resolv.conf').readlink
         !!symlink && symlink.end_with?('/run/systemd/resolve/stub-resolv.conf')
+      end
+
+      # @return [Pharos::Configuration::Host::ResolvConf]
+      def get_resolvconf
+        Pharos::Configuration::Host::ResolvConf.new(
+          nameserver_localhost: check_resolvconf_nameserver_localhost,
+          systemd_resolved_stub: check_resolvconf_systemd_resolved_stub,
+        )
       end
     end
   end

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -44,7 +44,7 @@ module Pharos
         @host.hostname = hostname
         @host.checks = host_checks
         @host.private_interface_address = private_interface_address(@host.private_interface) if @host.private_interface
-        @host.resolvconf = get_resolvconf
+        @host.resolvconf = read_resolvconf
       end
 
       def check_role
@@ -157,10 +157,10 @@ module Pharos
       end
 
       # @return [Pharos::Configuration::Host::ResolvConf]
-      def get_resolvconf
+      def read_resolvconf
         Pharos::Configuration::Host::ResolvConf.new(
           nameserver_localhost: check_resolvconf_nameserver_localhost,
-          systemd_resolved_stub: check_resolvconf_systemd_resolved_stub,
+          systemd_resolved_stub: check_resolvconf_systemd_resolved_stub
         )
       end
     end

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -153,8 +153,8 @@ module Pharos
       # Host /etc/resolv.conf is configured to use the systemd-resolved stub resolver at 127.0.0.53
       # @return [Boolean]
       def check_systemd_resolved_stub
-        symlink = @ssh.exec!('readlink /etc/resolv.conf || echo').strip
-        symlink.end_with? '/run/systemd/resolve/stub-resolv.conf'
+        symlink = @ssh.file('/etc/resolv.conf').readlink
+        !!symlink && symlink.end_with?('/run/systemd/resolve/stub-resolv.conf')
       end
     end
   end

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -82,6 +82,15 @@ module Pharos
         @client.exec!("sudo ln -s #{escaped_path} #{target.shellescape}")
       end
 
+      # @return [String, nil]
+      def readlink
+        target = @client.exec!("readlink #{escaped_path} || echo").strip
+
+        return nil if target.empty?
+
+        target
+      end
+
       # Yields each line in the remote file
       # @yield [String]
       def each_line

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -119,5 +119,31 @@ describe Pharos::Phases::ConfigureKubelet do
         ]
       end
     end
+
+    context "with a systemd-resolved stub" do
+      let(:host_resolvconf) { Pharos::Configuration::Host::ResolvConf.new(
+          nameserver_localhost: true,
+          systemd_resolved_stub: true,
+      ) }
+
+      it "uses --resolv-conf" do
+        expect(subject.kubelet_dns_args).to eq [
+          '--cluster-dns=10.96.0.10',
+          '--cluster-domain=cluster.local',
+          '--resolv-conf=/run/systemd/resolve/resolv.conf',
+        ]
+      end
+    end
+
+    context "with a non-systemd-resolved localhost resolver" do
+      let(:host_resolvconf) { Pharos::Configuration::Host::ResolvConf.new(
+          nameserver_localhost: true,
+          systemd_resolved_stub: false,
+      ) }
+
+      it "fails" do
+        expect{subject.kubelet_dns_args}.to raise_error 'Host has /etc/resolv.conf configured with localhost as a resolver'
+      end
+    end
   end
 end

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -1,7 +1,14 @@
 require "pharos/phases/configure_kubelet"
 
 describe Pharos::Phases::ConfigureKubelet do
-  let(:host) { Pharos::Configuration::Host.new(address: 'test', private_address: '192.168.42.1') }
+  let(:host_resolvconf) { Pharos::Configuration::Host::ResolvConf.new(
+      nameserver_localhost: false,
+      systemd_resolved_stub: false,
+  ) }
+  let(:host) { Pharos::Configuration::Host.new(
+    address: 'test',
+    private_address: '192.168.42.1',
+  ) }
 
   let(:config) { Pharos::Config.new(
       hosts: [host],
@@ -15,6 +22,8 @@ describe Pharos::Phases::ConfigureKubelet do
   subject { described_class.new(host, config: config, ssh: ssh) }
 
   before(:each) do
+    host.resolvconf = host_resolvconf
+
     allow(host).to receive(:cpu_arch).and_return(double(:cpu_arch, name: 'amd64'))
   end
 

--- a/spec/pharos/phases/validate_host_spec.rb
+++ b/spec/pharos/phases/validate_host_spec.rb
@@ -168,7 +168,7 @@ describe Pharos::Phases::ValidateHost do
       let(:file_lines) { ['nameserver 8.8.8.8'] }
 
       it 'returns ok' do
-        expect(subject.get_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
+        expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
           nameserver_localhost: false,
           systemd_resolved_stub: false,
         )
@@ -179,7 +179,7 @@ describe Pharos::Phases::ValidateHost do
       let(:file_lines) { ['nameserver 127.0.0.53'] }
 
       it 'returns nameserver_localhost' do
-        expect(subject.get_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
+        expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
           nameserver_localhost: true,
           systemd_resolved_stub: false,
         )
@@ -191,7 +191,7 @@ describe Pharos::Phases::ValidateHost do
       let(:file_readlink) { '../run/systemd/resolve/stub-resolv.conf' }
 
       it 'returns systemd_resolved_stub' do
-        expect(subject.get_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
+        expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
           nameserver_localhost: true,
           systemd_resolved_stub: true,
         )
@@ -203,7 +203,7 @@ describe Pharos::Phases::ValidateHost do
       let(:file_readlink) { '/run/resolvconf/resolv.conf' }
 
       it 'returns ok' do
-        expect(subject.get_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
+        expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
           nameserver_localhost: false,
           systemd_resolved_stub: false,
         )


### PR DESCRIPTION
Fixes #448 pod `dnsPolicy: Default` behavior on Ubuntu bionic with the systemd-resolved stub resolver enabled.

This covers both the general issue and the specific fix for `systemd-resolved`: it uses the upstream resolvers if available, and otherwise fails if the host is configured to use localhost nameservers.