### PR TITLE
Upgrade cri-o to v1.10.6

### DIFF
--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -8,11 +8,9 @@ require_relative "pharos/error"
 require_relative "pharos/root_command"
 
 module Pharos
-  CRIO_VERSION = '1.10.4'
-  CRICTL_VERSION = '1.0.0-beta.0'
+  CRIO_VERSION = '1.10.6'
   KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.5' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.1.12' }
-  DOCKER_VERSION = '1.13.1'
   KUBELET_PROXY_VERSION = '0.3.6'
 end


### PR DESCRIPTION
Includes a security fix, see: 
- http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10892
- https://github.com/kubernetes-incubator/cri-o/releases/tag/v1.10.6