### PR TITLE
Added optional secret name for private registry

### DIFF
--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -15,6 +15,7 @@ Pharos.addon 'ingress-nginx' do
     optional(:node_selector).filled(:hash?)
     optional(:default_backend).schema {
       optional(:image).filled(:str?)
+      optional(:pull_secret_name).filled(:str?)
     }
   }
 
@@ -48,4 +49,5 @@ Pharos.addon 'ingress-nginx' do
     return 2 if r < 2
     r
   end
+
 end

--- a/addons/ingress-nginx/resources/default-backend.yml.erb
+++ b/addons/ingress-nginx/resources/default-backend.yml.erb
@@ -50,3 +50,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+      <% if config.default_backend[:pull_secret_name] %>
+      imagePullSecrets:
+        - name: <%= config.default_backend[:pull_secret_name] %>
+      <% end %>

--- a/cluster.example.yml
+++ b/cluster.example.yml
@@ -49,6 +49,8 @@ addons:
     configmap:
       # see all supported options: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/configmap.md
       load-balance: least_conn
+      # optional pull secret name for private registry: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pull_secret_name: foo_bar
   cert-manager:
     enabled: true
     issuer:


### PR DESCRIPTION
When someone is using private registry (eg, gitlab) we need to create secret so we can execute pull on the specific ingres-nginx-backend image.