### PR TITLE
Release v1.2.3

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.2.3-rc.2"
+  VERSION = "1.2.3"
 end


### PR DESCRIPTION
## Changes since v1.2.2

- kubernetes 1.10.6 (#493)
- cri-o: add docker.io as default registry (#494)
- ubuntu: restart docker on upgrade (#496)