### PR TITLE
Enable kubelet authentication token webhook

### DIFF
--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -120,6 +120,7 @@ module Pharos
         end
         args += @host.kubelet_args(local_only: false, cloud_provider: @config.cloud&.provider)
 
+        args << "--authentication-token-webhook=true"
         args << "--pod-infra-container-image=#{@config.image_repository}/pause-#{@host.cpu_arch.name}:3.1"
         args << "--cloud-provider=#{@config.cloud.provider}" if @config.cloud
         args << "--cloud-config=#{CLOUD_CONFIG_FILE}" if @config.cloud&.config

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -32,7 +32,7 @@ describe Pharos::Phases::ConfigureKubelet do
     it "returns a systemd unit" do
       expect(subject.build_systemd_dropin).to eq <<~EOM
         [Service]
-        Environment='KUBELET_EXTRA_ARGS=--read-only-port=0 --node-ip=192.168.42.1 --hostname-override= --pod-infra-container-image=quay.io/kontena/pause-amd64:3.1'
+        Environment='KUBELET_EXTRA_ARGS=--read-only-port=0 --node-ip=192.168.42.1 --hostname-override= --authentication-token-webhook=true --pod-infra-container-image=quay.io/kontena/pause-amd64:3.1'
         Environment='KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local'
         ExecStartPre=-/sbin/swapoff -a
       EOM
@@ -44,7 +44,8 @@ describe Pharos::Phases::ConfigureKubelet do
       expect(subject.kubelet_extra_args).to include(
         '--read-only-port=0',
         '--node-ip=192.168.42.1',
-        '--hostname-override='
+        '--hostname-override=',
+        '--authentication-token-webhook=true'
       )
     end
 


### PR DESCRIPTION
Enables service account tokens for accessing kubelet api.


https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/#kubelet-authentication