### PR TITLE
Fixup #455 for newer dry-struct

### DIFF
--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -42,10 +42,10 @@ module Pharos
           # special-case the default route and ignore it
           return nil if prefix == 'default'
 
-          prefix = IPAddr.new(self.prefix)
+          route_prefix = IPAddr.new(prefix)
           cidr = IPAddr.new(cidr)
 
-          prefix.include?(cidr) || cidr.include?(prefix)
+          route_prefix.include?(cidr) || cidr.include?(route_prefix)
         end
       end
 

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -11,7 +11,7 @@ module Pharos
         attribute :systemd_resolved_stub, Pharos::Types::Strict::Bool
       end
 
-      class Route < Dry::Struct
+      class Route < Pharos::Configuration::Struct
         ROUTE_REGEXP = %r(^((?<type>\S+)\s+)?(?<prefix>default|[0-9./]+)(\s+via (?<via>\S+))?(\s+dev (?<dev>\S+))?(\s+proto (?<proto>\S+))?(\s+(?<options>.+))?$)
 
         # @param line [String]
@@ -24,8 +24,6 @@ module Pharos
 
           new(raw: line.strip, **captures)
         end
-
-        constructor_type :schema
 
         attribute :raw, Pharos::Types::Strict::String
         attribute :type, Pharos::Types::Strict::String.optional

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -40,9 +40,9 @@ module Pharos
         # @return [Boolean]
         def overlaps?(cidr)
           # special-case the default route and ignore it
-          return nil if @prefix == 'default'
+          return nil if self.prefix == 'default'
 
-          prefix = IPAddr.new(@prefix)
+          prefix = IPAddr.new(self.prefix)
           cidr = IPAddr.new(cidr)
 
           prefix.include?(cidr) || cidr.include?(prefix)

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -20,7 +20,7 @@ module Pharos
         def self.parse(line)
           fail "Unmatched ip route: #{line.inspect}" unless match = ROUTE_REGEXP.match(line.strip)
 
-          captures = Hash[match.named_captures.map{ |k, v| [k.to_sym, v] }]
+          captures = Hash[match.named_captures.map{ |k, v| [k.to_sym, v] }.select{|k, v| !!v}]
 
           new(raw: line.strip, **captures)
         end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -20,7 +20,7 @@ module Pharos
         def self.parse(line)
           fail "Unmatched ip route: #{line.inspect}" unless match = ROUTE_REGEXP.match(line.strip)
 
-          captures = Hash[match.named_captures.map{ |k, v| [k.to_sym, v] }.select{|k, v| !!v}]
+          captures = Hash[match.named_captures.map{ |k, v| [k.to_sym, v] }.reject{ |_k, v| v.nil? }]
 
           new(raw: line.strip, **captures)
         end
@@ -40,7 +40,7 @@ module Pharos
         # @return [Boolean]
         def overlaps?(cidr)
           # special-case the default route and ignore it
-          return nil if self.prefix == 'default'
+          return nil if prefix == 'default'
 
           prefix = IPAddr.new(self.prefix)
           cidr = IPAddr.new(cidr)

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -44,7 +44,7 @@ module Pharos
       # @param routes [Array<Pharos::Configuration::Host::Routes>]
       # @return [Array<Pharos::Configuration::Host::Routes>]
       def filter_host_routes(routes)
-        case self.provider
+        case provider
         when 'weave'
           Weave.filter_host_routes(routes)
         when 'calico'

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -44,7 +44,7 @@ module Pharos
       # @param routes [Array<Pharos::Configuration::Host::Routes>]
       # @return [Array<Pharos::Configuration::Host::Routes>]
       def filter_host_routes(routes)
-        case @provider
+        case self.provider
         when 'weave'
           Weave.filter_host_routes(routes)
         when 'calico'

--- a/spec/pharos/configuration/host_route_spec.rb
+++ b/spec/pharos/configuration/host_route_spec.rb
@@ -12,7 +12,7 @@ describe Pharos::Configuration::Host::Route do
       '172.17.0.0/16 dev docker0  proto kernel  scope link  src 172.17.0.1 linkdown' => {prefix: '172.17.0.0/16', dev: 'docker0', proto: 'kernel', options: 'scope link  src 172.17.0.1 linkdown'},
     }.each do |line, attrs|
       it "parses: #{line}" do
-        expect(described_class.parse(line)).to eq described_class.new(raw: line, **attrs)
+        expect(described_class.parse(line).to_hash).to eq described_class.new(raw: line, **attrs).to_hash
       end
     end
   end


### PR DESCRIPTION
#455 was written against git master before the `Dry::Struct` upgrade in #474, and is broken with the newer dry-struct:

```
undefined method `constructor_type' for Pharos::Configuration::Host::Route:Class
Did you mean?  constructor
/app/lib/pharos/configuration/host.rb:28:in `<class:Route>'
/app/lib/pharos/configuration/host.rb:14:in `<class:Host>'
/app/lib/pharos/configuration/host.rb:8:in `<module:Configuration>'
/app/lib/pharos/configuration/host.rb:7:in `<module:Pharos>'
/app/lib/pharos/configuration/host.rb:6:in `<top (required)>'
/app/lib/pharos/config.rb:4:in `require_relative'
/app/lib/pharos/config.rb:4:in `<top (required)>'
/usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/app/lib/pharos/up_command.rb:59:in `load_config'
/app/lib/pharos/up_command.rb:36:in `execute'
/usr/local/bundle/gems/clamp-1.2.1/lib/clamp/command.rb:63:in `run'
/usr/local/bundle/gems/clamp-1.2.1/lib/clamp/subcommand/execution.rb:11:in `execute'
/usr/local/bundle/gems/clamp-1.2.1/lib/clamp/command.rb:63:in `run'
/usr/local/bundle/gems/clamp-1.2.1/lib/clamp/command.rb:132:in `run'
/app/lib/pharos/root_command.rb:16:in `run'
bin/pharos-cluster:12:in `<main>'
```