### PR TITLE
Allow to use custom docker runtime

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -55,7 +55,7 @@ module Pharos
               end
               optional(:user).filled
               optional(:ssh_key_path).filled
-              optional(:container_runtime).filled(included_in?: ['docker', 'cri-o'])
+              optional(:container_runtime).filled(included_in?: ['docker', 'custom_docker', 'cri-o'])
               optional(:environment).filled
             end
           end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -117,6 +117,10 @@ module Pharos
         container_runtime == 'docker'
       end
 
+      def custom_docker?
+        container_runtime == 'custom_docker'
+      end
+
       # @return [Integer]
       def master_sort_score
         if checks['api_healthy']

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -91,6 +91,10 @@ module Pharos
         @host.docker?
       end
 
+      def custom_docker?
+        @host.custom_docker?
+      end
+
       # @return [Pharos::Config,NilClass]
       def cluster_config
         self.class.cluster_config

--- a/lib/pharos/host/el7/el7.rb
+++ b/lib/pharos/host/el7/el7.rb
@@ -50,6 +50,10 @@ module Pharos
             DOCKER_VERSION: DOCKER_VERSION,
             DOCKER_REPO_NAME: docker_repo_name
           )
+        elsif custom_docker?
+          exec_script(
+            'configure-docker.sh'
+          )
         elsif crio?
           exec_script(
             'configure-cri-o.sh',

--- a/lib/pharos/host/el7/scripts/configure-docker.sh
+++ b/lib/pharos/host/el7/scripts/configure-docker.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-mkdir -p /etc/docker
-cat <<EOF >/etc/docker/daemon.json
-{
-    "live-restore": true,
-    "iptables": false,
-    "ip-masq": false
-}
-EOF
-
 reload_daemon() {
     if systemctl is-active --quiet docker; then
         systemctl daemon-reload
@@ -31,6 +22,20 @@ else
         reload_daemon
     fi
 fi
+
+if [ -z "$DOCKER_VERSION" ]; then
+    docker info
+    exit 0
+fi
+
+mkdir -p /etc/docker
+cat <<EOF >/etc/docker/daemon.json
+{
+    "live-restore": true,
+    "iptables": false,
+    "ip-masq": false
+}
+EOF
 
 yum install --enablerepo="${DOCKER_REPO_NAME}" -y "docker-${DOCKER_VERSION}"
 

--- a/lib/pharos/host/ubuntu/scripts/configure-docker.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-docker.sh
@@ -2,25 +2,6 @@
 
 set -e
 
-mkdir -p /etc/docker
-cat <<EOF >/etc/docker/daemon.json
-{
-    "storage-driver": "overlay2",
-    "live-restore": true,
-    "iptables": false,
-    "ip-masq": false,
-    "log-driver": "json-file",
-    "log-opts": {
-        "max-size": "20m",
-        "max-file": "3"
-    }
-}
-EOF
-
-debconf-set-selections <<EOF
-docker.io docker.io/restart boolean true
-EOF
-
 reload_daemon() {
     if systemctl is-active --quiet docker; then
         systemctl daemon-reload
@@ -41,6 +22,30 @@ else
         reload_daemon
     fi
 fi
+
+if [ -z "$DOCKER_VERSION" ]; then
+    docker info
+    exit 0
+fi
+
+mkdir -p /etc/docker
+cat <<EOF >/etc/docker/daemon.json
+{
+    "storage-driver": "overlay2",
+    "live-restore": true,
+    "iptables": false,
+    "ip-masq": false,
+    "log-driver": "json-file",
+    "log-opts": {
+        "max-size": "20m",
+        "max-file": "3"
+    }
+}
+EOF
+
+debconf-set-selections <<EOF
+docker.io docker.io/restart boolean true
+EOF
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/lib/pharos/host/ubuntu/ubuntu_bionic.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_bionic.rb
@@ -38,6 +38,10 @@ module Pharos
             DOCKER_PACKAGE: 'docker.io',
             DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1"
           )
+        elsif custom_docker?
+          exec_script(
+            'configure-docker.sh'
+          )
         elsif crio?
           exec_script(
             'configure-cri-o.sh',

--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -38,6 +38,10 @@ module Pharos
             DOCKER_PACKAGE: 'docker.io',
             DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu2~16.04.1"
           )
+        elsif custom_docker?
+          exec_script(
+            'configure-docker.sh'
+          )
         elsif crio?
           exec_script(
             'configure-cri-o.sh',


### PR DESCRIPTION
Makes it possible for users to install docker-ce/ee or custom build manually to hosts.

```yaml
hosts:
  - address: 192.168.100.100
    user: root
    role: master
    container_runtime: custom_docker
```