### PR TITLE
Add missing kubeadm-flags.env on upgrade

### DIFF
--- a/lib/pharos/phases/migrate_worker.rb
+++ b/lib/pharos/phases/migrate_worker.rb
@@ -32,13 +32,17 @@ module Pharos
       end
 
       def migrate_1_3
-        logger.info { 'Upgrade kubelet config for 1.10' }
+        logger.info { 'Upgrade kubelet config' }
 
         # use the new version of kubeadm to write out /var/lib/kubelet/config.yaml for new kubelet version to be installed
         # the kube master must be running, which is the case for upgrades
         host_configurer.upgrade_kubeadm(Pharos::KUBEADM_VERSION)
 
         @ssh.exec!("sudo /usr/local/bin/pharos-kubeadm-#{Pharos::KUBEADM_VERSION} upgrade node config --kubelet-version=v#{Pharos::KUBE_VERSION}")
+        kubeadm_flags = @ssh.file("/var/lib/kubelet/kubeadm-flags.env")
+        unless kubeadm_flags.exist?
+          kubeadm_flags.write('KUBELET_KUBEADM_ARGS=--cni-bin-dir=/opt/cni/bin --cni-conf-dir=/etc/cni/net.d --network-plugin=cni')
+        end
       end
     end
   end

--- a/lib/pharos/phases/migrate_worker.rb
+++ b/lib/pharos/phases/migrate_worker.rb
@@ -39,10 +39,11 @@ module Pharos
         host_configurer.upgrade_kubeadm(Pharos::KUBEADM_VERSION)
 
         @ssh.exec!("sudo /usr/local/bin/pharos-kubeadm-#{Pharos::KUBEADM_VERSION} upgrade node config --kubelet-version=v#{Pharos::KUBE_VERSION}")
+
         kubeadm_flags = @ssh.file("/var/lib/kubelet/kubeadm-flags.env")
-        unless kubeadm_flags.exist?
-          kubeadm_flags.write('KUBELET_KUBEADM_ARGS=--cni-bin-dir=/opt/cni/bin --cni-conf-dir=/etc/cni/net.d --network-plugin=cni')
-        end
+        return if kubeadm_flags.exist?
+
+        kubeadm_flags.write('KUBELET_KUBEADM_ARGS=--cni-bin-dir=/opt/cni/bin --cni-conf-dir=/etc/cni/net.d --network-plugin=cni')
       end
     end
   end


### PR DESCRIPTION
Fixes #577 

Tested upgrade:

- [x] ubuntu 16.04
- [x] ubuntu 18.04
- [x] centos 7