### PR TITLE
Nested transform helpers to hashes and case conversions to strings

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -31,6 +31,8 @@ module Pharos
 
   module CoreExt
     autoload :IPAddrLoopback, 'pharos/core-ext/ip_addr_loopback'
+    autoload :DeepTransformKeys, 'pharos/core-ext/deep_transform_keys'
+    autoload :StringCasing, 'pharos/core-ext/string_casing'
   end
 
   module SSH

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -16,6 +16,8 @@ module Pharos
   class Config < Pharos::Configuration::Struct
     HOSTS_PER_DNS_REPLICA = 10
 
+    using Pharos::CoreExt::DeepTransformKeys
+
     # @param raw_data [Hash]
     # @raise [Pharos::ConfigError]
     # @return [Pharos::Config]
@@ -83,7 +85,7 @@ module Pharos
 
     # @return [String]
     def to_yaml
-      JSON.parse(to_h.to_json).to_yaml
+      YAML.dump(to_h.deep_stringify_keys)
     end
   end
 end

--- a/lib/pharos/core-ext/deep_transform_keys.rb
+++ b/lib/pharos/core-ext/deep_transform_keys.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Pharos
+  module CoreExt
+    module DeepTransformKeys
+      using Pharos::CoreExt::StringCasing
+
+      def self.deep_transform_keys(value = nil, &block)
+        case value
+        when Array
+          value.map { |v| deep_transform_keys(v, &block) }
+        when Hash
+          Hash[value.map { |k, v| [yield(k), deep_transform_keys(v, &block)] }]
+        else
+          value
+        end
+      end
+
+      def deep_transform_keys(&block)
+        ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &block)
+      end
+
+      def deep_transform_keys!(&block)
+        replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &block))
+      end
+
+      def deep_stringify_keys
+        ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_s)
+      end
+
+      def deep_stringify_keys!
+        replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_s))
+      end
+
+      refine Hash do
+        include ::Pharos::CoreExt::DeepTransformKeys
+      end
+    end
+  end
+end

--- a/lib/pharos/core-ext/string_casing.rb
+++ b/lib/pharos/core-ext/string_casing.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Pharos
+  module CoreExt
+    module StringCasing
+      def underscore
+        return self if empty?
+
+        result = gsub(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+        result.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+        result.tr!('-', '_')
+        result.gsub!(/\s+/, '_')
+        result.gsub!(/__+/, '_')
+        result.downcase!
+        result
+      end
+
+      def camelcase
+        return self if empty?
+
+        extend(StringCasing).underscore.split('_').map(&:capitalize).join
+      end
+
+      def camelback
+        return self if empty?
+
+        camelcased = extend(StringCasing).camelcase
+        camelcased[0] = camelcased[0].downcase
+        camelcased
+      end
+
+      %i(underscore camelcase camelback).each do |meth|
+        define_method("#{meth}!") do
+          return self if empty?
+
+          replace(extend(StringCasing).send(meth))
+        end
+      end
+
+      refine String do
+        include StringCasing
+      end
+
+      refine Symbol do
+        %i(underscore camelcase camelback).each do |meth|
+          define_method(meth) do
+            to_s.extend(StringCasing).send(meth)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pharos/core_ext/deep_transform_keys_spec.rb
+++ b/spec/pharos/core_ext/deep_transform_keys_spec.rb
@@ -1,0 +1,53 @@
+describe Pharos::CoreExt::DeepTransformKeys do
+  describe '#deep_transform_keys' do
+    context 'as a module' do
+      subject { { foo: { bar: [ { baz: 1 } ] } } }
+      it 'deep transforms keys' do
+        subject.extend(described_class)
+        expect(subject.deep_transform_keys(&:to_s)).to eq(
+          { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } }
+        )
+      end
+    end
+
+    context 'as a refinement' do
+      using Pharos::CoreExt::DeepTransformKeys
+      subject { { foo: { bar: [ { baz: 1 } ] } } }
+
+      it 'deep transforms keys' do
+        expect(subject.deep_transform_keys(&:to_s)).to eq(
+          { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } }
+        )
+      end
+
+      it 'includes the string casing refinement' do
+        expect(subject.deep_transform_keys(&:camelcase)).to eq(
+          { 'Foo' => { 'Bar' => [ { 'Baz' => 1 } ] } }
+        )
+      end
+    end
+  end
+
+  describe '#deep_stringify_keys' do
+    context 'as a module' do
+      subject { { foo: { bar: [ { baz: 1 } ] } } }
+      it 'deep stringifies keys' do
+        subject.extend(described_class)
+        expect(subject.deep_stringify_keys).to eq(
+          { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } }
+        )
+      end
+    end
+
+    context 'as a refinement' do
+      using Pharos::CoreExt::DeepTransformKeys
+      subject { { foo: { bar: [ { baz: 1 } ] } } }
+
+      it 'deep stringifies keys' do
+        expect(subject.deep_stringify_keys).to eq(
+          { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } }
+        )
+      end
+    end
+  end
+end

--- a/spec/pharos/core_ext/string_casing_spec.rb
+++ b/spec/pharos/core_ext/string_casing_spec.rb
@@ -1,0 +1,87 @@
+describe Pharos::CoreExt::StringCasing do
+  context 'as a module' do
+    subject { "fooBar".extend(described_class) }
+    it 'underscores a string' do
+      expect(subject.underscore).to eq "foo_bar"
+    end
+  end
+
+  context 'as a refinement' do
+    using Pharos::CoreExt::StringCasing
+
+    describe '#underscore' do
+      it 'underscores a string' do
+        expect("Foo Barbaz".underscore).to eq "foo_barbaz"
+        expect("foo BarBaz".underscore).to eq "foo_bar_baz"
+        expect("foo barBaz".underscore).to eq "foo_bar_baz"
+        expect("fooBARbaz".underscore).to eq "foo_ba_rbaz"
+      end
+    end
+
+    describe '#camelcase' do
+      it 'camelcases a string' do
+        expect("foo Bar baz".camelcase).to eq "FooBarBaz"
+        expect("foo barBaz".camelcase).to eq "FooBarBaz"
+        expect("fooBARbaz".camelcase).to eq "FooBaRbaz"
+      end
+    end
+
+    describe '#camelback' do
+      it 'camelbacks a string' do
+        expect("foo Bar baz".camelback).to eq "fooBarBaz"
+        expect("foo barBaz".camelback).to eq "fooBarBaz"
+        expect("fooBARbaz".camelback).to eq "fooBaRbaz"
+      end
+    end
+
+    context 'bang' do
+      using Pharos::CoreExt::StringCasing
+
+      describe '#underscore' do
+        it 'underscores a string' do
+          str = "Foo Barbaz"
+          str.underscore!
+          expect(str).to eq "foo_barbaz"
+        end
+      end
+
+      describe '#camelcase' do
+        it 'camelcases a string' do
+          str = "Foo BarBaz"
+          str.camelcase!
+          expect(str).to eq "FooBarBaz"
+        end
+      end
+
+      describe '#camelback' do
+        it 'camelbacks a string' do
+          str = "Foo BarBaz"
+          str.camelback!
+          expect(str).to eq "fooBarBaz"
+        end
+      end
+    end
+
+    context 'Symbol' do
+      using Pharos::CoreExt::StringCasing
+
+      describe '#underscore' do
+        it 'stringifies and underscores a symbol' do
+          expect(:fooBar.underscore).to eq "foo_bar"
+        end
+      end
+
+      describe '#camelcase' do
+        it 'stringifies and camelcases a symbol' do
+          expect(:foo_bar.camelcase).to eq "FooBar"
+        end
+      end
+
+      describe '#camelback' do
+        it 'stringifies and camelbacks a symbol' do
+          expect(:foo_bar.camelback).to eq "fooBar"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Adds:
- `Hash#deep_transform_keys`
- `Hash#deep_stringify_keys`
- `String#camelcase`
- `String#underscore`
- `String#camelback`

### Usage:

Either as a module or a refinement (no global monkey patch)

```ruby
class Foofoo
  using Pharos::CoreExt::DeepTransformKeys

  def test
    { foo: { bar: [ { baz: 1 } ] } }.deep_transform_keys { |k| k.to_s.reverse.to_sym })
  end
  # => { oof: { rab: [ { zab: 1} ] } }
end
```

```ruby
class Foofoo
  def test
    { foo: { bar: [ { baz: 1 } ] } }.extend(Pharos::CoreExt::DeepTransformKeys).deep_stringify_keys
  # => { "foo" => { "bar" => [ { "baz" => 1} ] } }
end
```

```ruby
class Foofoo
  using Pharos::CoreExt::StringCasing

  def test
    "foo Bar baz".underscore
  end
  # => "foo_bar_baz"
end
```

```ruby
class Foofoo
  def test
    str = "foo BarBaz"
    str.extend(Pharos::CoreExt::StringCasing)
    str.camelback
  end
  # => "fooBarBaz"
end
```





