### PR TITLE
Add "environment:" host config to update /etc/environment

### DIFF
--- a/cluster.example.yml
+++ b/cluster.example.yml
@@ -17,6 +17,9 @@ hosts:
     container_runtime: cri-o
     labels:
       disk: ssd
+    environment:
+      http_proxy: proxy.example.com
+      NO_PROXY: 10.*
 network:
   dns_replicas: 3
   service_cidr: 10.96.0.0/12

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -55,7 +55,7 @@ module Pharos
               optional(:user).filled
               optional(:ssh_key_path).filled
               optional(:container_runtime).filled(included_in?: ['docker', 'cri-o'])
-              optional(:http_proxy).filled(:str?)
+              optional(:environment).filled
             end
           end
         end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -58,7 +58,7 @@ module Pharos
       attribute :user, Pharos::Types::Strict::String
       attribute :ssh_key_path, Pharos::Types::Strict::String
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
-      attribute :http_proxy, Pharos::Types::Strict::String
+      attribute :environment, Pharos::Types::Strict::Hash
 
       attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks, :resolvconf, :routes
 

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -116,7 +116,7 @@ module Pharos
           end.to_h
         end
 
-        new_content = original_data.merge(@host.environment) { |_new_val, old_val| old_val }.compact.map do |key, val|
+        new_content = original_data.merge(@host.environment) { |_key, old_val, _new_val| old_val }.compact.map do |key, val|
           "#{key}=#{val}"
         end.join("\n") + "\n"
 

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -116,8 +116,7 @@ module Pharos
           end.to_h
         end
 
-        new_content = original_data.merge(@host.environment).compact.map do |key, val|
-          next if val.nil?;
+        new_content = original_data.merge(@host.environment) { |new_val, old_val| old_val }.compact.map do |key, val|
           "#{key}=#{val}"
         end.join("\n") + "\n"
 

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -107,18 +107,19 @@ module Pharos
         host_env_file = env_file
         original_data = {}
         if host_env_file.exist?
-          original_data = host_env_file.read.lines.map do |line|
+          host_env_file.read.lines.each do |line|
             line.strip!
             next if line.start_with?('#')
             key, val = line.split('=', 2)
             val = nil if val.to_s.empty?
-            [key, val]
-          end.to_h
+            original_data[key] = val
+          end
         end
 
-        new_content = original_data.merge(@host.environment) { |_key, old_val, _new_val| old_val }.compact.map do |key, val|
+        new_content = @host.environment.merge(original_data) { |_key, old_val, _new_val| old_val }.compact.map do |key, val|
           "#{key}=#{val}"
-        end.join("\n") + "\n"
+        end.join("\n")
+        new_content << "\n" unless new_content.end_with?("\n")
 
         host_env_file.write(new_content)
         @ssh.disconnect; @ssh.connect # reconnect to reread env

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -105,6 +105,7 @@ module Pharos
         return if @host.environment.nil? || @host.environment.empty?
 
         host_env_file = env_file
+        original_data = {}
         if host_env_file.exist?
           original_data = host_env_file.read.lines.map do |line|
             line.strip!
@@ -113,8 +114,6 @@ module Pharos
             val = nil if val.to_s.empty?
             [key, val]
           end.to_h
-        else
-          original_data = {}
         end
 
         new_content = original_data.merge(@host.environment).compact.map do |key, val|

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -116,7 +116,7 @@ module Pharos
           end.to_h
         end
 
-        new_content = original_data.merge(@host.environment) { |new_val, old_val| old_val }.compact.map do |key, val|
+        new_content = original_data.merge(@host.environment) { |_new_val, old_val| old_val }.compact.map do |key, val|
           "#{key}=#{val}"
         end.join("\n") + "\n"
 

--- a/lib/pharos/host/el7/el7.rb
+++ b/lib/pharos/host/el7/el7.rb
@@ -13,11 +13,7 @@ module Pharos
       end
 
       def install_essentials
-        exec_script(
-          'configure-essentials.sh',
-          HTTP_PROXY: host.http_proxy.to_s,
-          SET_HTTP_PROXY: host.http_proxy.nil? ? 'false' : 'true'
-        )
+        exec_script('configure-essentials.sh')
       end
 
       def configure_repos

--- a/lib/pharos/host/el7/scripts/configure-essentials.sh
+++ b/lib/pharos/host/el7/scripts/configure-essentials.sh
@@ -43,16 +43,6 @@ if ! grep -q "/usr/local/bin" $env_file ; then
     echo "PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin" >> $env_file
 fi
 
-if [ "${SET_HTTP_PROXY}" = "true" ]; then
-    lineinfile "^http_proxy=" "http_proxy=${HTTP_PROXY}" $env_file
-    lineinfile "^HTTP_PROXY=" "HTTP_PROXY=${HTTP_PROXY}" $env_file
-    lineinfile "^HTTPS_PROXY=" "HTTPS_PROXY=${HTTP_PROXY}" $env_file
-else
-    linefromfile "^http_proxy=" $env_file
-    linefromfile "^HTTP_PROXY=" $env_file
-    linefromfile "^HTTPS_PROXY=" $env_file
-fi
-
 if [ ! "$(getenforce)" = "Disabled" ]; then
     setenforce 0 || true
     lineinfile "^SELINUX=" "SELINUX=permissive" "/etc/selinux/config"

--- a/lib/pharos/host/ubuntu/scripts/configure-essentials.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-essentials.sh
@@ -4,18 +4,6 @@ set -e
 
 . /usr/local/share/pharos/util.sh
 
-env_file="/etc/environment"
-
-if [ "${SET_HTTP_PROXY}" = "true" ]; then
-    lineinfile "^http_proxy=" "http_proxy=${HTTP_PROXY}" $env_file
-    lineinfile "^HTTP_PROXY=" "HTTP_PROXY=${HTTP_PROXY}" $env_file
-    lineinfile "^HTTPS_PROXY=" "HTTPS_PROXY=${HTTP_PROXY}" $env_file
-else
-    linefromfile "^http_proxy=" $env_file
-    linefromfile "^HTTP_PROXY=" $env_file
-    linefromfile "^HTTPS_PROXY=" $env_file
-fi
-
 if ! dpkg -l apt-transport-https software-properties-common > /dev/null; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -y

--- a/lib/pharos/host/ubuntu/ubuntu.rb
+++ b/lib/pharos/host/ubuntu/ubuntu.rb
@@ -4,11 +4,7 @@ module Pharos
   module Host
     class Ubuntu < Configurer
       def install_essentials
-        exec_script(
-          'configure-essentials.sh',
-          HTTP_PROXY: host.http_proxy.to_s,
-          SET_HTTP_PROXY: host.http_proxy.nil? ? 'false' : 'true'
-        )
+        exec_script('configure-essentials.sh')
       end
 
       def configure_repos

--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -6,6 +6,11 @@ module Pharos
       title "Configure hosts"
 
       def call
+        unless @host.environment.nil? || @host.environment.empty?
+          logger.info { "Updating environment file ..." }
+          host_configurer.update_env_file
+        end
+
         logger.info { "Configuring script helpers ..." }
         host_configurer.configure_script_library
 

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -9,7 +9,7 @@ describe Pharos::Host::Configurer do
   let(:ssh) { double(:ssh) }
   let(:subject) { described_class.new(host, ssh) }
 
-  describe '.register_config' do
+  describe '#register_config' do
     it 'sets os_name and os_version' do
       expect(test_config_class.os_name).to eq('test')
       expect(test_config_class.os_version).to eq('1.1.0')
@@ -21,7 +21,7 @@ describe Pharos::Host::Configurer do
     end
   end
 
-  describe '.supported_os?' do
+  describe '#supported_os?' do
     it 'returns true if supported' do
       expect(
         test_config_class.supported_os?(
@@ -36,6 +36,51 @@ describe Pharos::Host::Configurer do
           double(:os_release, id: test_config_class.os_name, version: '1.2.0')
         )
       ).to be_falsey
+    end
+  end
+
+  describe '#update_env_file' do
+    let(:host) { instance_double(Pharos::Configuration::Host) }
+    let(:ssh) { instance_double(Pharos::SSH::Client) }
+    let(:file) { instance_double(Pharos::SSH::RemoteFile) }
+    let(:host_env_content) { "PATH=/bin:/usr/local/bin\n" }
+
+    subject { described_class.new(host, ssh) }
+
+    before do
+      allow(ssh).to receive(:file).with('/etc/environment').and_return(file)
+      allow(ssh).to receive(:disconnect)
+      allow(ssh).to receive(:connect)
+      allow(file).to receive(:exist?).and_return(true)
+      allow(file).to receive(:read).and_return(host_env_content)
+      allow(host).to receive(:environment).and_return(config_environment)
+    end
+
+    context 'add keys' do
+      let(:config_environment) { { 'TEST' => 'foo' } }
+
+      it 'adds a line to /etc/environment' do
+        expect(file).to receive(:write).with("TEST=foo\nPATH=/bin:/usr/local/bin\n")
+        subject.update_env_file
+      end
+    end
+
+    context 'modify keys' do
+      let(:config_environment) { { 'PATH' => '/bin' } }
+
+      it 'modifies a line in /etc/environment' do
+        expect(file).to receive(:write).with("PATH=/bin\n")
+        subject.update_env_file
+      end
+    end
+
+    context 'delete keys' do
+      let(:config_environment) { { 'PATH' => nil } }
+
+      it 'removes a line in /etc/environment' do
+        expect(file).to receive(:write).with("\n")
+        subject.update_env_file
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #587 

Removes the host `proxy:` configuration and replaces it with a generic "environment:" configuration for updating `/etc/environment`.

When setting the `http_proxy`, you should usually also set the uppercase `HTTP_PROXY` since some programs use one and some the other.

This also enables the use of `NO_PROXY` as requested in #587 and separately resolved in #611 

To remove an entry from `/etc/environment` set a null value:

```yaml
hosts:
  - address: 127.0.0.1
     environment:
       PATH: null # or leave blank
```


