### PR TITLE
Release v1.3.0-rc.3

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.3.0-rc.2"
+  VERSION = "1.3.0-rc.3"
 end


### PR DESCRIPTION
## Changelog since v1.3.0-rc.2

- cri-o 1.11.2 (#550)
- fix kube client config (#548)
- don't show the full path to pharos-cluster in post-install command example (#552)