### PR TITLE
Bump xenial to docker version 17.03.2 from xenial-updates docker.io

### DIFF
--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -7,7 +7,7 @@ module Pharos
     class UbuntuXenial < Ubuntu
       register_config 'ubuntu', '16.04'
 
-      DOCKER_VERSION = '1.13.1'
+      DOCKER_VERSION = '17.03.2'
       CFSSL_VERSION = '1.2'
 
       register_component(
@@ -36,7 +36,7 @@ module Pharos
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1~16.04.2"
+            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu2~16.04.1"
           )
         elsif crio?
           exec_script(


### PR DESCRIPTION
Fixes #476

Upgrade Ubuntu xenial hosts from Docker 1.13.1 -> 17.03.2 per the supported Ubuntu `xenial-updates` version.