### PR TITLE
Add "no_proxy" for setting NO_PROXY in /etc/environment

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -56,6 +56,7 @@ module Pharos
               optional(:ssh_key_path).filled
               optional(:container_runtime).filled(included_in?: ['docker', 'cri-o'])
               optional(:http_proxy).filled(:str?)
+              optional(:no_proxy).filled(:str?)
             end
           end
         end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -59,6 +59,7 @@ module Pharos
       attribute :ssh_key_path, Pharos::Types::Strict::String
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
       attribute :http_proxy, Pharos::Types::Strict::String
+      attribute :no_proxy, Pharos::Types::Strict::String
 
       attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks, :resolvconf, :routes
 

--- a/lib/pharos/host/el7/el7.rb
+++ b/lib/pharos/host/el7/el7.rb
@@ -16,7 +16,7 @@ module Pharos
         exec_script(
           'configure-essentials.sh',
           HTTP_PROXY: host.http_proxy.to_s,
-          SET_HTTP_PROXY: host.http_proxy.nil? ? 'false' : 'true'
+          NO_PROXY: host.http.no_proxy.to_s
         )
       end
 

--- a/lib/pharos/host/el7/scripts/configure-essentials.sh
+++ b/lib/pharos/host/el7/scripts/configure-essentials.sh
@@ -54,7 +54,7 @@ else
 fi
 
 if [ ! -z "${NO_PROXY}" ]; then
-    lineinfile "^NO_PROXY=" "NO_PROXY=${NO_PROXY}" "$env_file"
+    lineinfile "^NO_PROXY=" "NO_PROXY=\"${NO_PROXY}\"" "$env_file"
 else
     linefromfile "^NO_PROXY=" "$env_file"
 fi

--- a/lib/pharos/host/el7/scripts/configure-essentials.sh
+++ b/lib/pharos/host/el7/scripts/configure-essentials.sh
@@ -43,7 +43,7 @@ if ! grep -q "/usr/local/bin" $env_file ; then
     echo "PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin" >> $env_file
 fi
 
-if [ "${SET_HTTP_PROXY}" = "true" ]; then
+if [ ! -z "${HTTP_PROXY}" ]; then
     lineinfile "^http_proxy=" "http_proxy=${HTTP_PROXY}" $env_file
     lineinfile "^HTTP_PROXY=" "HTTP_PROXY=${HTTP_PROXY}" $env_file
     lineinfile "^HTTPS_PROXY=" "HTTPS_PROXY=${HTTP_PROXY}" $env_file
@@ -51,6 +51,12 @@ else
     linefromfile "^http_proxy=" $env_file
     linefromfile "^HTTP_PROXY=" $env_file
     linefromfile "^HTTPS_PROXY=" $env_file
+fi
+
+if [ ! -z "${NO_PROXY}" ]; then
+    lineinfile "^NO_PROXY=" "NO_PROXY=${NO_PROXY}" "$env_file"
+else
+    linefromfile "^NO_PROXY=" "$env_file"
 fi
 
 if [ ! "$(getenforce)" = "Disabled" ]; then

--- a/lib/pharos/host/ubuntu/scripts/configure-essentials.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-essentials.sh
@@ -6,7 +6,7 @@ set -e
 
 env_file="/etc/environment"
 
-if [ "${SET_HTTP_PROXY}" = "true" ]; then
+if [ ! -z "${HTTP_PROXY}" ]; then
     lineinfile "^http_proxy=" "http_proxy=${HTTP_PROXY}" $env_file
     lineinfile "^HTTP_PROXY=" "HTTP_PROXY=${HTTP_PROXY}" $env_file
     lineinfile "^HTTPS_PROXY=" "HTTPS_PROXY=${HTTP_PROXY}" $env_file

--- a/lib/pharos/host/ubuntu/scripts/configure-essentials.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-essentials.sh
@@ -16,6 +16,12 @@ else
     linefromfile "^HTTPS_PROXY=" $env_file
 fi
 
+if [ ! -z "${NO_PROXY}" ]; then
+    lineinfile "^NO_PROXY=" "NO_PROXY=\"${NO_PROXY}\"" "$env_file"
+else
+    linefromfile "^NO_PROXY=" "$env_file"
+fi
+
 if ! dpkg -l apt-transport-https software-properties-common > /dev/null; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -y

--- a/lib/pharos/host/ubuntu/ubuntu.rb
+++ b/lib/pharos/host/ubuntu/ubuntu.rb
@@ -7,7 +7,7 @@ module Pharos
         exec_script(
           'configure-essentials.sh',
           HTTP_PROXY: host.http_proxy.to_s,
-          SET_HTTP_PROXY: host.http_proxy.nil? ? 'false' : 'true'
+          NO_PROXY: host.no_proxy.to_s
         )
       end
 


### PR DESCRIPTION
Fixes #587 

Adds `no_proxy` setting to host config:

```
hosts:
  - address: 1.1.1.1
    private_interface: eth1
    user: root
    ssh_key_path: ~/.ssh/my_key
    role: master
    no_proxy: "*.example.com,127.0.0.1"
```

The setting will be written to `/etc/environment`.


