### PR TITLE
Force LC_ALL=C.UTF-8 locale for all SSH commands

### DIFF
--- a/lib/pharos/ssh/manager.rb
+++ b/lib/pharos/ssh/manager.rb
@@ -12,6 +12,7 @@ module Pharos
         return @clients[host] if @clients[host]
         opts = {}
         opts[:keys] = [host.ssh_key_path] if host.ssh_key_path
+        opts[:send_env] = [] # override default to not send LC_* envs
         @clients[host] = Pharos::SSH::Client.new(host.address, host.user, opts).tap(&:connect)
       end
 

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -73,6 +73,7 @@ module Pharos
         result = Result.new
 
         response = @client.session.open_channel do |channel|
+          channel.env('LC_ALL', 'C.UTF-8')
           channel.exec @cmd do |_, success|
             raise Error, "Failed to exec #{cmd}" unless success
 


### PR DESCRIPTION
Fixes #506

Disable the default `SendEnv LC_*` behavior and send `LC_ALL=C.UTF-8` instead to normalize the locale used for SSH commands.

This uses the native SSH env mechanism instead of shell envs, as used for script execs. This is a special case because the default sshd configuration for remote envs is typically `AcceptEnv LANG LC_*`, so this is the only viable usecase for SSH channel envs.