### PR TITLE
Lockdown crio stream-address to localhost-only for kubelet proxying

### DIFF
--- a/lib/pharos/host/el7/el7.rb
+++ b/lib/pharos/host/el7/el7.rb
@@ -52,7 +52,7 @@ module Pharos
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
-            CRIO_STREAM_ADDRESS: host.peer_address,
+            CRIO_STREAM_ADDRESS: '127.0.0.1',
             CPU_ARCH: host.cpu_arch.name,
             IMAGE_REPO: cluster_config.image_repository
           )

--- a/lib/pharos/host/ubuntu/ubuntu_bionic.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_bionic.rb
@@ -42,7 +42,7 @@ module Pharos
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
-            CRIO_STREAM_ADDRESS: host.peer_address,
+            CRIO_STREAM_ADDRESS: '127.0.0.1',
             CPU_ARCH: host.cpu_arch.name,
             IMAGE_REPO: cluster_config.image_repository
           )

--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -42,7 +42,7 @@ module Pharos
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
-            CRIO_STREAM_ADDRESS: host.peer_address,
+            CRIO_STREAM_ADDRESS: '127.0.0.1',
             CPU_ARCH: host.cpu_arch.name,
             IMAGE_REPO: cluster_config.image_repository
           )


### PR DESCRIPTION
Fixes #508

Replace the host public/private IP (reachable by the kube-apiserver for redirects) with `127.0.0.1`, for kubelet CRI proxying.

Tested that `kubectl logs` and `kubectl exec` still works.