### PR TITLE
Switch to multi-arch compatible image registry

### DIFF
--- a/addons/cert-manager/resources/deployment.yml.erb
+++ b/addons/cert-manager/resources/deployment.yml.erb
@@ -13,14 +13,14 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v<%= version %>"
+          image: "<%= image_repository %>/cert-manager-controller:v<%= version %>"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 10m
               memory: 32Mi
         - name: ingress-shim
-          image: "quay.io/jetstack/cert-manager-ingress-shim:v<%= version %>"
+          image: "<%= image_repository %>/cert-manager-ingress-shim:v<%= version %>"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/addons/helm/resources/deployment.yml.erb
+++ b/addons/helm/resources/deployment.yml.erb
@@ -20,7 +20,7 @@ spec:
           value: kube-system
         - name: TILLER_HISTORY_MAX
           value: "10"
-        image: gcr.io/kubernetes-helm/tiller:v<%= version %>
+        image: <%= image_repository %>/tiller:v<%= version %>
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/addons/host-upgrades/resources/50-daemonset.yml.erb
+++ b/addons/host-upgrades/resources/50-daemonset.yml.erb
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: host-upgrades
       containers:
         - name: host-upgrades
-          image: "quay.io/kontena/pharos-host-upgrades-<%= arch.name %>:<%= version %>"
+          image: "<%= image_repository %>/pharos-host-upgrades:<%= version %>"
           imagePullPolicy: IfNotPresent
           command:
             - pharos-host-upgrades

--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -24,6 +24,7 @@ Pharos.addon 'ingress-nginx' do
     apply_resources(
       configmap: config.configmap || {},
       node_selector: config.node_selector || {},
+      default_backend_image: config.default_backend['image'],
       default_backend_replicas: default_backend_replicas
     )
   }

--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -22,23 +22,9 @@ Pharos.addon 'ingress-nginx' do
     apply_resources(
       configmap: config.configmap || {},
       node_selector: config.node_selector || {},
-      image: image_name,
       default_backend_replicas: default_backend_replicas
     )
   }
-
-  DEFAULT_BACKEND_ARM64_IMAGE = 'docker.io/kontena/pharos-default-backend-arm64:0.0.2'
-  DEFAULT_BACKEND_IMAGE = 'docker.io/kontena/pharos-default-backend:0.0.2'
-
-  def image_name
-    return config.default_backend[:image] if config.default_backend&.dig(:image)
-
-    if cpu_arch.name == 'arm64'
-      DEFAULT_BACKEND_ARM64_IMAGE
-    else
-      DEFAULT_BACKEND_IMAGE
-    end
-  end
 
   # ~One replica per 10 workers, min 2
   # @return [Integer]

--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -7,9 +7,9 @@ Pharos.addon 'ingress-nginx' do
   config {
     attribute :configmap, Pharos::Types::Hash
     attribute :node_selector, Pharos::Types::Hash
-    attribute :default_backend, Pharos::Types::Hash.default({
+    attribute :default_backend, Pharos::Types::Hash.default(
       'image' => 'registry.pharos.sh/kontenapharos/pharos-default-backend:0.0.3'
-    })
+    )
   }
 
   config_schema {

--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -7,7 +7,9 @@ Pharos.addon 'ingress-nginx' do
   config {
     attribute :configmap, Pharos::Types::Hash
     attribute :node_selector, Pharos::Types::Hash
-    attribute :default_backend, Pharos::Types::Hash
+    attribute :default_backend, Pharos::Types::Hash.default({
+      'image' => 'registry.pharos.sh/kontenapharos/pharos-default-backend:0.0.3'
+    })
   }
 
   config_schema {

--- a/addons/ingress-nginx/resources/daemonset.yml.erb
+++ b/addons/ingress-nginx/resources/daemonset.yml.erb
@@ -37,7 +37,7 @@ spec:
           privileged: true
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller-<%= arch.name %>:<%= version %>
+          image: <%= image_repository %>/nginx-ingress-controller:<%= version %>
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/addons/ingress-nginx/resources/daemonset.yml.erb
+++ b/addons/ingress-nginx/resources/daemonset.yml.erb
@@ -30,7 +30,7 @@ spec:
         - sh
         - -c
         - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range="1024 65535"
-        image: "docker.io/<%= arch.name == 'amd64' ? 'alpine' : 'arm64v8/alpine' %>:3.6"
+        image: "<%= image_repository %>/alpine:3.6"
         imagePullPolicy: IfNotPresent
         name: sysctl
         securityContext:

--- a/addons/ingress-nginx/resources/default-backend.yml.erb
+++ b/addons/ingress-nginx/resources/default-backend.yml.erb
@@ -33,7 +33,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: <%= image_repository %>/pharos-default-backend:0.0.3
+        image: <%= default_backend_image %>
         livenessProbe:
           httpGet:
             path: /healthz

--- a/addons/ingress-nginx/resources/default-backend.yml.erb
+++ b/addons/ingress-nginx/resources/default-backend.yml.erb
@@ -33,7 +33,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: <%= image %>
+        image: <%= image_repository %>/pharos-default-backend:0.0.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/addons/openebs/resources/10-api-server-deployment.yml.erb
+++ b/addons/openebs/resources/10-api-server-deployment.yml.erb
@@ -14,15 +14,15 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: docker.io/openebs/m-apiserver:<%= version %>
+        image: <%= image_repository %>/openebs-m-apiserver:<%= version %>
         ports:
         - containerPort: 5656
         env:
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "docker.io/openebs/jiva:<%= version %>"
+          value: "<%= image_repository %>/openebs-jiva:<%= version %>"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "docker.io/openebs/jiva:<%= version %>"
+          value: "<%= image_repository %>/openebs-jiva:<%= version %>"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "docker.io/openebs/m-exporter:<%= version %>"
+          value: "<%= image_repository %>/openebs-m-exporter:<%= version %>"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "<%= default_replicas %>"

--- a/addons/openebs/resources/12-provisioner-deployment.yml.erb
+++ b/addons/openebs/resources/12-provisioner-deployment.yml.erb
@@ -14,7 +14,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: docker.io/openebs/openebs-k8s-provisioner:<%= version %>
+        image: <%= image_repository %>/openebs-k8s-provisioner:<%= version %>
         env:
         - name: NODE_NAME
           valueFrom:

--- a/addons/openebs/resources/12-provisioner-deployment.yml.erb
+++ b/addons/openebs/resources/12-provisioner-deployment.yml.erb
@@ -14,7 +14,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: <%= image_repository %>/openebs-k8s-provisioner:<%= version %>
+        image: <%= image_repository %>/openebs-openebs-k8s-provisioner:<%= version %>
         env:
         - name: NODE_NAME
           valueFrom:

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -198,6 +198,7 @@ module Pharos
         version: self.class.version,
         config: config,
         arch: cpu_arch,
+        image_repository: cluster_config.image_repository,
         **vars
       )
     end

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -43,7 +43,7 @@ module Pharos
     attribute :audit, Pharos::Configuration::Audit
     attribute :kubelet, Pharos::Configuration::Kubelet
     attribute :telemetry, Pharos::Configuration::Telemetry
-    attribute :image_repository, Pharos::Types::String.default('quay.io/kontena')
+    attribute :image_repository, Pharos::Types::String.default('registry.pharos.sh/kontenapharos')
     attribute :addon_paths, Pharos::Types::Array.default([])
     attribute :addons, Pharos::Types::Hash.default({})
 

--- a/lib/pharos/phases/configure_dns.rb
+++ b/lib/pharos/phases/configure_dns.rb
@@ -86,14 +86,6 @@ module Pharos
             }
           }
         }
-        if @host.cpu_arch.name != 'amd64'
-          spec[:template][:spec][:containers] = [
-            {
-              name: 'coredns',
-              image: "#{@config.image_repository}/coredns-#{@host.cpu_arch.name}:#{Pharos::COREDNS_VERSION}"
-            }
-          ]
-        end
         kube_resource_client.merge_patch(
           name,
           spec: spec

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -111,7 +111,7 @@ module Pharos
         end
 
         args << "--authentication-token-webhook=true"
-        args << "--pod-infra-container-image=#{@config.image_repository}/pause-#{@host.cpu_arch.name}:3.1"
+        args << "--pod-infra-container-image=#{@config.image_repository}/pause:3.1"
         args << "--cloud-provider=#{@config.cloud.provider}" if @config.cloud
         args << "--cloud-config=#{CLOUD_CONFIG_FILE}" if @config.cloud&.config
         args

--- a/lib/pharos/phases/configure_telemetry.rb
+++ b/lib/pharos/phases/configure_telemetry.rb
@@ -12,6 +12,7 @@ module Pharos
           logger.info { "Configuring telemetry service ..." }
           apply_stack(
             'telemetry',
+            version: Pharos::TELEMETRY_VERSION,
             image_repository: @config.image_repository,
             arch: @host.cpu_arch,
             customer_token: Base64.strict_encode64(customer_token)

--- a/lib/pharos/phases/upgrade_master.rb
+++ b/lib/pharos/phases/upgrade_master.rb
@@ -36,50 +36,11 @@ module Pharos
         logger.info { "Upgrading control plane ..." }
         logger.debug { cfg.to_yaml }
 
-        dns_patch_thread = create_dns_patch_thread if dns_patch_needed?
         @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
           @ssh.exec!("sudo /usr/local/bin/pharos-kubeadm-#{Pharos::KUBEADM_VERSION} upgrade apply #{Pharos::KUBE_VERSION} -y --ignore-preflight-errors=all --allow-experimental-upgrades --config #{tmp_file}")
         end
-        dns_patch_thread.join if dns_patch_needed?
 
         logger.info { "Control plane upgrade succeeded!" }
-      end
-
-      def dns_patch_needed?
-        @host.cpu_arch.name != 'amd64'
-      end
-
-      # Hack to make coredns work without multi-arch enabled image repository
-      #
-      # @param wait [Integer]
-      # @return [Thread]
-      def create_dns_patch_thread(wait = 5)
-        deployments_client = kube_client.api('extensions/v1beta1').resource('deployments', namespace: 'kube-system')
-        Thread.new {
-          begin
-            sleep wait
-            deployments_client.merge_patch(
-              'coredns',
-              spec: {
-                template: {
-                  spec: {
-                    containers: [
-                      {
-                        name: 'coredns',
-                        image: "#{@config.image_repository}/coredns-#{@host.cpu_arch.name}:#{Pharos::COREDNS_VERSION}"
-                      }
-                    ]
-                  }
-                }
-              }
-            )
-            logger.debug { "CoreDNS patch succeeded!" }
-          rescue StandardError => exc
-            logger.debug { "CoreDNS patch failed (will retry after #{wait} secs): #{exc.message}" }
-            sleep wait
-            retry
-          end
-        }
       end
     end
   end

--- a/lib/pharos/resources/metrics-server/metrics-server-deployment.yml.erb
+++ b/lib/pharos/resources/metrics-server/metrics-server-deployment.yml.erb
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: <%= image_repository %>/metrics-server-<%= arch.name %>:v<%= version %>
+        image: <%= image_repository %>/metrics-server:v<%= version %>
         imagePullPolicy: IfNotPresent
         command:
         - /metrics-server

--- a/lib/pharos/resources/telemetry/cronjob.yml.erb
+++ b/lib/pharos/resources/telemetry/cronjob.yml.erb
@@ -14,8 +14,8 @@ spec:
           restartPolicy: Never
           containers:
           - name: agent
-            image: <%= image_repository %>/pharos-telemetry-<%= arch.name %>:latest
-            args: 
+            image: <%= image_repository %>/pharos-telemetry:<%= version %>
+            args:
             - --run-once
             env:
             - name: CUSTOMER_TOKEN

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -38,7 +38,7 @@ spec:
                 secretKeyRef:
                   name: weave-passwd
                   key: weave-passwd
-          image: '<%= image_repository %>/weave-kube-<%= arch.name %>:<%= version %>'
+          image: '<%= image_repository %>/weave-kube:<%= version %>'
           livenessProbe:
             httpGet:
               host: 127.0.0.1
@@ -73,7 +73,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: '<%= image_repository %>/weave-npc-<%= arch.name %>:<%= version %>'
+          image: '<%= image_repository %>/weave-npc:<%= version %>'
           resources:
             requests:
               cpu: 10m

--- a/lib/pharos/scripts/configure-etcd.sh
+++ b/lib/pharos/scripts/configure-etcd.sh
@@ -42,7 +42,7 @@ spec:
     - --initial-cluster-token=pharos-etcd-token
     - --initial-cluster-state=${INITIAL_CLUSTER_STATE}
 
-    image: ${IMAGE_REPO}/etcd-${ARCH}:${ETCD_VERSION}
+    image: ${IMAGE_REPO}/etcd:${ETCD_VERSION}
     livenessProbe:
       exec:
         command:

--- a/lib/pharos/scripts/configure-kubelet-proxy.sh
+++ b/lib/pharos/scripts/configure-kubelet-proxy.sh
@@ -17,7 +17,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-    - image: ${IMAGE_REPO}/pharos-kubelet-proxy-${ARCH}:${VERSION}
+    - image: ${IMAGE_REPO}/pharos-kubelet-proxy:${VERSION}
       name: proxy
       env:
       - name: KUBE_MASTERS

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -14,4 +14,5 @@ module Pharos
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.2.18' }
   KUBELET_PROXY_VERSION = '0.3.7'
   COREDNS_VERSION = '1.1.3'
+  TELEMETRY_VERSION = '0.1.0'
 end

--- a/spec/pharos/addon_spec.rb
+++ b/spec/pharos/addon_spec.rb
@@ -22,7 +22,7 @@ describe Pharos::Addon do
   let(:kube_client) { instance_double(K8s::Client) }
   let(:config) { {foo: 'bar'} }
 
-  subject { test_addon.new(config, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: nil) }
+  subject { test_addon.new(config, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: double(image_repository: 'foo')) }
 
   describe ".addon_name" do
     it "returns configured name" do

--- a/spec/pharos/addons/ingress_nginx_spec.rb
+++ b/spec/pharos/addons/ingress_nginx_spec.rb
@@ -32,27 +32,11 @@ describe Pharos::Addons::IngressNginx do
 
   describe "#image_name" do
     context "with a configured image" do
-      let(:config) { {default_backend: {image: 'some_image'}} }
+      let(:config) { {default_backend: {'image' => 'some_image'}} }
 
       it "returns configured name" do
         expect(cpu_arch).not_to receive(:name)
-        expect(subject.image_name).to eq("some_image")
-      end
-    end
-
-    context "for cpu_arch=arm64" do
-      let(:cpu_arch) { double(:cpu_arch, name: 'arm64' ) }
-
-      it "returns default for arm64" do
-        expect(subject.image_name).to eq(Pharos::Addons::IngressNginx::DEFAULT_BACKEND_ARM64_IMAGE)
-      end
-    end
-
-    context "for cpu_arch=amd64" do
-      let(:cpu_arch) { double(:cpu_arch, name: 'amd64' ) }
-
-      it "returns default" do
-        expect(subject.image_name).to eq(Pharos::Addons::IngressNginx::DEFAULT_BACKEND_IMAGE)
+        expect(subject.config.default_backend['image']).to eq("some_image")
       end
     end
   end

--- a/spec/pharos/phases/configure_dns_spec.rb
+++ b/spec/pharos/phases/configure_dns_spec.rb
@@ -167,17 +167,5 @@ describe Pharos::Phases::ConfigureDNS do
 
       subject.patch_deployment('kube-dns', replicas: 1, max_surge: 0, max_unavailable: 1)
     end
-
-    it "patches coredns image on arm64" do
-      allow(cpu_arch).to receive(:name).and_return('arm64')
-      expect(kube_resource_client).to receive(:merge_patch).with('kube-dns', Hash) do |_name, h|
-        res = K8s::Resource.new(h)
-        expect(res.spec.template.spec.containers[0].image).to include("coredns-#{master.cpu_arch.name}")
-
-        resource
-      end
-
-      subject.patch_deployment('kube-dns', replicas: 1, max_surge: 0, max_unavailable: 1)
-    end
   end
 end

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -37,7 +37,7 @@ describe Pharos::Phases::ConfigureKubelet do
     it "returns a systemd unit" do
       expect(subject.build_systemd_dropin).to eq <<~EOM
         [Service]
-        Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override= --authentication-token-webhook=true --pod-infra-container-image=quay.io/kontena/pause-amd64:3.1'
+        Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override= --authentication-token-webhook=true --pod-infra-container-image=registry.pharos.sh/kontenapharos/pause:3.1'
         ExecStartPre=-/sbin/swapoff -a
       EOM
     end

--- a/spec/pharos/phases/upgrade_master_spec.rb
+++ b/spec/pharos/phases/upgrade_master_spec.rb
@@ -15,26 +15,4 @@ describe Pharos::Phases::UpgradeMaster do
   end
 
   subject { described_class.new(master, config: config) }
-
-  describe '#create_dns_patch_thread' do
-    let(:kube_client) { instance_double(K8s::Client) }
-    let(:kube_api_client) { instance_double(K8s::APIClient) }
-    let(:kube_resource_client) { instance_double(K8s::ResourceClient) }
-
-    before do
-      allow(subject).to receive(:kube_client).and_return(kube_client)
-      allow(kube_client).to receive(:api).with('extensions/v1beta1').and_return(kube_api_client)
-      allow(kube_api_client).to receive(:resource).with('deployments', namespace: 'kube-system').and_return(kube_resource_client)
-    end
-
-    it 'patches coredns deployment' do
-      expect(kube_resource_client).to receive(:merge_patch) do |name, patch|
-        res = K8s::Resource.new(patch)
-        expect(res.spec.template.spec.containers[0].image).to include("coredns-#{cpu_arch.name}")
-      end
-
-      thread = subject.create_dns_patch_thread(0)
-      thread.join
-    end
-  end
 end


### PR DESCRIPTION
- moves all core & addon images to a central registry
- uses multi-arch images wherever possible -> makes possible to mix amd64 & arm64 machines in a cluster
- improves air-gapped setups