### PR TITLE
Don't set default value for ssh user

### DIFF
--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -19,7 +19,7 @@ module Pharos
       attribute :role, Pharos::Types::Strict::String
       attribute :labels, Pharos::Types::Strict::Hash
       attribute :taints, Pharos::Types::Strict::Array.of(Pharos::Configuration::Taint)
-      attribute :user, Pharos::Types::Strict::String.default('ubuntu')
+      attribute :user, Pharos::Types::Strict::String
       attribute :ssh_key_path, Pharos::Types::Strict::String.default('~/.ssh/id_rsa')
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
       attribute :http_proxy, Pharos::Types::Strict::String


### PR DESCRIPTION
Default value `ubuntu` does not make sense anymore. This change allows `net-ssh` library to pick user from environment (or from ssh-config). 

Fixes #443