### PR TITLE
Deprecate user addons directory in favor of pharos-addons

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -45,9 +45,10 @@ module Pharos
       )
       addon_dirs = [
         File.join(__dir__, '..', '..', 'addons'),
-        File.join(Dir.pwd, 'addons'),
+        File.join(Dir.pwd, 'pharos-addons'),
         File.join(__dir__, '..', '..', 'non-oss', 'addons')
       ] + @config.addon_paths.map { |d| File.join(Dir.pwd, d) }
+
       addon_dirs.keep_if { |dir| File.exist?(dir) }
       addon_dirs = addon_dirs.map { |dir| Pathname.new(dir).realpath.to_s }.uniq
 


### PR DESCRIPTION
(base is pr #553)

- Adds a deprecation warning if `addons/` directory is added to addon loadpaths.
- Adds `pharos-addons/` to addon loadpaths.
