### PR TITLE
Fix broken pipe handling

### DIFF
--- a/bin/pharos-cluster
+++ b/bin/pharos-cluster
@@ -9,4 +9,5 @@ $LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
 STDOUT.sync = true
 
 require 'pharos_cluster'
+Signal.trap("SIGPIPE", "SYSTEM_DEFAULT")
 Pharos::RootCommand.run


### PR DESCRIPTION
Traps `Errno::EPIPE` and terminates quietly with exit code 141 (system default behaviour)

Makes something like:

```
pharos up | mroe
```

not throw:

```
Errno::EPIPE : Broken pipe @ io_writev - <STDOUT>
```

