### PR TITLE
Add "pharos ssh" command to launch ssh into cluster hosts

### DIFF
--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -4,6 +4,7 @@ require_relative 'up_command'
 require_relative 'reset_command'
 require_relative 'version_command'
 require_relative 'kubeconfig_command'
+require_relative 'ssh_command'
 
 module Pharos
   class RootCommand < Pharos::Command
@@ -12,6 +13,7 @@ module Pharos
     subcommand ["build", "up"], "initialize/upgrade cluster", UpCommand
     subcommand "kubeconfig", "fetch admin kubeconfig file", KubeconfigCommand
     subcommand ["reset"], "reset cluster", ResetCommand
+    subcommand "ssh", "start an ssh session to a server in a pharos cluster", SSHCommand
     subcommand ["version"], "show version information", VersionCommand
 
     def self.run

--- a/lib/pharos/ssh_command.rb
+++ b/lib/pharos/ssh_command.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Pharos
+  class SSHCommand < UpCommand
+    usage "[OPTIONS] -- [COMMANDS] ..."
+    parameter "[COMMANDS] ...", "Run command on host"
+
+    banner "Opens an SSH session to a host in the Kontena Pharos cluster. If no filtering parameters are given, the first host is used."
+
+    option ['-r', '--role'], 'ROLE', 'select a server by role'
+    option ['-l', '--label'], 'LABEL=VALUE', 'select a server by label, can be specified multiple times', multivalued: true do |pair|
+      Hash[*[:key, :value].zip(pair.split('=', 2))]
+    end
+    option ['-a', '--address'], 'ADDRESS', 'select a server by public address'
+    option ['-p', '--private-address'], 'ADDRESS', 'select a server by private address'
+
+    option ['-P', '--use-private'], :flag, 'connect to the private address'
+
+    def host
+      @host ||= load_config.hosts.find do |host|
+        next if role && host.role != role
+        next if address && host.address != address
+        next if private_address && host.private_address != private_address
+
+        unless label_list.empty?
+          next unless label_list.all? { |l| host.labels[l[:key]] == l[:value] }
+        end
+
+        true
+      end
+    end
+
+    def execute
+      if host
+        target = "#{host.user}@#{use_private? ? host.private_address : host.address}"
+        puts pastel.green("==> Opening a session to #{target} ..") unless !$stdout.tty?
+        cmd = ['ssh', "-i", host.ssh_key_path, target]
+
+        unless commands_list.empty?
+          cmd << '--'
+          cmd.concat(commands_list)
+        end
+
+        puts "Executing #{cmd.inspect}" if debug?
+
+        exec(*cmd)
+      else
+        signal_usage_error 'no host matched in configuration'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds "pharos ssh" subcommand that can be used to launch a ssh session that connects to a host in the cluster configuration.

There are filtering options to select hosts based on roles, labels or their addresses.

```
Usage:
    pharos-cluster ssh [OPTIONS] -- [COMMANDS] ...

  Opens an SSH session to a host in the Kontena Pharos cluster. If no filtering parameters are given, the first host is used.

Parameters:
    [COMMANDS] ...                Run command on host

Options:
    -r, --role ROLE               select a server by role
    -l, --label LABEL=VALUE       select a server by label, can be specified multiple times
    -a, --address ADDRESS         select a server by public address
    -p, --private-address ADDRESS select a server by private address
    -P, --use-private             connect to the private address
    -h, --help                    print help
    -c, --config PATH             path to config file (default: cluster.yml)
    --tf-json PATH                path to terraform output json
    -y, --yes                     answer automatically yes to prompts
    --[no-]color                  colorize output (default: true)
    -v, --version                 print pharos-cluster version
    -d, --debug                   enable debug output (default: $DEBUG)
```

```
$ bundle exec bin/pharos-cluster ssh -r master -- ls -al
==> Reading instructions ...
==> Opening a session to vagrant@192.168.100.100 ..
total 36
drwxr-xr-x 6 vagrant vagrant 4096 Aug 14 07:33 .
drwxr-xr-x 4 root    root    4096 Aug  2 11:11 ..
-rw-r--r-- 1 vagrant vagrant  220 Mar  6 08:30 .bash_logout
-rw-r--r-- 1 vagrant vagrant 3771 Mar  6 08:30 .bashrc
drwx------ 2 vagrant vagrant 4096 Aug  2 11:11 .cache
drwx------ 2 root    root    4096 Aug 14 07:33 .gnupg
drwx------ 2 vagrant vagrant 4096 Aug  2 11:51 .kube
-rw-r--r-- 1 vagrant vagrant  655 Mar  6 08:30 .profile
drwx------ 2 vagrant vagrant 4096 Mar  6 08:30 .ssh
```
