### PR TITLE
cri-o v1.11.6

### DIFF
--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -8,7 +8,7 @@ require_relative "pharos/error"
 require_relative "pharos/root_command"
 
 module Pharos
-  CRIO_VERSION = '1.11.3'
+  CRIO_VERSION = '1.11.6'
   KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.11.3' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.2.18' }


### PR DESCRIPTION
Bumps cri-o version from 1.11.3 to 1.11.6.

- https://github.com/kubernetes-sigs/cri-o/releases/tag/v1.11.4
- https://github.com/kubernetes-sigs/cri-o/releases/tag/v1.11.5
- https://github.com/kubernetes-sigs/cri-o/releases/tag/v1.11.6