### PR TITLE
Release v1.2.3-rc.1

### DIFF
--- a/lib/pharos/host/el7/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/el7/scripts/configure-cri-o.sh
@@ -77,6 +77,7 @@ lineinfile "^stream_address =" "stream_address = \"${CRIO_STREAM_ADDRESS}\"" "/e
 lineinfile "^cgroup_manager =" "cgroup_manager = \"systemd\"" "/etc/crio/crio.conf"
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}/pause-${CPU_ARCH}:3.1\"" "/etc/crio/crio.conf"
+lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"
 
 if ! systemctl is-active --quiet crio; then
     systemctl daemon-reload

--- a/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
@@ -86,6 +86,7 @@ lineinfile "^stream_address =" "stream_address = \"${CRIO_STREAM_ADDRESS}\"" "/e
 lineinfile "^cgroup_manager =" "cgroup_manager = \"cgroupfs\"" "/etc/crio/crio.conf"
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}\/pause-${CPU_ARCH}:3.1\"" "/etc/crio/crio.conf"
+lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"
 
 if ! systemctl is-active --quiet crio; then
     systemctl daemon-reload

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -9,7 +9,7 @@ require_relative "pharos/root_command"
 
 module Pharos
   CRIO_VERSION = '1.10.6'
-  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.5' }
+  KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.10.6' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.1.12' }
   KUBELET_PROXY_VERSION = '0.3.6'


### PR DESCRIPTION
## Changes since v1.2.2

- kubernetes 1.10.6 (#493)
- cri-o: add docker.io as default registry (#494)