### PR TITLE
Only output config loading headers when stdout is a tty

### DIFF
--- a/lib/pharos/kubeconfig_command.rb
+++ b/lib/pharos/kubeconfig_command.rb
@@ -36,7 +36,7 @@ module Pharos
     end
 
     def ssh
-      @ssh ||= Pharos::SSH::Manager.client_for(master_host)
+      @ssh ||= Pharos::SSH::Manager.new.client_for(master_host)
     end
 
     # @return [Pharos::Config]

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -36,7 +36,6 @@ module Pharos
 
       Pharos::Kube.init_logging!
 
-      puts pastel.green("==> Reading instructions ...")
       config = load_config
 
       # set workdir to the same dir where config was loaded from
@@ -55,6 +54,8 @@ module Pharos
 
     # @return [Pharos::Config]
     def load_config
+      puts(pastel.green("==> Reading instructions ...")) if $stdout.tty?
+
       config_hash = config_yaml.load(ENV.to_h)
 
       load_terraform(tf_json, config_hash) if tf_json
@@ -70,7 +71,7 @@ module Pharos
     # @param config [Hash]
     # @return [Hash]
     def load_terraform(file, config)
-      puts pastel.green("==> Importing configuration from Terraform ...")
+      puts(pastel.green("==> Importing configuration from Terraform ...")) if $stdout.tty?
 
       tf_parser = Pharos::Terraform::JsonParser.new(File.read(file))
       config['hosts'] ||= []


### PR DESCRIPTION
Fixes #542 
Fixes #540 

Changes the config loading headers to appear only when the output is a TTY instead of a pipe or redirect.

This makes something like `pharos-cluster kubeconfig --tf-json xyz > kube.config` to not result in a garbled YAML with `==> Importing configuration from Terraform ...`.

Also fixes the broken `kubeconfig` command.
