### PR TITLE
Validate calico ippool cidr against the cluster.yml pod network cidr

### DIFF
--- a/lib/pharos/phases/configure_calico.rb
+++ b/lib/pharos/phases/configure_calico.rb
@@ -25,8 +25,8 @@ module Pharos
       # @return [Kubeclient::Resource, nil]
       def get_ippool(name)
         client = kube_session.resource_client('crd.projectcalico.org/v1')
-        ippool = client.get_entity('ippools', name)
-      rescue Kubeclient::ResourceNotFoundError => exc
+        client.get_entity('ippools', name)
+      rescue Kubeclient::ResourceNotFoundError
         nil
       end
 
@@ -34,9 +34,9 @@ module Pharos
       def validate_ippool
         return unless ippool = get_ippool('default-ipv4-ippool')
 
-        if ippool.spec.cidr != @config.network.pod_network_cidr
-          fail "cluster.yml network.pod_network_cidr has been changed: cluster has #{ippool.spec.cidr}, config has #{@config.network.pod_network_cidr}"
-        end
+        return if ippool.spec.cidr == @config.network.pod_network_cidr
+
+        fail "cluster.yml network.pod_network_cidr has been changed: cluster has #{ippool.spec.cidr}, config has #{@config.network.pod_network_cidr}"
       end
 
       def validate

--- a/spec/pharos/phases/configure_calico_spec.rb
+++ b/spec/pharos/phases/configure_calico_spec.rb
@@ -1,0 +1,74 @@
+require "pharos/phases/configure_calico"
+
+describe Pharos::Phases::ConfigureCalico do
+  let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.1') }
+  let(:config_network) { { }}
+  let(:config) { Pharos::Config.new(
+      hosts: [host],
+      network: config_network,
+      addons: {},
+      etcd: {},
+      kubelet: {read_only_port: false}
+  ) }
+
+  let(:kube_session) { instance_double(Pharos::Kube::Session) }
+
+  subject { described_class.new(host, config: config, master: host) }
+
+  before do
+    allow(subject).to receive(:kube_session).and_return(kube_session)
+  end
+
+  describe '#get_ippool' do
+    let(:kube_client) { instance_double(Pharos::Kube::Client) }
+    let(:ippool) { Kubeclient::Resource.new }
+
+    before do
+      expect(kube_session).to receive(:resource_client).with('crd.projectcalico.org/v1').and_return(kube_client)
+    end
+
+    it 'returns kube resource' do
+      expect(kube_client).to receive(:get_entity).with('ippools', 'test').and_return(ippool)
+
+      expect(subject.get_ippool('test')).to eq ippool
+    end
+
+    it 'returns nil on 404' do
+      expect(kube_client).to receive(:get_entity).with('ippools', 'test').and_raise(Kubeclient::ResourceNotFoundError.new(404, "Not Found", double()))
+
+      expect(subject.get_ippool('test')).to be nil
+    end
+  end
+
+  describe '#validate_ippool' do
+    let(:ippool) { }
+
+    before do
+      allow(subject).to receive(:get_ippool).with('default-ipv4-ippool').and_return(ippool)
+    end
+
+    context 'without any ippool' do
+      let(:ippool) { nil }
+
+      it "does not raise" do
+        expect{subject.validate_ippool}.to_not raise_error
+      end
+    end
+
+    context 'with a matching ippool' do
+      let(:ippool) { double(spec: double(cidr: '10.32.0.0/12')) }
+
+      it "does not raise" do
+        expect{subject.validate_ippool}.to_not raise_error
+      end
+    end
+
+    context 'with a mismatching ippool' do
+      let(:ippool) { double(spec: double(cidr: '10.128.0.0/12')) }
+
+      it "raises" do
+        expect{subject.validate_ippool}.to raise_error(/cluster.yml network.pod_network_cidr has been changed/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fail if the `cluster.yml` `.network.pod_network_cidr` is changed.