### PR TITLE
Release v1.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (1.3.0.rc.1)
+    pharos-cluster (1.3.2)
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
       dry-struct (= 0.5.0)
@@ -58,17 +58,17 @@ GEM
       dry-types (~> 0.13.1)
     ed25519 (1.2.4)
     equatable (0.5.0)
-    et-orbi (1.1.4)
+    et-orbi (1.1.6)
       tzinfo
     excon (0.62.0)
     fakefs (0.18.0)
-    fugit (1.1.5)
-      et-orbi (~> 1.1, >= 1.1.3)
+    fugit (1.1.6)
+      et-orbi (~> 1.1, >= 1.1.6)
       raabro (~> 1.1)
     hitimes (1.3.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.1)
-    k8s-client (0.3.2)
+    k8s-client (0.3.4)
       deep_merge (~> 1.2.1)
       dry-struct (~> 0.5.0)
       excon (~> 0.62.0)
@@ -142,4 +142,4 @@ DEPENDENCIES
   rubocop (~> 0.57)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end


### PR DESCRIPTION
## Changes since v1.3.1

- kubernetes 1.11.3 (#598)
- cri-o 1.11.3 (#599)
- weave net 2.4.1 (#605)
- improve addon config error message (#607)
- normalize add-on paths to avoid loading twice (#553)
- don't abort when apt mark unhold reports nothing to unhold (#593)
- fix broken pipe handling (#602)
- fix el7 kubelet restart on upgrade (#608)