### PR TITLE
Remove config default ssh key path in favor of library default

### DIFF
--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -20,7 +20,7 @@ module Pharos
       attribute :labels, Pharos::Types::Strict::Hash
       attribute :taints, Pharos::Types::Strict::Array.of(Pharos::Configuration::Taint)
       attribute :user, Pharos::Types::Strict::String
-      attribute :ssh_key_path, Pharos::Types::Strict::String.default('~/.ssh/id_rsa')
+      attribute :ssh_key_path, Pharos::Types::Strict::String
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
       attribute :http_proxy, Pharos::Types::Strict::String
 

--- a/lib/pharos/ssh/manager.rb
+++ b/lib/pharos/ssh/manager.rb
@@ -9,13 +9,14 @@ module Pharos
 
       # @param host [Pharos::Configuration::Host]
       def client_for(host)
-        @clients[host] ||= Pharos::SSH::Client.new(host.address, host.user, keys: [host.ssh_key_path]).tap(&:connect)
+        return @clients[host] if @clients[host]
+        opts = {}
+        opts[:keys] = [host.ssh_key_path] if host.ssh_key_path
+        @clients[host] = Pharos::SSH::Client.new(host.address, host.user, opts).tap(&:connect)
       end
 
       def disconnect_all
-        @clients.each do |_host, client|
-          client.disconnect
-        end
+        @clients.each_value(&:disconnect)
       end
     end
   end


### PR DESCRIPTION
Fixes #443

The default for ssh identity files in Net-SSH is:

```ruby
%w[~/.ssh/id_dsa ~/.ssh/id_rsa ~/.ssh2/id_dsa ~/.ssh2/id_rsa]
```

