### PR TITLE
Fix Pharos::Kube::Stack label/annotation override

### DIFF
--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -32,6 +32,10 @@ module Pharos
 
         new(name, resources)
       end
+
+      def initialize(name, resources = [])
+        super(name, resources, label: LABEL, checksum_annotation: CHECKSUM_ANNOTATION)
+      end
     end
 
     # @param host [String]

--- a/spec/fixtures/stacks/test/test.yml
+++ b/spec/fixtures/stacks/test/test.yml
@@ -1,0 +1,8 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test
+  namespace: default
+data:
+  foo: bar

--- a/spec/pharos/kube_stack_spec.rb
+++ b/spec/pharos/kube_stack_spec.rb
@@ -43,7 +43,7 @@ describe Pharos::Kube::Stack do
       }
 
       before do
-        allow(client).to receive(:get_resources).and_return([nil])
+        allow(client).to receive(:get_resources).with([K8s::Resource]).and_return([nil])
         allow(client).to receive(:list_resources).with(labelSelector: { 'pharos.kontena.io/stack' => 'test' }).and_return([resource])
       end
 

--- a/spec/pharos/kube_stack_spec.rb
+++ b/spec/pharos/kube_stack_spec.rb
@@ -1,0 +1,57 @@
+describe Pharos::Kube::Stack do
+  describe "for a trivial test stack" do
+    let(:client) { instance_double(K8s::Client) }
+
+    subject do
+      described_class.load('test', fixtures_path('stacks/test'))
+    end
+
+    it "has the correct name" do
+      expect(subject.name).to eq 'test'
+    end
+
+    it "has the resource" do
+      expect(subject.resources.map{|r| r.to_hash}).to match [
+        hash_including(
+          metadata: {
+            namespace: 'default',
+            name: 'test',
+          },
+        )
+      ]
+    end
+
+    context "when not yet installed" do
+      let(:resource) {
+        K8s::Resource.new(
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: {
+            namespace: 'default',
+            name: 'test',
+            labels: {
+              'pharos.kontena.io/stack': 'test',
+            },
+            annotations: {
+              'pharos.kontena.io/stack-checksum': subject.checksum,
+            }
+          },
+          data: {
+            'foo' => 'bar',
+          }
+        )
+      }
+
+      before do
+        allow(client).to receive(:get_resources).and_return([nil])
+        allow(client).to receive(:list_resources).with(labelSelector: { 'pharos.kontena.io/stack' => 'test' }).and_return([resource])
+      end
+
+      it "creates the resource with the correct label" do
+        expect(client).to receive(:create_resource).with(resource).and_return(resource)
+
+        subject.apply(client)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#475 didn't actually override the label used for `Pharos::Kube::Stack`s due to how the `LABEL` constant is used as a default value in the superclass initialize method.  This caused existing stack resources to gain an additional `k8s.kontena.io/stack` label, and new resources would be missing the `pharos.kontena.io/stack` label.

Changing the stack label is harmless, because existing resources are found by name during the apply, however, it would better to keep it the same in case any stack resources are meant to be purged during the ugprade.