### PR TITLE
Update cert-manager to 0.2.5

### DIFF
--- a/addons/cert-manager/addon.rb
+++ b/addons/cert-manager/addon.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Pharos.addon 'cert-manager' do
-  version '0.2.3'
+  version '0.2.5'
   license 'Apache License 2.0'
 
   issuer = custom_type {


### PR DESCRIPTION
https://github.com/jetstack/cert-manager/releases/tag/v0.2.5

> This is a bugfix release which fixes bugs in the way rate limits were handled within the Certificate control loop. This could cause failing authorizations to be retried in quick succession.

