### PR TITLE
Do not allow addons to define consts

### DIFF
--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -27,16 +27,13 @@ Pharos.addon 'ingress-nginx' do
     )
   }
 
-  DEFAULT_BACKEND_ARM64_IMAGE = 'docker.io/kontena/pharos-default-backend-arm64:0.0.2'
-  DEFAULT_BACKEND_IMAGE = 'docker.io/kontena/pharos-default-backend:0.0.2'
-
   def image_name
     return config.default_backend[:image] if config.default_backend&.dig(:image)
 
-    if cpu_arch.name == 'arm64'
-      DEFAULT_BACKEND_ARM64_IMAGE
+    if cpu_arch.name == 'amd64'
+      'docker.io/kontena/pharos-default-backend:0.0.2'
     else
-      DEFAULT_BACKEND_IMAGE
+      "docker.io/kontena/pharos-default-backend-#{cpu_arch.name}:0.0.2"
     end
   end
 

--- a/addons/openebs/addon.rb
+++ b/addons/openebs/addon.rb
@@ -4,20 +4,14 @@ Pharos.addon 'openebs' do
   version '0.5.3'
   license 'Apache License 2.0'
 
-  DEFAULT_CLASS_OPTS = {
-    default_class: false,
-    capacity: '5G'
-  }.freeze
-
-  DEFAULT_STORAGE_PATH = '/var/openebs'
-
-  DEFAULT_POOL_OPTS = {
-    path: DEFAULT_STORAGE_PATH
-  }.freeze
-
   config {
-    attribute :default_storage_class, Pharos::Types::Hash.default(DEFAULT_CLASS_OPTS)
-    attribute :default_storage_pool, Pharos::Types::Hash.default(DEFAULT_POOL_OPTS)
+    attribute :default_storage_class, Pharos::Types::Hash.default(
+      default_class: false,
+      capacity: '5G'
+    )
+    attribute :default_storage_pool, Pharos::Types::Hash.default(
+      path: '/var/openebs',
+    )
   }
 
   config_schema {

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -10,7 +10,16 @@ module Pharos
   # @param name [String]
   # @return [Pharos::Addon]
   def self.addon(name, &block)
-    klass = Class.new(Pharos::Addon, &block).tap do |addon|
+    klass = Class.new(Pharos::Addon)
+
+    pre_consts = Object.constants
+    klass.class_eval(&block)
+    post_consts = Object.constants
+    new_consts = (post_consts - pre_consts)
+
+    fail "Addon #{name} cannot define any constants: #{new_consts.join(' ')}" unless new_consts.empty?
+
+    klass.tap do |addon|
       addon.addon_location = File.dirname(block.source_location.first)
       addon.addon_name = name
     end

--- a/spec/pharos/addons/ingress_nginx_spec.rb
+++ b/spec/pharos/addons/ingress_nginx_spec.rb
@@ -44,7 +44,7 @@ describe Pharos::Addons::IngressNginx do
       let(:cpu_arch) { double(:cpu_arch, name: 'arm64' ) }
 
       it "returns default for arm64" do
-        expect(subject.image_name).to eq(Pharos::Addons::IngressNginx::DEFAULT_BACKEND_ARM64_IMAGE)
+        expect(subject.image_name).to match %r(/pharos-default-backend-arm64:)
       end
     end
 
@@ -52,7 +52,7 @@ describe Pharos::Addons::IngressNginx do
       let(:cpu_arch) { double(:cpu_arch, name: 'amd64' ) }
 
       it "returns default" do
-        expect(subject.image_name).to eq(Pharos::Addons::IngressNginx::DEFAULT_BACKEND_IMAGE)
+        expect(subject.image_name).to match %r(/pharos-default-backend:)
       end
     end
   end


### PR DESCRIPTION
Fixes #562
Alternative to #563

Only two of the core addons use consts in a way that is trivial to refactor.

Hack in validation to detect if any addon defines global consts when loading: