### PR TITLE
Release v1.3.0

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.3.0-rc.4"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
## Changes since v1.2.3

- upgrade to kubernetes 1.11.1 (#473)
- ingress-nginx 0.17.1 (#514)
- cri-o 1.11.2 (#550, #539)
- update weave net to 2.4.0 (#491)
- new K8s::Client (#475, #516, #524, #545)
- retry phases (with exp backoff) on errors (#512)
- add pharos-cluster kubeconfig -command (#502, #544, #543, #546)
- lock-down crio stream-address to localhost-only for kubelet proxying (#530)
- update apiserver cert if SANs changed (#526)
- change lscpu to uname -m (#505)
- validate host routes (#455, #504)
- upgrade dry-struct, dry-validation (#474)
- fix utils.sh for dash (#486)
- remove default ssh key path (should come from net-ssh) (#485)
- fixup reported version of cri-o in register_component for bionic (#484)
- use hostname for logging output (#304)
- ubuntu reset.sh DEBIAN_FRONTEND=noninteractive (#510)
- force LC_ALL=C.UTF-8 locale for all SSH commands (#511)
- load libraries in phase manager to fix version command (#522)
- bumb kubelet proxy version (#527)
- add Gemfile.lock to version control for builds (#531)
- create release as a draft (#528)
- upload binaries to s3
- don't upgrade kubelet, only ensure it's installed (#535)
- normalize help description casings (#537)
- add telemetry (#536, #554)
- fix kube client config (#548)
- don't show the full path to pharos-cluster in post-install command example (#552)
- fix apiserver & controller-manager cloud-provider args (#572)
- patch coredns image only on arm64 (#561)