### PR TITLE
Upgrade k8s-client version 0.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (1.3.0.beta.3)
+    pharos-cluster (1.3.0.rc.1)
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
       dry-struct (= 0.5.0)
@@ -9,7 +9,7 @@ PATH
       dry-validation (= 0.12.1)
       ed25519 (= 1.2.4)
       fugit (~> 1.1.2)
-      k8s-client (~> 0.3.1)
+      k8s-client (~> 0.3.2)
       net-ssh (= 5.0.1)
       pastel
       rouge (~> 3.1)
@@ -68,7 +68,7 @@ GEM
     hitimes (1.3.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.1)
-    k8s-client (0.3.1)
+    k8s-client (0.3.2)
       deep_merge (~> 1.2.1)
       dry-struct (~> 0.5.0)
       excon (~> 0.62.0)
@@ -86,7 +86,7 @@ GEM
     rainbow (3.0.0)
     rake (10.5.0)
     recursive-open-struct (1.1.0)
-    rouge (3.2.0)
+    rouge (3.2.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
-  spec.add_runtime_dependency "k8s-client", "~> 0.3.1"
+  spec.add_runtime_dependency "k8s-client", "~> 0.3.2"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
See https://github.com/kontena/pharos-cluster/issues/529#issue-350397542 Fixes the error handling but not the race condition itself (needs addon retry)
See https://github.com/kontena/pharos-cluster/pull/536#issuecomment-413484910 Fixes stack prune of `CronJob` resources