### PR TITLE
Fix LabelNodes to not clear taints when only patching labels

### DIFF
--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -15,25 +15,26 @@ module Pharos
         raise Pharos::Error, "Cannot set labels, node not found" if node.nil?
 
         logger.info { "Configuring node labels and taints ... " }
-        patch_node(node)
-      end
-
-      # @return [Array{Hash}]
-      def taints
-        return [] unless @host.taints
-
-        @host.taints.map(&:to_h)
+        patch_labels(node) if @host.labels
+        patch_taints(node) if @host.taints
       end
 
       # @param node [Kubeclient::Resource]
-      def patch_node(node)
+      def patch_labels(node)
         kube.patch_node(
           node.metadata.name,
           metadata: {
-            labels: @host.labels || {}
+            labels: @host.labels
           },
+        )
+      end
+
+      # @param node [Kubeclient::Resource]
+      def patch_taints(node)
+        kube.patch_node(
+          node.metadata.name,
           spec: {
-            taints: taints
+            taints: @host.taints.map(&:to_h)
           }
         )
       end

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -25,7 +25,7 @@ module Pharos
           node.metadata.name,
           metadata: {
             labels: @host.labels
-          },
+          }
         )
       end
 

--- a/spec/pharos/phases/label_node_spec.rb
+++ b/spec/pharos/phases/label_node_spec.rb
@@ -79,9 +79,6 @@ describe Pharos::Phases::LabelNode do
           metadata: {
             labels: { :foo => 'bar' },
           },
-          spec: {
-            taints: [ ],
-          }
         )
 
         subject.call
@@ -98,9 +95,31 @@ describe Pharos::Phases::LabelNode do
 
       it 'patches node' do
         expect(kube).to receive(:patch_node).with('test',
+          spec: {
+            taints: [ { key: 'node-role.kubernetes.io/master', value: nil, effect: 'NoSchedule' } ],
+          }
+        )
+
+        subject.call
+      end
+    end
+
+    context 'with labels and taints' do
+      let(:host) { Pharos::Configuration::Host.new(
+        address: '192.0.2.2',
+        labels: {foo: 'bar'},
+        taints: [
+          Pharos::Configuration::Taint.new(key: 'node-role.kubernetes.io/master', effect: 'NoSchedule'),
+        ]
+      ) }
+
+      it 'patches node twice' do
+        expect(kube).to receive(:patch_node).with('test',
           metadata: {
-            labels: { },
+            labels: { :foo => 'bar' },
           },
+        )
+        expect(kube).to receive(:patch_node).with('test',
           spec: {
             taints: [ { key: 'node-role.kubernetes.io/master', value: nil, effect: 'NoSchedule' } ],
           }


### PR DESCRIPTION
Fixes #470

The `.metadata.labels` and `.spec.taints` are now patched separately, so as to not touch the node taints if the config host `taints` is missing. You can still use an explicit `taints: []` to clear them.