### PR TITLE
Generate sha256sums on release and add to github release page

### DIFF
--- a/build/drone/ubuntu_xenial.sh
+++ b/build/drone/ubuntu_xenial.sh
@@ -8,15 +8,16 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 gem install bundler
-rubyc -o pharos-cluster pharos-cluster
-./pharos-cluster version
-
+rubyc -o pharos-cluster-linux-amd64 pharos-cluster
+./pharos-cluster-linux-amd64 version
+shasum -a 256 pharos-cluster-linux-amd64 > pharos-cluster-linux-amd64.sha256
 # ship to github
 curl -sL https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 | tar -xjO > /usr/local/bin/github-release
 chmod +x /usr/local/bin/github-release
-/usr/local/bin/github-release upload \
+ls -1 pharos-cluster-linux-adm64 pharos-cluster-linux-amd64.sha256 | xargs -n1 -I{} -P0 -- \
+  /usr/local/bin/github-release upload \
     --user kontena \
     --repo pharos-cluster \
     --tag $DRONE_TAG \
-    --name "pharos-cluster-linux-amd64" \
-    --file ./pharos-cluster
+    --name {} \
+    --file {} ::: pharos-cluster-linux-amd64 pharos-cluster-linux-amd64.shasum

--- a/build/drone/ubuntu_xenial.sh
+++ b/build/drone/ubuntu_xenial.sh
@@ -20,4 +20,4 @@ ls -1 pharos-cluster-linux-adm64 pharos-cluster-linux-amd64.sha256 | xargs -n1 -
     --repo pharos-cluster \
     --tag $DRONE_TAG \
     --name {} \
-    --file {} ::: pharos-cluster-linux-amd64 pharos-cluster-linux-amd64.shasum
+    --file {}

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -17,5 +17,5 @@ ls -1 pharos-cluster-darwin-adm64 pharos-cluster-darwin-amd64.sha256 | xargs -n1
     --user kontena \
     --repo pharos-cluster \
     --tag $TRAVIS_TAG \
-    --name "pharos-cluster-darwin-amd64" \
-    --file ./pharos-cluster
+    --name {} \
+    --file {}

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -5,13 +5,15 @@ set -ue
 brew install squashfs
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
-rubyc -o pharos-cluster pharos-cluster
-./pharos-cluster version
+rubyc -o pharos-cluster-darwin-amd64 pharos-cluster
+./pharos-cluster-darwin-amd64 version
+shasum -a 256 pharos-cluster-darwin-amd64 > pharos-cluster-darwin-amd64.sha256
 
 # ship to github
 curl -sL https://github.com/aktau/github-release/releases/download/v0.7.2/darwin-amd64-github-release.tar.bz2 | tar -xjO > /usr/local/bin/github-release
 chmod +x /usr/local/bin/github-release
-/usr/local/bin/github-release upload \
+ls -1 pharos-cluster-darwin-adm64 pharos-cluster-darwin-amd64.sha256 | xargs -n1 -I{} -P0 -- \
+  /usr/local/bin/github-release upload \
     --user kontena \
     --repo pharos-cluster \
     --tag $TRAVIS_TAG \


### PR DESCRIPTION
Generate `pharos-cluster-linux-amd64.sha256` and `pharos-cluster-darwin-amd64.sha256` and upload them to github release as attachments.

`xargs -P0` should make the uploads happen in parallel, usually meaning that the creation timestamp that is visible in the [release info JSON](https://api.github.com/repos/kontena/pharos-cluster/releases/latest)'s asset list should be very similar.
