### PR TITLE
Fix stack loading to ignore empty resources

### DIFF
--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -29,6 +29,9 @@ module Pharos
         files = Pathname.glob(path.join('*.{yml,yaml,yml.erb,yaml.erb}')).sort_by(&:to_s)
         resources = files.map do |file|
           K8s::Resource.new(Pharos::YamlFile.new(file).load(name: name, **vars))
+        end.select do |r|
+          # Take in only resources that are valid kube resources
+          r.kind && r.apiVersion
         end
 
         new(name, resources)

--- a/spec/fixtures/stacks/empty/test.yml
+++ b/spec/fixtures/stacks/empty/test.yml
@@ -1,0 +1,8 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test
+  namespace: default
+data:
+  foo: bar

--- a/spec/pharos/kube_stack_spec.rb
+++ b/spec/pharos/kube_stack_spec.rb
@@ -36,4 +36,18 @@ describe Pharos::Kube::Stack do
       ]
     end
   end
+
+  context "stack with empty resources" do
+    let(:client) { instance_double(K8s::Client) }
+
+    subject do
+      described_class.load('test', fixtures_path('stacks/empty'))
+    end
+
+    it "ignores empty resources during stack loading" do
+      expect(subject.resources.size).to eq(1)
+      expect(subject.resources.first.kind).not_to be_nil
+      expect(subject.resources.first.apiVersion).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
In some cases we might want to render resources templates as empty, to completely skip those. Currently the template loader loads these as "empty" `K8s::Resource`s making things fail miserably.