### PR TITLE
Release v1.2.0

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.2.0-rc.1"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
## Changes since v1.1.1

- support for multiple operating systems (#362)
- CentOS/RHEL7 support (#410, #425)
- Ubuntu 18.04 support (#362)
- cluster reset command (#432)
- update host-upgrades addon to use pharos-host-upgrades (#393)
- replace heapster with metrics-server (#461)
- enable kubelet authentication token webhook (#460)
- add cluster-service annotation to dashboard to make it visible in cluster-info (#464)
- refresh yum repo metadata on every run (#462)
- don't set default value for ssh user (#457)
- support cri-o on Ubuntu 18.04/CentOS7/RHEL7 (#449)
- update calico to v3.1.3 (#445)
- validate calico ippool cidr against the cluster.yml pod network cidr (#454)
- kured: show deprecation notice (#442)
- update cri-o to v1.10.4 (#456)
- fix Ubuntu bionic docker install version (#452)
- detect systemd-resolved stub resolver at localhost and bypass using kubelet --resolv-conf (#450)
- fix output error when color is disabled (#436)
- don't add --node-ip if cloud.provider is set (#444)
- fix ubuntu xenial cri-o error (#430)
- fix global --version etc by making RootCommand inherit from Pharos::Command (#423)
- handle migration from 1.1.x to 1.2.x (#424)
- rubocop: forget about Lint/SplatKeywordArguments (#447)