### PR TITLE
Update k8s-client to 0.3.1

### DIFF
--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
-  spec.add_runtime_dependency "k8s-client", "~> 0.3.0"
+  spec.add_runtime_dependency "k8s-client", "~> 0.3.1"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Fixes #523

Stack apply was failing for stacks containing both a CRD + custom resources using that definition.