### PR TITLE
Release v1.2.0-beta.2

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.2.0-beta.1"
+  VERSION = "1.2.0-beta.2"
 end


### PR DESCRIPTION
## Changes since v1.2.0-beta.1

- update host-upgrades addon to use pharos-host-upgrades (#393)
- support cri-o on Ubuntu 18.04/CentOS7/RHEL7 (#449)
- update calico to v3.1.3 (#445)
- detect systemd-resolved stub resolver at localhost and bypass using kubelet --resolv-conf (#450)
- kured: show deprecation notice (#442)
- fix output error when color is disabled (#436)
- don't add --node-ip if cloud.provider is set (#444)
- fix ubuntu xenial cri-o error (#430)
- rubocop: forget about Lint/SplatKeywordArguments (#447)
