### PR TITLE
Don't abort when apt mark unhold reports nothing to unhold

### DIFF
--- a/lib/pharos/host/ubuntu/scripts/configure-docker.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-docker.sh
@@ -44,6 +44,6 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-mark unhold $DOCKER_PACKAGE
+apt-mark unhold $DOCKER_PACKAGE || echo "Nothing to unhold"
 apt-get install -y $DOCKER_PACKAGE=$DOCKER_VERSION
 apt-mark hold $DOCKER_PACKAGE

--- a/lib/pharos/host/ubuntu/scripts/ensure-kubelet.sh
+++ b/lib/pharos/host/ubuntu/scripts/ensure-kubelet.sh
@@ -16,6 +16,6 @@ ExecStart=/usr/bin/kubelet ${KUBELET_ARGS} --pod-infra-container-image=${IMAGE_R
 EOF
 
 export DEBIAN_FRONTEND=noninteractive
-apt-mark unhold kubelet
+apt-mark unhold kubelet || echo "Nothing to unhold"
 apt-get install -y kubelet=${KUBE_VERSION}-00
 apt-mark hold kubelet

--- a/lib/pharos/host/ubuntu/scripts/install-kube-packages.sh
+++ b/lib/pharos/host/ubuntu/scripts/install-kube-packages.sh
@@ -3,7 +3,7 @@
 set -e
 
 export DEBIAN_FRONTEND=noninteractive
-apt-mark unhold kubelet kubectl kubeadm
+apt-mark unhold kubelet kubectl kubeadm || echo "Nothing to unhold"
 apt-get install -y kubelet=${KUBE_VERSION}-00 kubectl=${KUBE_VERSION}-00 kubeadm=${KUBEADM_VERSION}-00
 apt-mark hold kubelet kubectl kubeadm
 


### PR DESCRIPTION
Allows scripts to continue normally when performing `apt-mark unhold $PACKAGE_NAME` but the package was not being held.
