### PR TITLE
Fix oss binary release step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,12 +19,12 @@ pipeline:
       - ./build/drone/ubuntu_oss.sh
     when:
       event: tag
-  release_binary:
+  release_binary_oss:
     image: plugins/s3
     secrets: [ aws_access_key_id, aws_secret_access_key ]
     bucket: pharos-cluster-binaries
     region: eu-west-1
-    source: "pharos-cluster-oss-linux-amd64-${DRONE_TAG##v}"
+    source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}+oss"
     target: /
     when:
       event: tag


### PR DESCRIPTION
This PR will change oss release step to `release_binary_oss` since there is already duplicated `release_binary` step in the YAML. Also, fixed the oss binary to follow the new format