### PR TITLE
Use the real program name in help and version output

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -4,8 +4,8 @@ module Pharos
   class Command < Clamp::Command
     option '--[no-]color', :flag, "colorize output", default: $stdout.tty?
 
-    option ['-v', '--version'], :flag, "print pharos-cluster version" do
-      puts "pharos-cluster #{Pharos::VERSION}"
+    option ['-v', '--version'], :flag, "print #{File.basename($PROGRAM_NAME)} version" do
+      puts "#{File.basename($PROGRAM_NAME)} #{Pharos::VERSION}"
       exit 0
     end
 

--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -7,7 +7,7 @@ require_relative 'kubeconfig_command'
 
 module Pharos
   class RootCommand < Pharos::Command
-    banner "pharos-cluster - Kontena Pharos cluster manager"
+    banner "#{File.basename($PROGRAM_NAME)} - Kontena Pharos cluster manager"
 
     subcommand ["build", "up"], "initialize/upgrade cluster", UpCommand
     subcommand "kubeconfig", "fetch admin kubeconfig file", KubeconfigCommand

--- a/lib/pharos/version_command.rb
+++ b/lib/pharos/version_command.rb
@@ -4,7 +4,7 @@ module Pharos
   class VersionCommand < Pharos::Command
     def execute
       puts "Kontena Pharos:"
-      puts "  - pharos-cluster version #{Pharos::VERSION}"
+      puts "  - #{File.basename($PROGRAM_NAME)} version #{Pharos::VERSION}"
       ClusterManager.new(Pharos::Config.new({}), pastel: false).load
 
       phases.each do |os, phases|


### PR DESCRIPTION
Fixes #565 

Changes occurences of "pharos-cluster" in help and version outputs to reflect the current program name.


