### PR TITLE
Improve kubeconfig hint

### DIFF
--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'k8s-client'
+require_relative 'kube/config'
 
 module Pharos
   module Kube

--- a/lib/pharos/kubeconfig_command.rb
+++ b/lib/pharos/kubeconfig_command.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require 'pharos/up_command'
-require 'pharos/ssh/client'
-require 'pharos/ssh/manager'
-require 'pharos/yaml_file'
-require 'pharos/terraform/json_parser'
-require 'pharos/kube/config'
-
 module Pharos
   class KubeconfigCommand < UpCommand
     option ['-n', '--name'], 'NAME', 'overwrite cluster name', attribute_name: :new_name

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -112,8 +112,8 @@ module Pharos
       craft_time = Time.now - start_time
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    To configure kubectl for connecting to the cluster, use:"
-      puts "      #{$PROGRAM_NAME} kubeconfig > $HOME/.pharos/config"
-      puts "      export KUBECONFIG=$KUBECONFIG:$HOME/.pharos/config"
+      puts "      #{$PROGRAM_NAME} kubeconfig > ./kubeconfig"
+      puts "      export KUBECONFIG=./kubeconfig"
 
       manager.disconnect
     end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -112,7 +112,7 @@ module Pharos
       craft_time = Time.now - start_time
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    To configure kubectl for connecting to the cluster, use:"
-      puts "      #{$PROGRAM_NAME} kubeconfig > ./kubeconfig"
+      puts "      #{$PROGRAM_NAME} kubeconfig > kubeconfig"
       puts "      export KUBECONFIG=./kubeconfig"
 
       manager.disconnect

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -110,9 +110,11 @@ module Pharos
       manager.save_config
 
       craft_time = Time.now - start_time
+      defined_opts = ARGV[1..-1].join(" ")
+      defined_opts = defined_opts + " " unless defined_opts.empty?
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    To configure kubectl for connecting to the cluster, use:"
-      puts "      #{$PROGRAM_NAME} kubeconfig > kubeconfig"
+      puts "      #{$PROGRAM_NAME} kubeconfig #{defined_opts}> kubeconfig"
       puts "      export KUBECONFIG=./kubeconfig"
 
       manager.disconnect

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -111,7 +111,7 @@ module Pharos
 
       craft_time = Time.now - start_time
       defined_opts = ARGV[1..-1].join(" ")
-      defined_opts = defined_opts + " " unless defined_opts.empty?
+      defined_opts += " " unless defined_opts.empty?
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    To configure kubectl for connecting to the cluster, use:"
       puts "      #{$PROGRAM_NAME} kubeconfig #{defined_opts}> kubeconfig"


### PR DESCRIPTION
`$HOME/.pharos/config` is confusing if you have multiple clusters. Better to instruct user to save the config to the same path where the command is executed (usually the same folder that has cluster.yml).

Fixes #541 