### PR TITLE
Release 1.2.2-rc.1

### DIFF
--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -7,7 +7,7 @@ module Pharos
     class UbuntuXenial < Ubuntu
       register_config 'ubuntu', '16.04'
 
-      DOCKER_VERSION = '1.13.1'
+      DOCKER_VERSION = '17.03.2'
       CFSSL_VERSION = '1.2'
 
       register_component(
@@ -36,7 +36,7 @@ module Pharos
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1~16.04.2"
+            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu2~16.04.1"
           )
         elsif crio?
           exec_script(

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -15,25 +15,26 @@ module Pharos
         raise Pharos::Error, "Cannot set labels, node not found" if node.nil?
 
         logger.info { "Configuring node labels and taints ... " }
-        patch_node(node)
-      end
-
-      # @return [Array{Hash}]
-      def taints
-        return [] unless @host.taints
-
-        @host.taints.map(&:to_h)
+        patch_labels(node) if @host.labels
+        patch_taints(node) if @host.taints
       end
 
       # @param node [Kubeclient::Resource]
-      def patch_node(node)
+      def patch_labels(node)
         kube.patch_node(
           node.metadata.name,
           metadata: {
-            labels: @host.labels || {}
-          },
+            labels: @host.labels
+          }
+        )
+      end
+
+      # @param node [Kubeclient::Resource]
+      def patch_taints(node)
+        kube.patch_node(
+          node.metadata.name,
           spec: {
-            taints: taints
+            taints: @host.taints.map(&:to_h)
           }
         )
       end

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.2.1"
+  VERSION = "1.2.2-rc.1"
 end

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -10,7 +10,7 @@ require_relative "pharos/root_command"
 module Pharos
   CRIO_VERSION = '1.10.4'
   CRICTL_VERSION = '1.0.0-beta.0'
-  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.4' }
+  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.5' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.1.12' }
   DOCKER_VERSION = '1.13.1'

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -8,11 +8,9 @@ require_relative "pharos/error"
 require_relative "pharos/root_command"
 
 module Pharos
-  CRIO_VERSION = '1.10.4'
-  CRICTL_VERSION = '1.0.0-beta.0'
+  CRIO_VERSION = '1.10.6'
   KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.5' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.1.12' }
-  DOCKER_VERSION = '1.13.1'
   KUBELET_PROXY_VERSION = '0.3.6'
 end

--- a/spec/pharos/phases/label_node_spec.rb
+++ b/spec/pharos/phases/label_node_spec.rb
@@ -79,9 +79,6 @@ describe Pharos::Phases::LabelNode do
           metadata: {
             labels: { :foo => 'bar' },
           },
-          spec: {
-            taints: [ ],
-          }
         )
 
         subject.call
@@ -98,9 +95,31 @@ describe Pharos::Phases::LabelNode do
 
       it 'patches node' do
         expect(kube).to receive(:patch_node).with('test',
+          spec: {
+            taints: [ { key: 'node-role.kubernetes.io/master', value: nil, effect: 'NoSchedule' } ],
+          }
+        )
+
+        subject.call
+      end
+    end
+
+    context 'with labels and taints' do
+      let(:host) { Pharos::Configuration::Host.new(
+        address: '192.0.2.2',
+        labels: {foo: 'bar'},
+        taints: [
+          Pharos::Configuration::Taint.new(key: 'node-role.kubernetes.io/master', effect: 'NoSchedule'),
+        ]
+      ) }
+
+      it 'patches node twice' do
+        expect(kube).to receive(:patch_node).with('test',
           metadata: {
-            labels: { },
+            labels: { :foo => 'bar' },
           },
+        )
+        expect(kube).to receive(:patch_node).with('test',
           spec: {
             taints: [ { key: 'node-role.kubernetes.io/master', value: nil, effect: 'NoSchedule' } ],
           }


### PR DESCRIPTION
* Fix LabelNodes to not clear taints when only patching labels (#471)
* Upgrade kubernetes 1.10.5 (#478)
* Bump xenial to docker version 17.03.2 from xenial-updates docker.io (#477)
* Upgrade cri-o to v1.10.6 (#480)
