### PR TITLE
Refactor cluster version check to use Gem::Version && Gem::Requirement

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -77,9 +77,9 @@ module Pharos
 
     def apply_phases
       # we need to use sorted masters because phases expects that first one has
+      # ca etc config files
       master_hosts = sorted_master_hosts
 
-      # ca etc config files
       apply_phase(Phases::MigrateMaster, master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureClient, [master_hosts.first], ssh: true, master: master_hosts.first, parallel: false, optional: true)

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -61,6 +61,8 @@ module Pharos
       addon_manager.validate
       gather_facts
       apply_phase(Phases::ValidateHost, config.hosts, ssh: true, parallel: true)
+      master = sorted_master_hosts.first
+      apply_phase(Phases::ValidateVersion, [master], master: master, ssh: true, parallel: false)
     end
 
     # @return [Array<Pharos::Configuration::Host>]
@@ -75,10 +77,9 @@ module Pharos
 
     def apply_phases
       # we need to use sorted masters because phases expects that first one has
-      # ca etc config files
       master_hosts = sorted_master_hosts
 
-      apply_phase(Phases::ValidateVersion, [master_hosts.first], master: master_hosts.first, ssh: true, parallel: false)
+      # ca etc config files
       apply_phase(Phases::MigrateMaster, master_hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, ssh: true, parallel: true)
       apply_phase(Phases::ConfigureClient, [master_hosts.first], ssh: true, master: master_hosts.first, parallel: false, optional: true)

--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -21,15 +21,9 @@ module Pharos
 
       # @param cluster_version [String]
       def validate_version(cluster_version)
-        cluster_major, cluster_minor, cluster_patch = cluster_version.split('.')
-        major, minor, patch = Pharos::VERSION.split('.')
-        unless cluster_major == major && cluster_minor == minor
-          raise "Upgrade path not supported"
-        end
-
-        if cluster_patch.to_i <= patch.to_i
-          raise "Downgrade not supported"
-        end
+        cluster_version = Gem::Version.new(cluster_version)
+        raise "Downgrade not supported" if cluster_version > pharos_version
+        raise "Upgrade path not supported" unless requirement.satisfied_by?(cluster_version)
 
         logger.info { "Valid cluster version detected: #{cluster_version}" }
       end
@@ -59,6 +53,17 @@ module Pharos
         kube_client.api('v1').resource('configmaps', namespace: 'kube-system').get('pharos-config')
       rescue K8s::Error::NotFound
         nil
+      end
+
+      private
+
+      def pharos_version
+        @pharos_version ||= Gem::Version.new(pharos_version)
+      end
+
+      # Returns a requirement like "~>", "1.3.0"  which will match >= 1.3.0 && < 1.4.0
+      def requirement
+        Gem::Requirement.new('~>' + pharos_version.segments.first(2).join('.') + '.0')
       end
     end
   end

--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -58,7 +58,7 @@ module Pharos
       private
 
       def pharos_version
-        @pharos_version ||= Gem::Version.new(pharos_version)
+        @pharos_version ||= Gem::Version.new(Pharos::VERSION)
       end
 
       # Returns a requirement like "~>", "1.3.0"  which will match >= 1.3.0 && < 1.4.0

--- a/non-oss/phases/validate_version.rb
+++ b/non-oss/phases/validate_version.rb
@@ -5,12 +5,7 @@ module Pharos
     class ValidateVersion < Pharos::Phase
       # @param cluster_version [String]
       def validate_version(cluster_version)
-        cluster_major, cluster_minor, cluster_patch = cluster_version.split('.')
-        major, minor, patch = Pharos::VERSION.split('.')
-
-        if major.to_i < cluster_major.to_i || minor.to_i < cluster_minor.to_i || patch.to_i < cluster_patch.to_i
-          raise "Downgrade not supported"
-        end
+        raise "Downgrade not supported" if Gem::Version.new(cluster_version) > pharos_version
 
         logger.info { "Valid cluster version detected: #{cluster_version}" }
       end


### PR DESCRIPTION
Simplifies the comparisons and also handles comparison of `-rc2` vs `-pre1` type of version numbers.

Also moves the version check to happen during the validation, before the yes/no confirmation prompt.
