### PR TITLE
Upgrade kubeadm via configured repository

### DIFF
--- a/lib/pharos/host/el7/scripts/upgrade-kubeadm.sh
+++ b/lib/pharos/host/el7/scripts/upgrade-kubeadm.sh
@@ -8,12 +8,11 @@ if [ -x /usr/local/bin/pharos-kubeadm-${VERSION} ]; then
     exit
 fi
 
-BIN_URL="https://dl.bintray.com/kontena/pharos-bin/kube/${VERSION}/kubeadm-${ARCH}.gz"
-
-curl -fsSL https://bintray.com/user/downloadSubjectPublicKey?username=bintray | gpg --import
-curl -fsSL $BIN_URL -o /tmp/kubeadm.gz
-curl -fsSL "${BIN_URL}.asc" -o /tmp/kubeadm.gz.asc
-gpg --verify /tmp/kubeadm.gz.asc /tmp/kubeadm.gz
-gunzip /tmp/kubeadm.gz
-install -o root -g root -m 0755 -T /tmp/kubeadm /usr/local/bin/pharos-kubeadm-${VERSION}
-rm /tmp/kubeadm /tmp/kubeadm.gz.asc
+tmpdir=$(mktemp -d)
+mkdir -p $tmpdir
+yum install kubeadm-${VERSION} -y --downloadonly --downloaddir=$tmpdir
+cd $tmpdir
+rpm2cpio kubeadm*.rpm | cpio -idmv
+install -o root -g root -m 0755 -T ./usr/bin/kubeadm /usr/local/bin/pharos-kubeadm-${VERSION}
+rm -rf $tmpdir
+/usr/local/bin/pharos-kubeadm-${VERSION} version

--- a/lib/pharos/host/ubuntu/scripts/upgrade-kubeadm.sh
+++ b/lib/pharos/host/ubuntu/scripts/upgrade-kubeadm.sh
@@ -6,12 +6,10 @@ if [ -x /usr/local/bin/pharos-kubeadm-${VERSION} ]; then
     exit
 fi
 
-BIN_URL="https://dl.bintray.com/kontena/pharos-bin/kube/${VERSION}/kubeadm-${ARCH}.gz"
-
-curl -fsSL https://bintray.com/user/downloadSubjectPublicKey?username=bintray | gpg --import
-curl -fsSL $BIN_URL -o /tmp/kubeadm.gz
-curl -fsSL "${BIN_URL}.asc" -o /tmp/kubeadm.gz.asc
-gpg --verify /tmp/kubeadm.gz.asc /tmp/kubeadm.gz
-gunzip /tmp/kubeadm.gz
-install -o root -g root -m 0755 -T /tmp/kubeadm /usr/local/bin/pharos-kubeadm-${VERSION}
-rm /tmp/kubeadm /tmp/kubeadm.gz.asc
+tmpdir=$(mktemp -d)
+cd $tmpdir
+apt-get download "kubeadm=${VERSION}-00"
+dpkg-deb -R kubeadm_${VERSION}-00*.deb kubeadm
+install -o root -g root -m 0755 -T ./kubeadm/usr/bin/kubeadm /usr/local/bin/pharos-kubeadm-${VERSION}
+rm -rf $tmpdir
+/usr/local/bin/pharos-kubeadm-${VERSION} version

--- a/lib/pharos/host/ubuntu/ubuntu.rb
+++ b/lib/pharos/host/ubuntu/ubuntu.rb
@@ -7,12 +7,6 @@ module Pharos
         exec_script('configure-essentials.sh')
       end
 
-      def configure_repos
-        exec_script('repos/cri-o.sh') if crio?
-        exec_script('repos/kube.sh')
-        exec_script('repos/update.sh')
-      end
-
       def configure_netfilter
         exec_script('configure-netfilter.sh')
       end


### PR DESCRIPTION
We should try to avoid hardcoding any urls in scripts... this PR improves air-gapped setups because it does not depend on a fixed repository.