### PR TITLE
Fix utils.sh for Dash

### DIFF
--- a/lib/pharos/scripts/pharos.sh
+++ b/lib/pharos/scripts/pharos.sh
@@ -12,7 +12,7 @@ file_exists() {
 ## @param line
 ## @param file
 lineinfile() {
-    [[ $# -lt 3 ]] && return 1
+    [ "$#" -lt 3 ] && return 1
 
     match=$1
     line=$2
@@ -30,7 +30,7 @@ lineinfile() {
 ## @param match
 ## @param file
 linefromfile() {
-    [[ $# -lt 2 ]] && return 1
+    [ "$#" -lt 2 ] && return 1
 
     match=$1
     shift


### PR DESCRIPTION
Fixes #402

Argument count check in `utils.sh` fails when /bin/sh is Dash

`[[ $# -lt 3 ]]` does not work in dash.
`[ "$#" -lt 3 ]` works in bash and dash.
