### PR TITLE
Release v1.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       dry-validation (= 0.12.1)
       ed25519 (= 1.2.4)
       fugit (~> 1.1.2)
-      k8s-client (~> 0.3.2)
+      k8s-client (~> 0.3.3)
       net-ssh (= 5.0.1)
       pastel
       rouge (~> 3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (1.3.2)
+    pharos-cluster (2.0.0.dev)
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
       dry-struct (= 0.5.0)
@@ -9,7 +9,7 @@ PATH
       dry-validation (= 0.12.1)
       ed25519 (= 1.2.4)
       fugit (~> 1.1.2)
-      k8s-client (~> 0.3.3)
+      k8s-client (~> 0.3.4)
       net-ssh (= 5.0.1)
       pastel
       rouge (~> 3.1)

--- a/addons/kubernetes-dashboard/addon.rb
+++ b/addons/kubernetes-dashboard/addon.rb
@@ -9,12 +9,22 @@ Pharos.addon 'kubernetes-dashboard' do
 
     logger.info { "~~> kubernetes-dashboard can be accessed via kubectl proxy. Check proxy URL with: kubectl cluster-info" }
 
-    service_account = kube_client.api('v1').resource('serviceaccounts', namespace: 'kube-system').get('dashboard-admin')
-    token_secret = service_account.secrets[0]
-    if token_secret
+    retry_times = 0
+    begin
+      service_account = kube_client.api('v1').resource('serviceaccounts', namespace: 'kube-system').get('dashboard-admin')
+      raise "secret not available" if service_account.secrets.nil? || service_account.secrets.empty?
+      token_secret = service_account.secrets[0]
       logger.info { "~~> kubernetes-dashboard admin token can be fetched using: kubectl describe secret #{token_secret.name} -n kube-system" }
-    else
-      logger.error { "~~> kubernetes-dashboard admin token cannot be found" }
+    rescue RuntimeError => ex
+      raise unless ex.message == "secret not available"
+      retry_times += 1
+      if retry_times > 10
+        logger.error { "~~> kubernetes-dashboard admin token cannot be found" }
+      else
+        logger.send(retry_times == 1 ? :info : :debug) { "Waiting for secrets to update .." }
+        sleep 5
+        retry
+      end
     end
   }
 end

--- a/build/drone/ubuntu_xenial.sh
+++ b/build/drone/ubuntu_xenial.sh
@@ -10,7 +10,8 @@ chmod +x /usr/local/bin/rubyc
 gem install bundler
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}"
-rubyc -o $package pharos-cluster
+sudo mkdir /__enclose_io_memfs__
+rubyc -o $package -d /__enclose_io_memfs__ pharos-cluster
 ./$package version
 
 # ship to github

--- a/build/drone/ubuntu_xenial.sh
+++ b/build/drone/ubuntu_xenial.sh
@@ -10,7 +10,7 @@ chmod +x /usr/local/bin/rubyc
 gem install bundler
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}"
-sudo mkdir /__enclose_io_memfs__
+mkdir /__enclose_io_memfs__
 rubyc -o $package -d /__enclose_io_memfs__ pharos-cluster
 ./$package version
 

--- a/build/drone/ubuntu_xenial.sh
+++ b/build/drone/ubuntu_xenial.sh
@@ -10,7 +10,7 @@ chmod +x /usr/local/bin/rubyc
 gem install bundler
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}"
-mkdir /root/.pharos/build
+mkdir -p /root/.pharos/build
 rubyc -o $package -d /root/.pharos/build pharos-cluster
 ./$package version
 

--- a/build/drone/ubuntu_xenial.sh
+++ b/build/drone/ubuntu_xenial.sh
@@ -10,8 +10,8 @@ chmod +x /usr/local/bin/rubyc
 gem install bundler
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}"
-mkdir /__enclose_io_memfs__
-rubyc -o $package -d /__enclose_io_memfs__ pharos-cluster
+mkdir /root/.pharos/build
+rubyc -o $package -d /root/.pharos/build pharos-cluster
 ./$package version
 
 # ship to github

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -2,6 +2,7 @@
 
 require_relative 'addon'
 require_relative 'logging'
+require_relative 'kube'
 
 module Pharos
   class AddonManager
@@ -9,6 +10,12 @@ module Pharos
 
     class InvalidConfig < Pharos::Error; end
     class UnknownAddon < Pharos::Error; end
+
+    RETRY_ERRORS = [
+      OpenSSL::SSL::SSLError,
+      Excon::Error,
+      K8s::Error
+    ].freeze
 
     # @return [Array<Class<Pharos::Addon>>]
     def self.addons
@@ -72,16 +79,34 @@ module Pharos
       }
     end
 
-    def each
+    def each(&block)
       with_enabled_addons do |addon_class, config_hash|
         config = addon_class.validate(config_hash)
         addon = addon_class.new(config, enabled: true, **options)
         addon.validate
-        yield addon
+        yield_addon_with_retry(addon, &block)
       end
 
       with_disabled_addons do |addon_class|
-        yield addon_class.new(nil, enabled: false, **options)
+        yield_addon_with_retry(addon_class.new(nil, enabled: false, **options), &block)
+      end
+    end
+
+    # @param addon [Pharos::Addon]
+    # @param retry_times [Integer]
+    def yield_addon_with_retry(addon, retry_times = 10)
+      retries = 0
+      begin
+        yield addon
+      rescue *RETRY_ERRORS => exc
+        raise if retries >= retry_times
+
+        logger.error { "got error (#{exc.class.name}): #{exc.message.strip}" }
+        logger.debug { exc.backtrace.join("\n") }
+        logger.error { "retrying after #{2**retries} seconds ..." }
+        sleep 2**retries
+        retries += 1
+        retry
       end
     end
 

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -68,7 +68,7 @@ module Pharos
 
     # @return [K8s::Client]
     def kube_client
-      @kube_client ||= Pharos::Kube.client(@config.master_host, @cluster_context['kubeconfig'])
+      @kube_client ||= Pharos::Kube.client(@config.master_host.api_address, @cluster_context['kubeconfig'])
     end
 
     def options

--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -29,6 +29,10 @@ module Pharos
   autoload :ClusterManager, 'pharos/cluster_manager'
   autoload :HostConfigManager, 'pharos/host_config_manager'
 
+  module CoreExt
+    autoload :IPAddrLoopback, 'pharos/core-ext/ip_addr_loopback'
+  end
+
   module SSH
     autoload :Client, 'pharos/ssh/client'
     autoload :Manager, 'pharos/ssh/manager'

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -100,17 +100,19 @@ module Pharos
 
       # master is now configured and can be used
       apply_phase(Phases::LoadClusterConfiguration, [master_hosts.first], master: master_hosts.first)
+      # configure essential services
       apply_phase(Phases::ConfigureDNS, [master_hosts.first], master: master_hosts.first)
-
       apply_phase(Phases::ConfigureWeave, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'weave'
       apply_phase(Phases::ConfigureCalico, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'calico'
-      apply_phase(Phases::ConfigureMetrics, [master_hosts.first], master: master_hosts.first)
-      apply_phase(Phases::ConfigureTelemetry, [master_hosts.first], master: master_hosts.first)
+
       apply_phase(Phases::ConfigureBootstrap, [master_hosts.first], ssh: true) # using `kubeadm token`, not the kube API
 
       apply_phase(Phases::JoinNode, config.worker_hosts, ssh: true, parallel: true)
-
       apply_phase(Phases::LabelNode, config.hosts, master: master_hosts.first, ssh: false, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
+
+      # configure services that need workers
+      apply_phase(Phases::ConfigureMetrics, [master_hosts.first], master: master_hosts.first)
+      apply_phase(Phases::ConfigureTelemetry, [master_hosts.first], master: master_hosts.first)
     end
 
     def apply_reset

--- a/lib/pharos/core-ext/ip_addr_loopback.rb
+++ b/lib/pharos/core-ext/ip_addr_loopback.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Pharos
+  module CoreExt
+    module IPAddrLoopback
+      # Backported from Ruby 2.5
+      refine IPAddr do
+        # Returns true if the ipaddr is a loopback address.
+        def loopback?
+          case @family
+          when Socket::AF_INET
+            @addr & 0xff000000 == 0x7f000000
+          when Socket::AF_INET6
+            @addr == 1
+          else
+            # Ruby 2.5 raises here
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -36,10 +36,10 @@ module Pharos
     end
 
     # @param host [String]
-    # @param config [K8s::Config]
+    # @param config [Hash]
     # @return [K8s::Client]
     def self.client(host, config)
-      K8s::Client.config(config, server: "https://#{host}:6443")
+      K8s::Client.config(K8s::Config.new(config), server: "https://#{host}:6443")
     end
 
     # @param name [String]

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -33,18 +33,13 @@ module Pharos
 
         new(name, resources)
       end
-
-      def initialize(name, resources = [])
-        super(name, resources, label: LABEL, checksum_annotation: CHECKSUM_ANNOTATION)
-      end
     end
 
     # @param host [String]
-    # @param config [Hash]
+    # @param config [K8s::Config]
     # @return [K8s::Client]
     def self.client(host, config)
-      @kube_client ||= {}
-      @kube_client[host] ||= K8s::Client.config(K8s::Config.new(config))
+      K8s::Client.config(config, server: "https://#{host}:6443")
     end
 
     # @param name [String]

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -27,19 +27,18 @@ module Pharos
         @ssh.file(REMOTE_FILE).exist?
       end
 
-      # @return [String]
+      # @return [K8s::Config]
       def read_kubeconfig
         @ssh.file(REMOTE_FILE).read
       end
 
-      # @return [Hash]
+      # @return [K8s::Config]
       def kubeconfig
         logger.info { "Fetching kubectl config ..." }
-        config = Pharos::Kube::Config.new(read_kubeconfig)
-        config.update_server_address(@host.api_address)
+        config = YAML.safe_load(read_kubeconfig)
 
         logger.debug { "New config: #{config}" }
-        config.to_h
+        K8s::Config.new(config)
       end
 
       # prefetch client resources to warm up caches

--- a/lib/pharos/phases/gather_facts.rb
+++ b/lib/pharos/phases/gather_facts.rb
@@ -5,6 +5,8 @@ require 'ipaddr'
 module Pharos
   module Phases
     class GatherFacts < Pharos::Phase
+      using Pharos::CoreExt::IPAddrLoopback if RUBY_VERSION < '2.5.0'
+
       title "Gather host facts"
 
       def call
@@ -98,30 +100,18 @@ module Pharos
       end
 
       # @return [Array<String>]
-      def read_resolvconf_nameservers
-        nameservers = []
-
-        @ssh.file('/etc/resolv.conf').each_line do |line|
-          if match = line.match(/nameserver (.+)/)
-            nameservers << match[1]
-          end
-        end
-
-        nameservers
+      def resolvconf_nameservers
+        @ssh.file('/etc/resolv.conf').lines.map { |l| l[/^nameserver ([\h:.]+)/, 1] }.compact
       end
 
-      LOCALNET = IPAddr.new('127.0.0.0/8')
-
-      # Host /etc/resolv.conf is configured to use a nameserver at localhost in the host network namespace
       # @return [Boolean]
-      def check_resolvconf_nameserver_localhost
-        resolvers = read_resolvconf_nameservers.map{ |ip| IPAddr.new(ip) }
-        resolvers.any? { |ip| LOCALNET.include?(ip) }
+      def resolvconf_nameserver_localhost?
+        resolvconf_nameservers.any? { |ip| IPAddr.new(ip).loopback? }
       end
 
       # Host /etc/resolv.conf is configured to use the systemd-resolved stub resolver at 127.0.0.53
       # @return [Boolean]
-      def check_resolvconf_systemd_resolved_stub
+      def resolvconf_systemd_resolved_stub?
         symlink = @ssh.file('/etc/resolv.conf').readlink
         !!symlink && symlink.end_with?('/run/systemd/resolve/stub-resolv.conf')
       end
@@ -129,8 +119,8 @@ module Pharos
       # @return [Pharos::Configuration::Host::ResolvConf]
       def read_resolvconf
         Pharos::Configuration::Host::ResolvConf.new(
-          nameserver_localhost: check_resolvconf_nameserver_localhost,
-          systemd_resolved_stub: check_resolvconf_systemd_resolved_stub
+          nameserver_localhost: resolvconf_nameserver_localhost?,
+          systemd_resolved_stub: resolvconf_systemd_resolved_stub?
         )
       end
 

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -91,12 +91,16 @@ module Pharos
         target
       end
 
+      # Returns an array of lines in the remote file
+      # @return [Array<String>]
+      def lines
+        read.lines
+      end
+
       # Yields each line in the remote file
       # @yield [String]
-      def each_line
-        read.split(/[\r\n]/).each do |row|
-          yield row
-        end
+      def each_line(&block)
+        read.each_line(&block)
       end
 
       private

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -8,7 +8,7 @@ require_relative "pharos/error"
 require_relative "pharos/root_command"
 
 module Pharos
-  CRIO_VERSION = '1.11.3'
+  CRIO_VERSION = '1.11.6'
   KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.11.3' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.2.18' }

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
-  spec.add_runtime_dependency "k8s-client", "~> 0.3.2"
+  spec.add_runtime_dependency "k8s-client", "~> 0.3.3"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
-  spec.add_runtime_dependency "k8s-client", "~> 0.3.3"
+  spec.add_runtime_dependency "k8s-client", "~> 0.3.4"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/pharos/kube_stack_spec.rb
+++ b/spec/pharos/kube_stack_spec.rb
@@ -21,37 +21,19 @@ describe Pharos::Kube::Stack do
       ]
     end
 
-    context "when not yet installed" do
-      let(:resource) {
-        K8s::Resource.new(
-          apiVersion: 'v1',
-          kind: 'ConfigMap',
-          metadata: {
+    it "labels resources with the correct label and annotation" do
+      expect(described_class::LABEL).to eq 'pharos.kontena.io/stack'
+
+      expect(subject.resources.map{|r| subject.prepare_resource(r).to_hash}).to match [
+        hash_including(
+          metadata: hash_including(
             namespace: 'default',
             name: 'test',
-            labels: {
-              'pharos.kontena.io/stack': 'test',
-            },
-            annotations: {
-              'pharos.kontena.io/stack-checksum': subject.checksum,
-            }
-          },
-          data: {
-            'foo' => 'bar',
-          }
-        )
-      }
-
-      before do
-        allow(client).to receive(:get_resources).with([K8s::Resource]).and_return([nil])
-        allow(client).to receive(:list_resources).with(labelSelector: { 'pharos.kontena.io/stack' => 'test' }).and_return([resource])
-      end
-
-      it "creates the resource with the correct label" do
-        expect(client).to receive(:create_resource).with(resource).and_return(resource)
-
-        subject.apply(client)
-      end
+            labels: { :'pharos.kontena.io/stack' => 'test' },
+            annotations: { :'pharos.kontena.io/stack-checksum' => subject.checksum },
+          ),
+        ),
+      ]
     end
   end
 end

--- a/spec/pharos/phases/gather_facts_spec.rb
+++ b/spec/pharos/phases/gather_facts_spec.rb
@@ -53,22 +53,18 @@ describe Pharos::Phases::GatherFacts do
   end
 
   describe '#get_resolvconf' do
-    let(:file) { instance_double(Pharos::SSH::RemoteFile) }
+    let(:file) { instance_double Pharos::SSH::RemoteFile }
+    let(:file_content) { "" }
     let(:file_readlink) { nil }
 
     before do
       allow(ssh).to receive(:file).with('/etc/resolv.conf').and_return(file)
-
-      mock = allow(file).to receive(:each_line)
-      file_lines.each do |line|
-        mock = mock.and_yield(line)
-      end
-
+      allow(file).to receive(:lines).and_return(file_content.lines)
       allow(file).to receive(:readlink).and_return(file_readlink)
     end
 
     context 'for a normal resolv.conf' do
-      let(:file_lines) { ['nameserver 8.8.8.8'] }
+      let(:file_content) { "# nameserver config\nnameserver 8.8.8.8\n" }
 
       it 'returns ok' do
         expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
@@ -79,7 +75,18 @@ describe Pharos::Phases::GatherFacts do
     end
 
     context 'for a normal resolv.conf with localhost' do
-      let(:file_lines) { ['nameserver 127.0.0.53'] }
+      let(:file_content) { "nameserver 127.0.0.53" }
+
+      it 'returns nameserver_localhost' do
+        expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
+          nameserver_localhost: true,
+          systemd_resolved_stub: false,
+        )
+      end
+    end
+
+    context 'for a normal resolv.conf with ipv6 localhost' do
+      let(:file_content) { "nameserver ::1" }
 
       it 'returns nameserver_localhost' do
         expect(subject.read_resolvconf).to eq Pharos::Configuration::Host::ResolvConf.new(
@@ -90,7 +97,7 @@ describe Pharos::Phases::GatherFacts do
     end
 
     context 'for a systemd-resolved resolv.conf stub' do
-      let(:file_lines) { ['nameserver 127.0.0.53'] }
+      let(:file_content) { "nameserver 127.0.0.53" }
       let(:file_readlink) { '../run/systemd/resolve/stub-resolv.conf' }
 
       it 'returns systemd_resolved_stub' do
@@ -102,7 +109,7 @@ describe Pharos::Phases::GatherFacts do
     end
 
     context 'for a non-resolved resolv.conf symlink' do
-      let(:file_lines) { ['nameserver 8.8.8.8'] }
+      let(:file_content) { "nameserver 8.8.8.8" }
       let(:file_readlink) { '/run/resolvconf/resolv.conf' }
 
       it 'returns ok' do


### PR DESCRIPTION
## Changes since v1.3.2

- cri-o v1.11.6 (#637)
- fix binary build temporary path (#621)
- retry addon on error with backoff (#628)
- fix kube client host usage (#567, #632)
- fix /etc/resolv.conf parser comment handling (#615)
- fix kubernetes dashboard addon first run timing issue (#631)
- k8s-client 0.3.4 (#640)
- fix 503 error in metrics-server setup (#639)