### PR TITLE
Basename instead of full path in post-install command example

### DIFF
--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -111,7 +111,7 @@ module Pharos
       craft_time = Time.now - start_time
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       puts "    To configure kubectl for connecting to the cluster, use:"
-      puts "      #{$PROGRAM_NAME} kubeconfig > $HOME/.pharos/config"
+      puts "      #{File.basename($PROGRAM_NAME)} kubeconfig > $HOME/.pharos/config"
       puts "      export KUBECONFIG=$KUBECONFIG:$HOME/.pharos/config"
 
       manager.disconnect


### PR DESCRIPTION
Fixes #551 

Changes:

```
==> Cluster has been crafted! (took 36 seconds)
    To configure kubectl for connecting to the cluster, use:
      /usr/local/Cellar/rbenv/1.1.1/versions/2.5.0/lib/ruby/gems/2.5.0/bin/pharos-cluster kubeconfig -c cluster.yml > kubeconfig
      export KUBECONFIG=./kubeconfig
```

To:

```
==> Cluster has been crafted! (took 27 seconds)
    To configure kubectl for connecting to the cluster, use:
      pharos-cluster kubeconfig > $HOME/.pharos/config
      export KUBECONFIG=$KUBECONFIG:$HOME/.pharos/config
```
