### PR TITLE
add cluster-service annotation to dashboard

### DIFF
--- a/addons/kubernetes-dashboard/addon.rb
+++ b/addons/kubernetes-dashboard/addon.rb
@@ -7,7 +7,7 @@ Pharos.addon 'kubernetes-dashboard' do
   install {
     apply_resources(heapster_version: '1.5.1')
 
-    logger.info { "~~> kubernetes-dashboard can be accessed via kubectl proxy at http://localhost:8001/ui" }
+    logger.info { "~~> kubernetes-dashboard can be accessed via kubectl proxy. Check proxy URL with: kubectl cluster-info" }
 
     service_account = kube_client.get_service_account('dashboard-admin', 'kube-system')
     token_secret = service_account.secrets[0]

--- a/addons/kubernetes-dashboard/resources/service.yml
+++ b/addons/kubernetes-dashboard/resources/service.yml
@@ -3,6 +3,7 @@ apiVersion: v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
+    kubernetes.io/cluster-service: "true"
   name: kubernetes-dashboard
   namespace: kube-system
 spec:


### PR DESCRIPTION
Makes it visible in cluster info:
```
$ kubectl cluster-info
Kubernetes master is running at https://174.138.107.114:6443
Heapster is running at https://174.138.107.114:6443/api/v1/namespaces/kube-system/services/heapster/proxy
KubeDNS is running at https://174.138.107.114:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
kubernetes-dashboard is running at https://174.138.107.114:6443/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy
Metrics-server is running at https://174.138.107.114:6443/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy

```

Also changed to dashboard addon to instruct user to check the proxy url from cluster-info