### PR TITLE
Rename OSS build packages

### DIFF
--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -11,7 +11,7 @@ curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-linux-amd64.
 chmod +x /usr/local/bin/rubyc
 gem install bundler
 version=${DRONE_TAG#"v"}
-package="pharos-cluster-linux-amd64-${version}-oss"
+package="pharos-cluster-linux-amd64-${version}+oss"
 sudo mkdir /__enclose_io_memfs__
 rubyc -o $package -d /__enclose_io_memfs__ pharos-cluster
 ./$package version

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -11,7 +11,7 @@ curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-linux-amd64.
 chmod +x /usr/local/bin/rubyc
 gem install bundler
 version=${DRONE_TAG#"v"}
-package="pharos-cluster-oss-linux-amd64-${version}"
+package="pharos-cluster-linux-amd64-${version}-oss"
 sudo mkdir /__enclose_io_memfs__
 rubyc -o $package -d /__enclose_io_memfs__ pharos-cluster
 ./$package version

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -8,7 +8,7 @@ brew install squashfs
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 version=${TRAVIS_TAG#"v"}
-package="pharos-cluster-darwin-amd64-${version}-oss"
+package="pharos-cluster-darwin-amd64-${version}+oss"
 rubyc -o $package pharos-cluster
 ./$package version
 

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -8,7 +8,7 @@ brew install squashfs
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 version=${TRAVIS_TAG#"v"}
-package="pharos-cluster-oss-darwin-amd64-${version}"
+package="pharos-cluster-darwin-amd64-${version}-oss"
 rubyc -o $package pharos-cluster
 ./$package version
 


### PR DESCRIPTION
This PR will rename built oss packages as `pharos-cluster-linux-amd64-${version}-oss`.

The motivation behind this is that we could then use `${version}-oss` as version for the binary.  It would make more straight-forward to install and resolve binaries, for example:
```sh
$ chpharos list-remote
2.0.0
2.0.0-oss
1.3.2
1.3.1
...
$ chpharos install 2.0.0-oss
```