### PR TITLE
Fix kube client config

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -125,17 +125,17 @@ module Pharos
       end
     end
 
-    attr_reader :config, :cpu_arch, :cluster_config, :master
+    attr_reader :config, :cpu_arch, :cluster_config, :kube_client
 
     # @param config [Hash,Dry::Validation::Result]
     # @param enabled [Boolean]
-    # @param master [Pharos::Configuration::Host,NilClass]
+    # @param kube_client [K8s::Client]
     # @param cpu_arch [String, NilClass]
     # @param cluster_config [Pharos::Config, NilClass]
-    def initialize(config = nil, enabled: true, master:, cpu_arch:, cluster_config:)
+    def initialize(config = nil, enabled: true, kube_client:, cpu_arch:, cluster_config:)
       @config = self.class.config? ? self.class.config.new(config) : RecursiveOpenStruct.new(Hash(config))
       @enabled = enabled
-      @master = master
+      @kube_client = kube_client
       @cpu_arch = cpu_arch
       @cluster_config = cluster_config
     end
@@ -178,11 +178,6 @@ module Pharos
       else
         delete_resources
       end
-    end
-
-    # @return [K8s::Client]
-    def kube_client
-      Pharos::Kube.client(master.api_address)
     end
 
     # @param vars [Hash]

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -58,9 +58,14 @@ module Pharos
       end
     end
 
+    # @return [K8s::Client]
+    def kube_client
+      @kube_client ||= Pharos::Kube.client(@config.master_host, @cluster_context['kubeconfig'])
+    end
+
     def options
       {
-        master: @config.master_host,
+        kube_client: kube_client,
         cpu_arch: @config.master_host.cpu_arch, # needs to be resolved *after* Phases::ValidateHost runs
         cluster_config: @config
       }

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -93,6 +93,7 @@ module Pharos
       apply_phase(Phases::ConfigureClient, [master_hosts.first], ssh: true, master: master_hosts.first, parallel: false)
 
       # master is now configured and can be used
+      apply_phase(Phases::LoadClusterConfiguration, [master_hosts.first], master: master_hosts.first)
       apply_phase(Phases::ConfigureDNS, [master_hosts.first], master: master_hosts.first)
 
       apply_phase(Phases::ConfigureWeave, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'weave'

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -85,7 +85,7 @@ module Pharos
 
       apply_phase(Phases::ConfigureSecretsEncryption, master_hosts, ssh: true, parallel: false)
       apply_phase(Phases::SetupMaster, master_hosts, ssh: true, parallel: true)
-      apply_phase(Phases::UpgradeMaster, master_hosts, ssh: true, master: master_hosts.first, parallel: false) # XXX: uses master kubeconfig before ConfigureClient runs
+      apply_phase(Phases::UpgradeMaster, master_hosts, ssh: true, master: master_hosts.first, parallel: false) # requires optional early ConfigureClient
 
       apply_phase(Phases::MigrateWorker, config.worker_hosts, ssh: true, parallel: true, master: master_hosts.first)
       apply_phase(Phases::ConfigureKubelet, config.hosts, ssh: true, parallel: true)

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -71,6 +71,7 @@ module Pharos
 
       apply_phase(Phases::MigrateMaster, master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
+      apply_phase(Phases::ConfigureClient, [master_hosts.first], ssh: true, master: master_hosts.first, parallel: false, optional: true)
 
       unless @config.etcd&.endpoints
         # we need to use sorted etcd hosts because phases expects that first one has

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -40,7 +40,7 @@ module Pharos
     end
 
     # @param host [String]
-    # @param config [Hash] optionally pass in kubeconfig as hash
+    # @param config [Hash]
     # @return [K8s::Client]
     def self.client(host, config)
       @kube_client ||= {}

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -42,11 +42,9 @@ module Pharos
     # @param host [String]
     # @param config [Hash] optionally pass in kubeconfig as hash
     # @return [K8s::Client]
-    def self.client(host, config = nil)
+    def self.client(host, config)
       @kube_client ||= {}
-      @kube_client[host] ||= K8s::Client.config(
-        config.is_a?(Hash) ? K8s::Config.new(config) : host_config(host)
-      )
+      @kube_client[host] ||= K8s::Client.config(K8s::Config.new(config))
     end
 
     # @param name [String]
@@ -54,24 +52,6 @@ module Pharos
     # @param vars [Hash]
     def self.stack(name, path, **vars)
       Pharos::Kube::Stack.load(name, path, **vars)
-    end
-
-    # @param host [String]
-    # @return [K8s::Config]
-    def self.host_config(host)
-      K8s::Config.load_file(host_config_path(host))
-    end
-
-    # @param host [String]
-    # @return [String]
-    def self.host_config_path(host)
-      File.join(Dir.home, ".pharos/#{host}")
-    end
-
-    # @param host [String]
-    # @return [Boolean]
-    def self.config_exists?(host)
-      File.exist?(host_config_path(host))
     end
   end
 end

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -79,6 +79,7 @@ module Pharos
     # @return [K8s::Client]
     def kube_client
       fail "Phase #{self.class.name} does not have kube @master" unless @master
+      fail "Phase #{self.class.name} does not have kubeconfig cluster_context" unless cluster_context['kubeconfig']
 
       @kube_client ||= Pharos::Kube.client(@master.api_address, cluster_context['kubeconfig'])
     end

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -10,11 +10,6 @@ module Pharos
       def call
         fetch_kubeconfig
         client_prefetch
-        config_map = previous_config_map
-        return unless config_map
-
-        cluster_context['previous-config-map'] = config_map
-        cluster_context['previous-config'] = build_config(config_map)
       end
 
       def fetch_kubeconfig
@@ -28,22 +23,6 @@ module Pharos
       # prefetch client resources to warm up caches
       def client_prefetch
         kube_client.apis(prefetch_resources: true)
-      end
-
-      # @param configmap [K8s::Resource]
-      # @return [Pharos::Config]
-      def build_config(configmap)
-        cluster_config = Pharos::YamlFile.new(StringIO.new(configmap.data['cluster.yml']), override_filename: "#{@host}:cluster.yml").load
-        cluster_config['hosts'] ||= []
-        data = Pharos::ConfigSchema.build.call(cluster_config)
-        Pharos::Config.new(data)
-      end
-
-      # @return [K8s::Resource, nil]
-      def previous_config_map
-        kube_client.api('v1').resource('configmaps', namespace: 'kube-system').get('pharos-config')
-      rescue K8s::Error::NotFound
-        nil
       end
     end
   end

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -8,16 +8,24 @@ module Pharos
       REMOTE_FILE = "/etc/kubernetes/admin.conf"
 
       def call
-        fetch_kubeconfig
+        cluster_context['kubeconfig'] = fetch_kubeconfig
+
         client_prefetch
       end
 
+      # @return [String]
+      def read_kubeconfig
+        @ssh.file(REMOTE_FILE).read
+      end
+
+      # @return [Hash]
       def fetch_kubeconfig
         logger.info { "Fetching kubectl config ..." }
-        config = Pharos::Kube::Config.new(@ssh.file(REMOTE_FILE).read)
+        config = Pharos::Kube::Config.new(read_kubeconfig)
         config.update_server_address(@host.api_address)
-        logger.debug "New config: #{config}"
-        cluster_context['kubeconfig'] = config.to_h
+
+        logger.debug { "New config: #{config}" }
+        config.to_h
       end
 
       # prefetch client resources to warm up caches

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -15,15 +15,15 @@ module Pharos
       end
 
       def call
-        return if @optional && !have_kubeconfig?
+        return if @optional && !kubeconfig?
 
-        cluster_context['kubeconfig'] = fetch_kubeconfig
+        cluster_context['kubeconfig'] = kubeconfig
 
         client_prefetch unless @optional
       end
 
       # @return [String]
-      def have_kubeconfig?
+      def kubeconfig?
         @ssh.file(REMOTE_FILE).exist?
       end
 
@@ -33,7 +33,7 @@ module Pharos
       end
 
       # @return [Hash]
-      def fetch_kubeconfig
+      def kubeconfig
         logger.info { "Fetching kubectl config ..." }
         config = Pharos::Kube::Config.new(read_kubeconfig)
         config.update_server_address(@host.api_address)

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -7,10 +7,24 @@ module Pharos
 
       REMOTE_FILE = "/etc/kubernetes/admin.conf"
 
+      # @param optional [Boolean] skip if kubeconfig does not exist instead of failing
+      def initialize(host, optional: false, **options)
+        super(host, **options)
+
+        @optional = optional
+      end
+
       def call
+        return if @optional && !have_kubeconfig?
+
         cluster_context['kubeconfig'] = fetch_kubeconfig
 
-        client_prefetch
+        client_prefetch unless @optional
+      end
+
+      # @return [String]
+      def have_kubeconfig?
+        @ssh.file(REMOTE_FILE).exist?
       end
 
       # @return [String]

--- a/lib/pharos/phases/load_cluster_configuration.rb
+++ b/lib/pharos/phases/load_cluster_configuration.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Phases
+    class LoadClusterConfiguration < Pharos::Phase
+      title "Load cluster configuration"
+
+      def call
+        config_map = previous_config_map
+
+        return unless config_map
+
+        logger.info { "Loading previous cluster configuration from configmap ..." }
+
+        cluster_context['previous-config-map'] = config_map
+        cluster_context['previous-config'] = build_config(config_map)
+      end
+
+      # @param configmap [K8s::Resource]
+      # @return [Pharos::Config]
+      def build_config(configmap)
+        cluster_config = Pharos::YamlFile.new(StringIO.new(configmap.data['cluster.yml']), override_filename: "#{@host}:cluster.yml").load
+        cluster_config['hosts'] ||= []
+        data = Pharos::ConfigSchema.build.call(cluster_config)
+        Pharos::Config.new(data)
+      end
+
+      # @return [K8s::Resource, nil]
+      def previous_config_map
+        kube_client.api('v1').resource('configmaps', namespace: 'kube-system').get('pharos-config')
+      rescue K8s::Error::NotFound
+        nil
+      end
+
+    end
+  end
+end

--- a/lib/pharos/phases/load_cluster_configuration.rb
+++ b/lib/pharos/phases/load_cluster_configuration.rb
@@ -31,7 +31,6 @@ module Pharos
       rescue K8s::Error::NotFound
         nil
       end
-
     end
   end
 end

--- a/spec/pharos/addon_spec.rb
+++ b/spec/pharos/addon_spec.rb
@@ -19,10 +19,10 @@ describe Pharos::Addon do
   end
 
   let(:cpu_arch) { double(:cpu_arch) }
-  let(:master) { double(:host, api_address: '1.1.1.1') }
+  let(:kube_client) { instance_double(K8s::Client) }
   let(:config) { {foo: 'bar'} }
 
-  subject { test_addon.new(config, master: master, cpu_arch: cpu_arch, cluster_config: nil) }
+  subject { test_addon.new(config, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: nil) }
 
   describe ".addon_name" do
     it "returns configured name" do
@@ -69,15 +69,13 @@ describe Pharos::Addon do
           config.justatest
           apply_resources
         }
-      end.new(config, master: master, cpu_arch: cpu_arch, cluster_config: nil)
+      end.new(config, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: nil)
     end
 
     let(:kube_stack) { double(:kube_stack) }
-    let(:kube_client) { double(:kube_client) }
 
     before do
       allow(subject).to receive(:kube_stack).and_return(kube_stack)
-      allow(subject).to receive(:kube_client).and_return(kube_client)
     end
 
     it 'runs install block on apply' do
@@ -96,24 +94,14 @@ describe Pharos::Addon do
 
   describe "#apply_resources" do
     let(:kube_stack) { double(:kube_stack) }
-    let(:kube_client) { double(:kube_client) }
 
     before do
       allow(subject).to receive(:kube_stack).and_return(kube_stack)
-      allow(subject).to receive(:kube_client).and_return(kube_client)
     end
 
     it "applies addon resources" do
       expect(kube_stack).to receive(:apply)
       subject.apply_resources
-    end
-  end
-
-  describe '#kube_client' do
-    it 'returns kube client' do
-      client = double(:client)
-      allow(Pharos::Kube).to receive(:client).with(master.api_address).and_return(client)
-      expect(subject.kube_client).to eq(client)
     end
   end
 end

--- a/spec/pharos/addons/host_upgrades_spec.rb
+++ b/spec/pharos/addons/host_upgrades_spec.rb
@@ -6,11 +6,11 @@ describe Pharos::Addons::HostUpgrades do
     hosts: [ {role: 'master', address: '192.0.2.1'} ],
   ) }
   let(:config) { { } }
+  let(:kube_client) { instance_double(K8s::Client) }
   let(:cpu_arch) { double(:cpu_arch ) }
-  let(:master) { double(:host, address: '192.0.2.1') }
 
   subject do
-    described_class.new({enabled: true}.merge(config), enabled: true, master: master, cpu_arch: cpu_arch, cluster_config: cluster_config)
+    described_class.new({enabled: true}.merge(config), enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config)
   end
 
   describe "#validate" do

--- a/spec/pharos/addons/ingress_nginx_spec.rb
+++ b/spec/pharos/addons/ingress_nginx_spec.rb
@@ -8,11 +8,11 @@ describe Pharos::Addons::IngressNginx do
     etcd: {}
   ) }
   let(:config) { { foo: 'bar'} }
+  let(:kube_client) { instance_double(K8s::Client) }
   let(:cpu_arch) { double(:cpu_arch ) }
-  let(:master) { double(:host, address: '1.1.1.1') }
 
   subject do
-    described_class.new(config, enabled: true, master: master, cpu_arch: cpu_arch, cluster_config: cluster_config)
+    described_class.new(config, enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config)
   end
 
   describe "#validate" do


### PR DESCRIPTION
Fixes #534 by calling `Phases::ConfigureClient` twice, allowing an optional kube config used for upgrades

* Refactoring to fix the usage of `Pharos::Kube.client` for both phases and addons, removing the broken fallback to `~/.pharos/*`
* Split `LoadClusterConfiguration` out of `ConfigureClient`
* Run `ConfigureClient` twice, with an optional early call for upgrades
