### PR TITLE
cri-o: add docker.io to default registries

### DIFF
--- a/lib/pharos/host/el7/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/el7/scripts/configure-cri-o.sh
@@ -77,6 +77,7 @@ lineinfile "^stream_address =" "stream_address = \"${CRIO_STREAM_ADDRESS}\"" "/e
 lineinfile "^cgroup_manager =" "cgroup_manager = \"systemd\"" "/etc/crio/crio.conf"
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}/pause-${CPU_ARCH}:3.1\"" "/etc/crio/crio.conf"
+lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"
 
 if ! systemctl is-active --quiet crio; then
     systemctl daemon-reload

--- a/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
@@ -86,6 +86,7 @@ lineinfile "^stream_address =" "stream_address = \"${CRIO_STREAM_ADDRESS}\"" "/e
 lineinfile "^cgroup_manager =" "cgroup_manager = \"cgroupfs\"" "/etc/crio/crio.conf"
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}\/pause-${CPU_ARCH}:3.1\"" "/etc/crio/crio.conf"
+lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"
 
 if ! systemctl is-active --quiet crio; then
     systemctl daemon-reload


### PR DESCRIPTION
Currently it's kinda surprising that non-qualified images work with docker but not with cri-o. This PR unifies default registries so that both supported runtimes use docker.io as the default registry (if non-qualified image repo is used). This should fix conformance problems with cri-o.