### PR TITLE
Release v1.3.0-rc.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ pipeline:
       event: tag
   release_binary:
     image: plugins/s3
-    secret: [ aws_access_key_id, aws_secret_access_key ]
+    secrets: [ aws_access_key_id, aws_secret_access_key ]
     bucket: pharos-cluster-binaries
     region: eu-west-1
     source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ pipeline:
       event: tag
   release_binary:
     image: plugins/s3
-    secret: [ access_key, secret_key ]
+    secret: [ aws_access_key_id, aws_secret_access_key ]
     bucket: pharos-cluster-binaries
     region: eu-west-1
     source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,3 +20,10 @@ pipeline:
       - ./build/drone/ubuntu_xenial.sh
     when:
       event: tag
+  release_binary:
+    image: plugins/s3
+    secret: [ access_key, secret_key ]
+    bucket: pharos-cluster-binaries
+    region: eu-west-1
+    source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"
+    target: /

--- a/.drone.yml
+++ b/.drone.yml
@@ -27,3 +27,5 @@ pipeline:
     region: eu-west-1
     source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"
     target: /
+    when:
+      event: tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,13 @@ jobs:
       script: ./build/travis/macos.sh
       rvm: 2.4
       os: osx
+      deploy:
+        provider: s3
+        access_key_id:
+          secure: "OHjLg4bzJBUdwmw42XK5s/+5tHUy7SO32/NzV5qCETIw+lr0lEhHIUeGUDGEqsMKvB3X1rIyFhhYJcRUCkJHfDUM2uRyIxYl/HUNNHCnZttwBHsn517Wt8sSzx5mSHuqXl54hoI47vvx0yfKrvW70/AF0aNufEde5tQePzsgghZ0FIPKx29CiG0QAufTgJ3B3tXJtDywDXO6kyQmmpjSTO+Rne8YEx4MvyoGH1DhHiiSsggSMrYUy80mZP967AvQ6cCQNS7d9A1ThNjJVNGQ9jzTGW8vWRsvI1Y5583sWwAwVbKSYtcaO2t5IC1q62PnYu9xVyy6D5QZ4uJ4jQk8at00348nj059CosNEE9IdqRaTJi5TIiX9H1nU8y3P/c/2dYpsQIKch0Ji/cQhl4RCe+QQuOpCzggElf8GeD/tg9GJFhX+uPPWFJMl4zvrH5EascRm+PHJsr7UFL0Lv4Q0x85qdCa/0Oh1XA+f+WaLpSkUUiLUUB27+2dLupD3VyuSZ0IferiDHHgIG0teXoSvI6hgSBg85ZYZKls72seTuGG0icrn+U/iz+7ywtaaS5yVmrelUiYq4ElZr3N9SPaWUxUGXo734B60AIJ9dPQQJY8e+TJ2jjX3OCAd//Z3Kh2+O+nbcHUUMY4OfUVp4wcRy2LKlNqPC5DevZij2uVmKM="
+        secret_access_key:
+          secure: "HCnQTlTJ3jo4oX2ZLXZUUWHOL7yiV/z2dVNTmiQYGJ8Xsf34zLnwRvPTymq4nA7elCmO0J6G2ub1wqBLZqyYHhbhI//9txPpRJmgFf7C3R0c9j5HRG2lxRJ8PNHuOzT5e2Zx1Aq9Aawy2+zXTuNMnTF0gtXg2tO3oHzs2h99mk5qeoLDAbu1HUd+W7ymalbhw+GH3D6X4mHuv/AUowOJuieIMpg/FPvu0/SXh4/KpSV54hlfSDYIqaBlMDxdAJsoJi/tKBegNMkLeXyaFf9PYF6U83P8RABdBkhinatN0b6EJB21mmaRkfVam4gNhEgB+SobZVelmLLAsTZU9kEkt2V4zBgUYUbNI32ZXMhMFsOZtPfInbGAzqZPmKGRh39yFnN92uQjxWJXocGFrk43K3d2lviAntP05+xPpBjO4CDXuC8mqyRZf6vg/Cysu3OuxrUGMru0EHePG6DZDcH8yNq7GcBbarA5+w+hupnfHD8SoRtnSuyPdyPsjGb25vikkgeLN8J8d2FxcUH9NBgeBJXhMcXCKCxmIgCcMtJ1NElip6MktTYMl2nkxDmgpPljUG0QL95fVq88jwWhyxTvpASJvUSDbq0AUWNP5xJ4R+4vlWkSkVrtLhn4IaJ4ou6PATmgzyaw+0EG4JeAT2TfP8z6ILv5NNb/4YThwg08fVA="
+        bucket: "pharos-cluster-binaries"
+        region: "eu-west-1"
+        local-dir: upload
+        skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ jobs:
         region: "eu-west-1"
         local-dir: upload
         skip_cleanup: true
+        on:
+          all_branches: true

--- a/build/drone/ubuntu_xenial.sh
+++ b/build/drone/ubuntu_xenial.sh
@@ -8,8 +8,10 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 gem install bundler
-rubyc -o pharos-cluster pharos-cluster
-./pharos-cluster version
+version=${DRONE_TAG#"v"}
+package="pharos-cluster-linux-amd64-${version}"
+rubyc -o $package pharos-cluster
+./$package version
 
 # ship to github
 curl -sL https://github.com/aktau/github-release/releases/download/v0.7.2/linux-amd64-github-release.tar.bz2 | tar -xjO > /usr/local/bin/github-release
@@ -18,5 +20,5 @@ chmod +x /usr/local/bin/github-release
     --user kontena \
     --repo pharos-cluster \
     --tag $DRONE_TAG \
-    --name "pharos-cluster-linux-amd64" \
-    --file ./pharos-cluster
+    --name $package \
+    --file ./$package

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -5,8 +5,10 @@ set -ue
 brew install squashfs
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
-rubyc -o pharos-cluster pharos-cluster
-./pharos-cluster version
+version=${TRAVIS_TAG#"v"}
+package="pharos-cluster-linux-amd64-${version}"
+rubyc -o $package pharos-cluster
+./$package version
 
 # ship to github
 curl -sL https://github.com/aktau/github-release/releases/download/v0.7.2/darwin-amd64-github-release.tar.bz2 | tar -xjO > /usr/local/bin/github-release
@@ -15,5 +17,8 @@ chmod +x /usr/local/bin/github-release
     --user kontena \
     --repo pharos-cluster \
     --tag $TRAVIS_TAG \
-    --name "pharos-cluster-darwin-amd64" \
-    --file ./pharos-cluster
+    --name $package \
+    --file ./$package
+
+mkdir -p upload
+mv $package upload/

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -6,7 +6,7 @@ brew install squashfs
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 version=${TRAVIS_TAG#"v"}
-package="pharos-cluster-linux-amd64-${version}"
+package="pharos-cluster-darwin-amd64-${version}"
 rubyc -o $package pharos-cluster
 ./$package version
 

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.3.0-beta.3"
+  VERSION = "1.3.0-rc.1"
 end


### PR DESCRIPTION
## Changes since v1.3.0-beta.3

- update apiserver cert if SANs changed (#526)
- lock-down crio stream-address to localhost-only for kubelet proxying (#530)
- bumb kubelet proxy version (#527)
- add Gemfile.lock to version control for builds (#531)
- create release as a draft (#528)
- upload binaries to s3