### PR TITLE
[wip] Specify cluster name, username and kubeconfig path in cluster.yml

### DIFF
--- a/cluster.example.yml
+++ b/cluster.example.yml
@@ -60,3 +60,9 @@ addons:
     interval: 7d
   kured:
     enabled: true
+cluster:
+  name: pharos-cluster
+  kube_config:
+    path: ~/.kube/config
+    user: admin
+    context: admin@pharos-cluster

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'types'
+require_relative 'configuration/cluster'
 require_relative 'configuration/host'
 require_relative 'configuration/api'
 require_relative 'configuration/network'
@@ -10,6 +11,7 @@ require_relative 'configuration/cloud'
 require_relative 'configuration/audit'
 require_relative 'configuration/kube_proxy'
 require_relative 'configuration/kubelet'
+require_relative 'configuration/kube_config'
 
 module Pharos
   class Config < Pharos::Configuration::Struct
@@ -30,6 +32,7 @@ module Pharos
       config
     end
 
+    attribute :cluster, Pharos::Configuration::Cluster
     attribute :hosts, Types::Coercible::Array.of(Pharos::Configuration::Host)
     attribute :network, Pharos::Configuration::Network
     attribute :kube_proxy, Pharos::Configuration::KubeProxy

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -36,6 +36,14 @@ module Pharos
             )
           end
         end
+        optional(:cluster).schema do
+          optional(:name).filled(:str?)
+          optional(:kube_config).schema do
+            optional(:path).filled(:str?)
+            optional(:user).filled(:str?)
+            optional(:context).filled(:str?)
+          end
+        end
         required(:hosts).filled(min_size?: 1) do
           each do
             schema do

--- a/lib/pharos/configuration/cluster.rb
+++ b/lib/pharos/configuration/cluster.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'pharos/configuration/kube_config'
+
+module Pharos
+  module Configuration
+    class Cluster < Pharos::Configuration::Struct
+      attribute :name, Pharos::Types::String.optional
+      attribute :kube_config, Pharos::Configuration::KubeConfig.optional
+    end
+  end
+end

--- a/lib/pharos/configuration/kube_config.rb
+++ b/lib/pharos/configuration/kube_config.rb
@@ -9,4 +9,3 @@ module Pharos
     end
   end
 end
-

--- a/lib/pharos/configuration/kube_config.rb
+++ b/lib/pharos/configuration/kube_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Configuration
+    class KubeConfig < Pharos::Configuration::Struct
+      attribute :path, Pharos::Types::String.optional
+      attribute :user, Pharos::Types::String.optional
+      attribute :context, Pharos::Types::String.optional
+    end
+  end
+end
+

--- a/lib/pharos/kube/config.rb
+++ b/lib/pharos/kube/config.rb
@@ -28,11 +28,6 @@ module Pharos
       end
       alias to_h config
 
-      def yaml_content
-        Pharos::YamlFile.new(StringIO.new(@content)).load unless @content.nil?
-      end
-      private :yaml_content
-
       # Convert to YAML
       # @return [String]
       def dump
@@ -123,6 +118,12 @@ module Pharos
         end
 
         instance
+      end
+
+      private
+
+      def yaml_content
+        Pharos::YamlFile.new(StringIO.new(@content)).load unless @content.nil?
       end
     end
   end

--- a/lib/pharos/kube/config.rb
+++ b/lib/pharos/kube/config.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'pharos/yaml_file'
+
+module Pharos
+  module Kube
+    # Loads and manipulates kubeconfig files
+    class Config
+      InvalidConfigError = Class.new(Pharos::Error)
+
+      # @param content [String] configuration content
+      def initialize(content = nil)
+        @content = content
+      end
+
+      # Accessor to the configuration hash. Will use the YAML content for initialization if available.
+      # @return [Hash]
+      def config
+        @config ||= yaml_content || {
+          'apiVersion' => 'v1',
+          'clusters' => [],
+          'contexts' => [],
+          'current-context' => nil,
+          'kind' => 'Config',
+          'preferences' => {},
+          'users' => []
+        }
+      end
+      alias to_h config
+
+      def yaml_content
+        Pharos::YamlFile.new(StringIO.new(@content)).load unless @content.nil?
+      end
+      private :yaml_content
+
+      # Convert to YAML
+      # @return [String]
+      def dump
+        YAML.dump(config)
+      end
+      alias to_s dump
+
+      # Performs a merge of another kubeconfig into the current instance
+      # @param other [Pharos::Kube::Config]
+      def merge!(other)
+        other.config.each do |key, value|
+          case key
+          when 'clusters', 'contexts', 'users'
+            value.each do |other_value|
+              own_value = config[key].find { |c| c['name'] == other_value['name'] }
+              config[key].delete(own_value) if own_value
+              config[key] << other_value
+            end
+          when 'current-context', 'preferences'
+            config[key] = value
+          else
+            config[key] ||= value
+          end
+        end
+
+        self
+      end
+      alias << merge!
+
+      # Create a duplicate
+      # @return [Pharos::Kube::Config]
+      def dup
+        self.class.new(@content)
+      end
+      alias clone dup
+
+      # Performs a merge and returns a new instance
+      # @param other_config [Pharos::Kube::Config]
+      # @return [Pharos::Kube::Config]
+      def merge(other)
+        dup << other
+      end
+      alias + merge
+
+      def self.from_remote(content, cluster_config, host)
+        instance = new(content)
+
+        unless instance.config['clusters'].size == 1
+          raise InvalidConfigError, "Remote configuration cluster count expected to be one"
+        end
+
+        cluster = instance.config['clusters']&.first
+
+        cluster_name = cluster_config&.name || cluster['name']
+
+        # Overwrite server address and cluster name
+        cluster['cluster']['server'] = "https://#{host.api_address}:6443"
+        cluster['name'] = cluster_name
+
+        unless instance.config['contexts'].size == 1
+          raise InvalidConfigError, "Remote configuration context count expected to be one"
+        end
+
+        if cluster_config&.kube_config&.user
+          # Rename user as configured in cluster yaml
+          user_name = cluster_config&.kube_config&.user
+          instance.config['users'].first['name'] = user_name
+        else
+          user_name = instance.config['users'].first['name']
+        end
+
+        # Rename cluster and user in context
+        context = instance.config['contexts'].first
+        context['context']['cluster'] = cluster_name
+        context['context']['user'] = user_name
+
+        config_context = cluster_config&.kube_config&.context
+
+        if config_context
+          # Rename context & current context to one specified in config
+          context['name'] = config_context
+          instance.config['current-context'] = config_context
+        else
+          # Rename context & current context to match cluster.yml cluster name and user name
+          context_name = "#{user_name}@#{cluster_name}"
+          instance.config['current-context'] = context_name
+          context['name'] = context_name
+        end
+
+        instance
+      end
+    end
+  end
+end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -108,7 +108,11 @@ module Pharos
       craft_time = Time.now - start_time
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    You can connect to the cluster with kubectl using:"
-      puts "    export KUBECONFIG=~/.pharos/#{manager.sorted_master_hosts.first.api_address}"
+      if config.cluster&.kube_config&.path
+        puts "    export KUBECONFIG=#{config.cluster.kube_config.path}"
+      else
+        puts "    export KUBECONFIG=~/.pharos/#{manager.sorted_master_hosts.first.api_address}"
+      end
 
       manager.disconnect
     end


### PR DESCRIPTION
Fixes #438

- Set cluster, user and context names in cluster.yml
- Set path for kubectl config. If file exists, the new config will be merged on top of it

Example config:

```yaml
# cluster.yml
---
cluster:
  name: pharos-cluster # default comes from kube and is 'kubernetes'
  kube_config:
    path: ~/.kube/config # default is ~/.pharos/ip.address.of.apiserver
    user: admin # default comes from kube and is 'kubernetes-admin'
    context: root # default comes from kube and is 'kubernetes-admin@kubernetes'
```
