### PR TITLE
Add support for enabling/disabling admission plugins

### DIFF
--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -11,6 +11,7 @@ require_relative 'configuration/audit'
 require_relative 'configuration/kube_proxy'
 require_relative 'configuration/kubelet'
 require_relative 'configuration/telemetry'
+require_relative 'configuration/admission_plugin'
 
 module Pharos
   class Config < Pharos::Configuration::Struct
@@ -46,6 +47,7 @@ module Pharos
     attribute :image_repository, Pharos::Types::String.default('quay.io/kontena')
     attribute :addon_paths, Pharos::Types::Array.default([])
     attribute :addons, Pharos::Types::Hash.default({})
+    attribute :admission_plugins, Types::Coercible::Array.of(Pharos::Configuration::AdmissionPlugin)
 
     attr_accessor :data
 

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -118,6 +118,14 @@ module Pharos
           optional(:enabled).filled(:bool?)
         end
         optional(:image_repository).filled(:str?)
+        optional(:admission_plugins).filled do
+          each do
+            schema do
+              required(:name).filled(:str?)
+              optional(:enabled).filled(:bool?)
+            end
+          end
+        end
 
         validate(network_dns_replicas: [:network, :hosts]) do |network, hosts|
           if network && network[:dns_replicas]

--- a/lib/pharos/configuration/admission_plugin.rb
+++ b/lib/pharos/configuration/admission_plugin.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Configuration
+    class AdmissionPlugin < Pharos::Configuration::Struct
+      attribute :name, Pharos::Types::String
+      attribute :enabled, Pharos::Types::Bool.default(true)
+    end
+  end
+end

--- a/lib/pharos/kubeadm.rb
+++ b/lib/pharos/kubeadm.rb
@@ -257,8 +257,8 @@ module Pharos
       end
 
       def configure_admission_plugins(config)
-        enabled_plugins = @config.admission_plugins.select {|ap| ap.enabled }.map{|ap| ap.name }
-        disabled_plugins = @config.admission_plugins.select {|ap| !ap.enabled }.map{|ap| ap.name }
+        enabled_plugins = @config.admission_plugins.select(&:enabled).map(&:name)
+        disabled_plugins = @config.admission_plugins.reject(&:enabled).map(&:name)
 
         config['apiServerExtraArgs']['enable-admission-plugins'] = enabled_plugins.join(',') unless enabled_plugins.empty?
         config['apiServerExtraArgs']['disable-admission-plugins'] = disabled_plugins.join(',') unless disabled_plugins.empty?

--- a/lib/pharos/kubeadm.rb
+++ b/lib/pharos/kubeadm.rb
@@ -91,6 +91,8 @@ module Pharos
 
         configure_kube_proxy(config) if @config.kube_proxy
 
+        configure_admission_plugins(config) if @config.admission_plugins
+
         # Set secrets config location and mount it to api server
         config['apiServerExtraArgs']['experimental-encryption-provider-config'] = SECRETS_CFG_FILE
         config['apiServerExtraVolumes'] << {
@@ -252,6 +254,14 @@ module Pharos
         end
 
         config
+      end
+
+      def configure_admission_plugins(config)
+        enabled_plugins = @config.admission_plugins.select {|ap| ap.enabled }.map{|ap| ap.name }
+        disabled_plugins = @config.admission_plugins.select {|ap| !ap.enabled }.map{|ap| ap.name }
+
+        config['apiServerExtraArgs']['enable-admission-plugins'] = enabled_plugins.join(',') unless enabled_plugins.empty?
+        config['apiServerExtraArgs']['disable-admission-plugins'] = disabled_plugins.join(',') unless disabled_plugins.empty?
       end
     end
   end

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -258,4 +258,10 @@ describe Pharos::Config do
       end
     end
   end
+
+  describe 'admission_plugins' do
+    it 'returns empty plugins by default' do
+      expect(subject.admission_plugins).to be_nil
+    end
+  end
 end

--- a/spec/pharos/kubeadm_spec.rb
+++ b/spec/pharos/kubeadm_spec.rb
@@ -278,7 +278,7 @@ describe Pharos::Kubeadm::ConfigGenerator do
 
         it 'configures enabled plugins to api server' do
           extra_args = subject.generate_config['apiServerExtraArgs']
-          expect(extra_args['enable-admission-plugins']).to eq('PodSecurityPolicy,AlwaysPullImages')
+          expect(extra_args['enable-admission-plugins']).to eq('PodSecurityPolicy,NodeRestriction,AlwaysPullImages')
           expect(extra_args['disable-admission-plugins']).to eq('Priority')
         end
       end
@@ -289,9 +289,12 @@ describe Pharos::Kubeadm::ConfigGenerator do
           network: {}
         ) }
 
-        it 'configures enabled plugins to api server' do
+        it 'configures default plugins to api server' do
           extra_args = subject.generate_config['apiServerExtraArgs']
-          expect(extra_args.has_key?('enable-admission-plugins')).to be_falsey
+          expect(extra_args.has_key?('enable-admission-plugins')).to be_truthy
+          plugins = extra_args['enable-admission-plugins'].split(',')
+          expect(plugins).to include('PodSecurityPolicy')
+          expect(plugins).to include('NodeRestriction')
           expect(extra_args.has_key?('disable-admission-plugins')).to be_falsey
         end
       end
@@ -303,9 +306,12 @@ describe Pharos::Kubeadm::ConfigGenerator do
           admission_plugins: []
         ) }
 
-        it 'configures enabled plugins to api server' do
+        it 'configures default plugins to api server' do
           extra_args = subject.generate_config['apiServerExtraArgs']
-          expect(extra_args.has_key?('enable-admission-plugins')).to be_falsey
+          expect(extra_args.has_key?('enable-admission-plugins')).to be_truthy
+          plugins = extra_args['enable-admission-plugins'].split(',')
+          expect(plugins).to include('PodSecurityPolicy')
+          expect(plugins).to include('NodeRestriction')
           expect(extra_args.has_key?('disable-admission-plugins')).to be_falsey
         end
       end
@@ -322,7 +328,7 @@ describe Pharos::Kubeadm::ConfigGenerator do
 
         it 'configures enabled plugins to api server' do
           extra_args = subject.generate_config['apiServerExtraArgs']
-          expect(extra_args['enable-admission-plugins']).to eq('PodSecurityPolicy,AlwaysPullImages')
+          expect(extra_args['enable-admission-plugins']).to eq('PodSecurityPolicy,NodeRestriction,AlwaysPullImages')
           expect(extra_args.has_key?('disable-admission-plugins')).to be_falsey
         end
       end
@@ -337,10 +343,11 @@ describe Pharos::Kubeadm::ConfigGenerator do
           ]
         ) }
 
-        it 'configures enabled plugins to api server' do
+        it 'configures correct plugins to api server' do
           extra_args = subject.generate_config['apiServerExtraArgs']
           expect(extra_args['disable-admission-plugins']).to eq('PodSecurityPolicy,AlwaysPullImages')
-          expect(extra_args.has_key?('enable-admission-plugins')).to be_falsey
+          expect(extra_args.has_key?('enable-admission-plugins')).to be_truthy
+          expect(extra_args['enable-admission-plugins']).to eq('NodeRestriction')
         end
       end
     end


### PR DESCRIPTION
fixes #644 

Introduces new top-level config key `admission_plugins` and can be used like:
```
admission_plugins:
  - name: AlwaysPullImages
    enabled: true
  - name: LimitRanger
    enabled: false
```

This now supports the cases where user can enable those plugins that do **NOT** require any additional config files in place. For those we can later add something like `config_path` key to upload the given config file in place.

I used `admission plugin` as the term, kube docs seems to use both `admission controller` and `admission plugin` pretty inconsistently.