### PR TITLE
Load libraries in phase manager to fix version command

### DIFF
--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require 'openssl'
-require 'excon'
-require 'k8s/error'
-require 'pharos/ssh/remote_command'
+require_relative 'kube'
 
 module Pharos
   class PhaseManager

--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require 'openssl'
+require 'excon'
+require 'k8s/error'
+require 'pharos/ssh/remote_command'
+
 module Pharos
   class PhaseManager
     include Pharos::Logging


### PR DESCRIPTION
Fixes #521

Adds `require`s to phase manager so that it can define the list of retriable errors.
