### PR TITLE
Normalize help description casings

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -2,7 +2,7 @@
 
 module Pharos
   class Command < Clamp::Command
-    option '--[no-]color', :flag, "Colorize output", default: $stdout.tty?
+    option '--[no-]color', :flag, "colorize output", default: $stdout.tty?
 
     option ['-v', '--version'], :flag, "print pharos-cluster version" do
       puts "pharos-cluster #{Pharos::VERSION}"

--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -8,9 +8,9 @@ module Pharos
   class RootCommand < Pharos::Command
     banner "pharos-cluster - Kontena Pharos cluster manager"
 
-    subcommand ["build", "up"], "Initialize/upgrade cluster", UpCommand
-    subcommand ["reset"], "Reset cluster", ResetCommand
-    subcommand ["version"], "Show version information", VersionCommand
+    subcommand ["build", "up"], "initialize/upgrade cluster", UpCommand
+    subcommand ["reset"], "reset cluster", ResetCommand
+    subcommand ["version"], "show version information", VersionCommand
 
     def self.run
       super

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -2,7 +2,7 @@
 
 module Pharos
   class UpCommand < Pharos::Command
-    option ['-c', '--config'], 'PATH', 'Path to config file (default: cluster.yml)', attribute_name: :config_yaml do |config_file|
+    option ['-c', '--config'], 'PATH', 'path to config file (default: cluster.yml)', attribute_name: :config_yaml do |config_file|
       begin
         Pharos::YamlFile.new(File.realpath(config_file))
       rescue Errno::ENOENT
@@ -10,7 +10,7 @@ module Pharos
       end
     end
 
-    option '--tf-json', 'PATH', 'Path to terraform output json' do |config_path|
+    option '--tf-json', 'PATH', 'path to terraform output json' do |config_path|
       begin
         File.realpath(config_path)
       rescue Errno::ENOENT
@@ -18,7 +18,7 @@ module Pharos
       end
     end
 
-    option ['-y', '--yes'], :flag, 'Answer automatically yes to prompts'
+    option ['-y', '--yes'], :flag, 'answer automatically yes to prompts'
 
     # @return [Pharos::YamlFile]
     def default_config_yaml


### PR DESCRIPTION
Changes all command and option descriptions to lower case to avoid mixing both. (Clamp's internal ones are lower cased, many of pharos-cluster's were capitalized)

Before:

```
Usage:
    pharos-cluster [OPTIONS] SUBCOMMAND [ARG] ...

  pharos-cluster - Kontena Pharos cluster manager

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    build, up                     Initialize/upgrade cluster
    reset                         Reset cluster
    version                       Show version information

Options:
    -h, --help                    print help
    --[no-]color                  Colorize output (default: true)
    -v, --version                 print pharos-cluster version
    -d, --debug                   enable debug output (default: $DEBUG)
```

After:

```
Usage:
    pharos-cluster [OPTIONS] SUBCOMMAND [ARG] ...

  pharos-cluster - Kontena Pharos cluster manager

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    build, up                     initialize/upgrade cluster
    reset                         reset cluster
    version                       show version information

Options:
    -h, --help                    print help
    --[no-]color                  colorize output (default: true)
    -v, --version                 print pharos-cluster version
    -d, --debug                   enable debug output (default: $DEBUG)
```
