### PR TITLE
Release v1.3.0-rc.2

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.3.0-rc.1"
+  VERSION = "1.3.0-rc.2"
 end


### PR DESCRIPTION
## Changes since v1.3.0-rc.1

- don't upgrade kubelet, only ensure it's installed (#535)
- add pharos-cluster kubeconfig -command (#502, #544, #543, #546)
- downgrade cri-o to 1.11.0 (#539)
- normalize help description casings (#537)
- upgrade k8s-client version 0.3.2 (#545)
- add telemetry (#536)