### PR TITLE
Fix kubernetes dashboard addon first run timing issue

### DIFF
--- a/addons/kubernetes-dashboard/addon.rb
+++ b/addons/kubernetes-dashboard/addon.rb
@@ -9,12 +9,22 @@ Pharos.addon 'kubernetes-dashboard' do
 
     logger.info { "~~> kubernetes-dashboard can be accessed via kubectl proxy. Check proxy URL with: kubectl cluster-info" }
 
-    service_account = kube_client.api('v1').resource('serviceaccounts', namespace: 'kube-system').get('dashboard-admin')
-    token_secret = service_account.secrets[0]
-    if token_secret
+    retry_times = 0
+    begin
+      service_account = kube_client.api('v1').resource('serviceaccounts', namespace: 'kube-system').get('dashboard-admin')
+      raise "secret not available" if service_account.secrets.nil? || service_account.secrets.empty?
+      token_secret = service_account.secrets[0]
       logger.info { "~~> kubernetes-dashboard admin token can be fetched using: kubectl describe secret #{token_secret.name} -n kube-system" }
-    else
-      logger.error { "~~> kubernetes-dashboard admin token cannot be found" }
+    rescue => ex
+      raise unless ex.message == "secret not available"
+      retry_times += 1
+      if retry_times > 10
+        logger.error { "~~> kubernetes-dashboard admin token cannot be found" }
+      else
+        logger.send(retry_times == 1 ? :info : :debug) { "Waiting for secrets to update .." }
+        sleep 5
+        retry
+      end
     end
   }
 end

--- a/addons/kubernetes-dashboard/addon.rb
+++ b/addons/kubernetes-dashboard/addon.rb
@@ -15,7 +15,7 @@ Pharos.addon 'kubernetes-dashboard' do
       raise "secret not available" if service_account.secrets.nil? || service_account.secrets.empty?
       token_secret = service_account.secrets[0]
       logger.info { "~~> kubernetes-dashboard admin token can be fetched using: kubectl describe secret #{token_secret.name} -n kube-system" }
-    rescue => ex
+    rescue RuntimeError => ex
       raise unless ex.message == "secret not available"
       retry_times += 1
       if retry_times > 10


### PR DESCRIPTION
Fixes #610

The kubernetes-dashboard addon installation raises an exception the first time it is enabled. This PR fixes that by retrying the secret retrieval for maximum of about 50 seconds before giving up.

It seems to take about 20 seconds on my local vagrant cluster, not sure if 50 seconds is enough.
