### PR TITLE
Fix /etc/resolv.conf parser comment handling

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -29,6 +29,10 @@ module Pharos
   autoload :ClusterManager, 'pharos/cluster_manager'
   autoload :HostConfigManager, 'pharos/host_config_manager'
 
+  module CoreExt
+    autoload :IPAddrLoopback, 'pharos/core-ext/ip_addr_loopback'
+  end
+
   module SSH
     autoload :Client, 'pharos/ssh/client'
     autoload :Manager, 'pharos/ssh/manager'

--- a/lib/pharos/core-ext/ip_addr_loopback.rb
+++ b/lib/pharos/core-ext/ip_addr_loopback.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Pharos
+  module CoreExt
+    module IPAddrLoopback
+      # Backported from Ruby 2.5
+      refine IPAddr do
+        # Returns true if the ipaddr is a loopback address.
+        def loopback?
+          case @family
+          when Socket::AF_INET
+            @addr & 0xff000000 == 0x7f000000
+          when Socket::AF_INET6
+            @addr == 1
+          else
+            # Ruby 2.5 raises here
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pharos/phases/gather_facts.rb
+++ b/lib/pharos/phases/gather_facts.rb
@@ -119,7 +119,7 @@ module Pharos
         end
       end
 
-      using IpAddrLoopbackBackport if RUBY_VERSION < '2.5.0'
+      using IPAddrLoopbackBackport if RUBY_VERSION < '2.5.0'
 
       # @return [Boolean]
       def resolvconf_nameserver_localhost?

--- a/lib/pharos/phases/gather_facts.rb
+++ b/lib/pharos/phases/gather_facts.rb
@@ -5,6 +5,8 @@ require 'ipaddr'
 module Pharos
   module Phases
     class GatherFacts < Pharos::Phase
+      using Pharos::CoreExt::IPAddrLoopback if RUBY_VERSION < '2.5.0'
+
       title "Gather host facts"
 
       def call
@@ -101,25 +103,6 @@ module Pharos
       def resolvconf_nameservers
         @ssh.file('/etc/resolv.conf').lines.map { |l| l[/^nameserver ([\h:.]+)/, 1] }.compact
       end
-
-      module IPAddrLoopbackBackport
-        refine IPAddr do
-          # Backported from Ruby 2.5
-          # Returns true if the ipaddr is a loopback address.
-          def loopback?
-            case @family
-            when Socket::AF_INET
-              @addr & 0xff000000 == 0x7f000000
-            when Socket::AF_INET6
-              @addr == 1
-            else
-              false
-            end
-          end
-        end
-      end
-
-      using IPAddrLoopbackBackport if RUBY_VERSION < '2.5.0'
 
       # @return [Boolean]
       def resolvconf_nameserver_localhost?

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -91,12 +91,16 @@ module Pharos
         target
       end
 
+      # Returns an array of lines in the remote file
+      # @return [Array<String>]
+      def lines
+        read.lines
+      end
+
       # Yields each line in the remote file
       # @yield [String]
-      def each_line
-        read.split(/[\r\n]/).each do |row|
-          yield row
-        end
+      def each_line(&block)
+        read.each_line(&block)
       end
 
       private

--- a/spec/pharos/phases/gather_facts_spec.rb
+++ b/spec/pharos/phases/gather_facts_spec.rb
@@ -53,22 +53,18 @@ describe Pharos::Phases::GatherFacts do
   end
 
   describe '#get_resolvconf' do
-    let(:file) { instance_double(Pharos::SSH::RemoteFile) }
+    let(:file) { instance_double Pharos::SSH::RemoteFile }
+    let(:file_content) { "" }
     let(:file_readlink) { nil }
 
     before do
       allow(ssh).to receive(:file).with('/etc/resolv.conf').and_return(file)
-
-      mock = allow(file).to receive(:each_line)
-      file_lines.each do |line|
-        mock = mock.and_yield(line)
-      end
-
+      allow(file).to receive(:lines).and_return(file_content.lines)
       allow(file).to receive(:readlink).and_return(file_readlink)
     end
 
     context 'for a normal resolv.conf' do
-      let(:file_lines) { ['nameserver 8.8.8.8'] }
+      let(:file_content) { "# nameserver config\nnameserver 8.8.8.8\n" }
 
       it 'returns ok' do
         expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
@@ -79,7 +75,18 @@ describe Pharos::Phases::GatherFacts do
     end
 
     context 'for a normal resolv.conf with localhost' do
-      let(:file_lines) { ['nameserver 127.0.0.53'] }
+      let(:file_content) { "nameserver 127.0.0.53" }
+
+      it 'returns nameserver_localhost' do
+        expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
+          nameserver_localhost: true,
+          systemd_resolved_stub: false,
+        )
+      end
+    end
+
+    context 'for a normal resolv.conf with ipv6 localhost' do
+      let(:file_content) { "nameserver ::1" }
 
       it 'returns nameserver_localhost' do
         expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
@@ -90,7 +97,7 @@ describe Pharos::Phases::GatherFacts do
     end
 
     context 'for a systemd-resolved resolv.conf stub' do
-      let(:file_lines) { ['nameserver 127.0.0.53'] }
+      let(:file_content) { "nameserver 127.0.0.53" }
       let(:file_readlink) { '../run/systemd/resolve/stub-resolv.conf' }
 
       it 'returns systemd_resolved_stub' do
@@ -102,7 +109,7 @@ describe Pharos::Phases::GatherFacts do
     end
 
     context 'for a non-resolved resolv.conf symlink' do
-      let(:file_lines) { ['nameserver 8.8.8.8'] }
+      let(:file_content) { "nameserver 8.8.8.8" }
       let(:file_readlink) { '/run/resolvconf/resolv.conf' }
 
       it 'returns ok' do


### PR DESCRIPTION
Fixes #614

Also checks for ipv6 loopback nameservers.

