### PR TITLE
Normalize internal loading of files to avoid loading twice

### DIFF
--- a/bin/pharos-cluster
+++ b/bin/pharos-cluster
@@ -8,5 +8,5 @@ $LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
 
 STDOUT.sync = true
 
-require 'pharos_cluster'
+require File.join(lib_path, 'pharos_cluster')
 Pharos::RootCommand.run

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -3,8 +3,8 @@
 require 'dry-validation'
 require 'fugit'
 
-require_relative 'addons/struct'
-require_relative 'logging'
+require 'pharos/addons/struct'
+require 'pharos/logging'
 
 module Pharos
   # @param name [String]

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'addon'
-require_relative 'logging'
+require 'pharos/addon'
+require 'pharos/logging'
 
 module Pharos
   class AddonManager
@@ -19,7 +19,7 @@ module Pharos
     # @return [Array<Class<Pharos::Addon>>]
     def self.load_addons(*dirs)
       dirs.each do |dir|
-        Dir.glob(File.join(dir, '**', 'addon.rb')).each { |f| require(f) }
+        Dir.glob(File.join(dir, '**', 'addon.rb')).each { |f| require(File.expand_path(f)) }
       end
 
       addons

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -19,7 +19,7 @@ module Pharos
     # @return [Array<Class<Pharos::Addon>>]
     def self.load_addons(*dirs)
       dirs.each do |dir|
-        Dir.glob(File.join(dir, '**', 'addon.rb')).each { |f| require(File.expand_path(f)) }
+        Dir.glob(File.join(dir, '**', 'addon.rb')).each { |f| require(f) }
       end
 
       addons

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 module Pharos
   class ClusterManager
     include Pharos::Logging
@@ -35,11 +37,14 @@ module Pharos
 
     # load phases/addons
     def load
-      Pharos::PhaseManager.load_phases(__dir__ + '/phases/')
+      Pharos::PhaseManager.load_phases(Pharos::RootPath.join('pharos', 'phases').to_s)
       addon_dirs = [
-        File.join(__dir__, '..', '..', 'addons'),
+        Pharos::RootPath.join('addons'),
         File.join(Dir.pwd, 'addons')
       ] + @config.addon_paths.map { |d| File.join(Dir.pwd, d) }
+      addon_dirs.keep_if { |dir| File.exist?(dir) }
+      addon_dirs = addon_dirs.map { |dir| Pathname.new(dir).realpath }.uniq
+
       Pharos::AddonManager.load_addons(*addon_dirs)
       Pharos::HostConfigManager.load_configs(@config)
     end

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require_relative 'types'
-require_relative 'configuration/host'
-require_relative 'configuration/api'
-require_relative 'configuration/network'
-require_relative 'configuration/etcd'
-require_relative 'configuration/authentication'
-require_relative 'configuration/cloud'
-require_relative 'configuration/audit'
-require_relative 'configuration/kube_proxy'
-require_relative 'configuration/kubelet'
-require_relative 'configuration/telemetry'
+require 'pharos/types'
+require 'pharos/configuration/host'
+require 'pharos/configuration/api'
+require 'pharos/configuration/network'
+require 'pharos/configuration/etcd'
+require 'pharos/configuration/authentication'
+require 'pharos/configuration/cloud'
+require 'pharos/configuration/audit'
+require 'pharos/configuration/kube_proxy'
+require 'pharos/configuration/kubelet'
+require 'pharos/configuration/telemetry'
 
 module Pharos
   class Config < Pharos::Configuration::Struct

--- a/lib/pharos/configuration/authentication.rb
+++ b/lib/pharos/configuration/authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'token_webhook'
+require 'pharos/configuration/token_webhook'
 
 module Pharos
   module Configuration

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'os_release'
-require_relative 'cpu_arch'
+require 'pharos/configuration/os_release'
+require 'pharos/configuration/cpu_arch'
 
 module Pharos
   module Configuration

--- a/lib/pharos/host/el7/centos7.rb
+++ b/lib/pharos/host/el7/centos7.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'el7'
+require 'pharos/host/el7/el7'
 
 module Pharos
   module Host

--- a/lib/pharos/host/el7/rhel7.rb
+++ b/lib/pharos/host/el7/rhel7.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'el7'
+require 'pharos/host/el7/el7'
 
 module Pharos
   module Host

--- a/lib/pharos/host/ubuntu/ubuntu_bionic.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_bionic.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'ubuntu'
+require 'pharos/host/ubuntu/ubuntu'
 
 module Pharos
   module Host

--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'ubuntu'
+require 'pharos/host/ubuntu/ubuntu'
 
 module Pharos
   module Host

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'k8s-client'
-require_relative 'kube/config'
+require 'pharos/kube/config'
 
 module Pharos
   module Kube

--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'kube'
+require 'pharos/kube'
 
 module Pharos
   class PhaseManager

--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'up_command'
-require_relative 'reset_command'
-require_relative 'version_command'
-require_relative 'kubeconfig_command'
+require 'pharos/up_command'
+require 'pharos/reset_command'
+require 'pharos/version_command'
+require 'pharos/kubeconfig_command'
 
 module Pharos
   class RootCommand < Pharos::Command

--- a/lib/pharos/ssh/tempfile.rb
+++ b/lib/pharos/ssh/tempfile.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'securerandom'
-require_relative 'remote_file'
+require 'pharos/ssh/remote_file'
 
 module Pharos
   module SSH

--- a/lib/pharos/yaml_file.rb
+++ b/lib/pharos/yaml_file.rb
@@ -2,7 +2,7 @@
 
 require 'yaml'
 require 'erb'
-require_relative 'yaml_file/namespace'
+require 'pharos/yaml_file/namespace'
 
 module Pharos
   # Reads YAML files and optionally performs ERB evaluation

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -6,6 +6,7 @@ require 'pharos/version'
 require 'pharos/command'
 require 'pharos/error'
 require 'pharos/root_command'
+require 'pathname'
 
 module Pharos
   CRIO_VERSION = '1.11.2'
@@ -14,4 +15,6 @@ module Pharos
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.2.18' }
   KUBELET_PROXY_VERSION = '0.3.7'
   COREDNS_VERSION = '1.1.3'
+
+  RootPath = Pathname.new(__dir__).realpath
 end

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require "clamp"
-require_relative "pharos/autoload"
-require_relative "pharos/version"
-require_relative "pharos/command"
-require_relative "pharos/error"
-require_relative "pharos/root_command"
+require 'clamp'
+require 'pharos/autoload'
+require 'pharos/version'
+require 'pharos/command'
+require 'pharos/error'
+require 'pharos/root_command'
 
 module Pharos
   CRIO_VERSION = '1.11.2'


### PR DESCRIPTION
Fixes #533 

- Changes all `require_relative`s to `require`
- Adds a `Pharos::RootPath` and uses it to require phases and internal addons
- `uniq`'s the list of addon directories in `load_addons`
- Changes `bin/pharos-cluster` to require the `lib/pharos_cluster` from `lib_path`

Option B would be to change all `require`s to `require_relative` and change `lib/pharos/autoload.rb` to use full paths.

Option C would be to remove all internal requires and make everything autoload either manually or dynamically in `autoload.rb`.
