### PR TITLE
Fix Ubuntu bionic docker install

### DIFF
--- a/lib/pharos/host/ubuntu/ubuntu_bionic.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_bionic.rb
@@ -36,7 +36,7 @@ module Pharos
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1~16.04.2"
+            DOCKER_VERSION: "#{DOCKER_VERSION}-*"
           )
         elsif crio?
           exec_script(


### PR DESCRIPTION
The `*--0ubuntu1~16.04.2` suffix seems to match what xenial is using?

```
SSH exec failed with code 100: configure-docker.sh
+ set -e
+ mkdir -p /etc/docker
+ cat
+ [ -n  ]
+ [ -f /etc/systemd/system/docker.service.d/http-proxy.conf ]
+ export DEBIAN_FRONTEND=noninteractive
+ apt-mark unhold docker.io
docker.io was already not hold.
+ apt-get install -y docker.io=17.12.1-0ubuntu1~16.04.2
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '17.12.1-0ubuntu1~16.04.2' for 'docker.io' was not found
/app/lib/pharos/ssh/remote_command.rb:66:in `run!'
/app/lib/pharos/ssh/client.rb:60:in `exec!'
/app/lib/pharos/ssh/client.rb:72:in `exec_script!'
/app/lib/pharos/host/configurer.rb:70:in `exec_script'
/app/lib/pharos/host/ubuntu/ubuntu_bionic.rb:36:in `configure_container_runtime'
/app/lib/pharos/phases/configure_host.rb:22:in `call'
/app/lib/pharos/phase_manager.rb:70:in `block in apply'
/app/lib/pharos/phase_manager.rb:26:in `block (2 levels) in run_parallel'
```