### PR TITLE
Release v1.2.0-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.2.0-beta.3"
+  VERSION = "1.2.0-rc.1"
 end


### PR DESCRIPTION
## Changes since v1.2.0-beta.3

- cluster reset command (#432)
- validate calico ippool cidr against the cluster.yml pod network cidr (#454)
- don't set default value for ssh user (#457)
- update cri-o to v1.10.4 (#456)