### PR TITLE
Add default worker label if none given by user

### DIFF
--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -80,6 +80,12 @@ module Pharos
         private_address || private_interface_address || address
       end
 
+      def labels
+        return @attributes[:labels] unless worker?
+
+        @attributes[:labels] || { 'node-role.kubernetes.io/worker': "" }
+      end
+
       def kubelet_args(local_only: false, cloud_provider: nil)
         args = []
 

--- a/spec/pharos/configuration/host_spec.rb
+++ b/spec/pharos/configuration/host_spec.rb
@@ -10,6 +10,56 @@ describe Pharos::Configuration::Host do
     )
   end
 
+  describe '#labels' do
+    context 'for master' do
+      it 'returns empty labels by default' do
+        subject = described_class.new(
+          address: '192.168.100.100',
+          role: 'master',
+          user: 'root'
+        )
+        expect(subject.labels).to eq(nil)
+      end
+
+      it 'returns given labels' do
+        subject = described_class.new(
+          address: '192.168.100.100',
+          role: 'master',
+          user: 'root',
+          labels: {
+            foo: 'bar',
+            baz: 'baf'
+          }
+        )
+        expect(subject.labels).to eq({foo: 'bar', baz: 'baf'})
+      end
+    end
+
+    context 'for worker' do
+      it 'returns given labels' do
+        subject = described_class.new(
+          address: '192.168.100.100',
+          role: 'worker',
+          user: 'root',
+          labels: {
+            foo: 'bar',
+            baz: 'baf'
+          }
+        )
+        expect(subject.labels).to eq({foo: 'bar', baz: 'baf'})
+      end
+
+      it 'returns default worker label' do
+        subject = described_class.new(
+          address: '192.168.100.100',
+          role: 'worker',
+          user: 'root'
+        )
+        expect(subject.labels).to eq({ 'node-role.kubernetes.io/worker': "" })
+      end
+    end
+  end
+
   describe '#short_hostname' do
     let(:hostname) { nil }
 


### PR DESCRIPTION
```
$ kubectl get node
NAME              STATUS    ROLES     AGE       VERSION
pharos-master-0   Ready     master    2d        v1.11.3
pharos-master-1   Ready     master    2d        v1.11.3
pharos-master-2   Ready     master    2d        v1.11.3
pharos-worker-0   Ready     <none>    2d        v1.11.3
pharos-worker-1   Ready     <none>    2d        v1.11.3
pharos-worker-2   Ready     <none>    2d        v1.11.3
```

After re-upping:
```
$ kubectl get node
NAME              STATUS    ROLES     AGE       VERSION
pharos-master-0   Ready     master    2d        v1.11.3
pharos-master-1   Ready     master    2d        v1.11.3
pharos-master-2   Ready     master    2d        v1.11.3
pharos-worker-0   Ready     worker    2d        v1.11.3
pharos-worker-1   Ready     worker    2d        v1.11.3
pharos-worker-2   Ready     worker    2d        v1.11.3
```

fixes #612 