### PR TITLE
Upgrade kubernetes 1.10.5

### DIFF
--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -10,7 +10,7 @@ require_relative "pharos/root_command"
 module Pharos
   CRIO_VERSION = '1.10.4'
   CRICTL_VERSION = '1.0.0-beta.0'
-  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.4' }
+  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.5' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.1.12' }
   DOCKER_VERSION = '1.13.1'


### PR DESCRIPTION
Fixes  #463

The kube packages should already be built and available from the `kontena/pharos-debian` repos.