### PR TITLE
 Add support for post install messages

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -133,7 +133,7 @@ module Pharos
       end
     end
 
-    attr_reader :config, :cpu_arch, :cluster_config, :kube_client
+    attr_reader :config, :cpu_arch, :cluster_config, :kube_client, :post_install_message
 
     # @param config [Hash,Dry::Validation::Result]
     # @param enabled [Boolean]
@@ -186,6 +186,10 @@ module Pharos
       else
         delete_resources
       end
+    end
+
+    def notify(msg)
+      @post_install_message = msg
     end
 
     # @param vars [Hash]

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -133,7 +133,7 @@ module Pharos
       end
     end
 
-    attr_reader :config, :cpu_arch, :cluster_config, :kube_client, :post_install_message
+    attr_reader :config, :cpu_arch, :cluster_config, :kube_client
 
     # @param config [Hash,Dry::Validation::Result]
     # @param enabled [Boolean]
@@ -188,8 +188,12 @@ module Pharos
       end
     end
 
-    def notify(msg)
-      @post_install_message = msg
+    def post_install_message(msg = nil)
+      if msg
+        @post_install_message = msg
+      else
+        @post_install_message
+      end
     end
 
     # @param vars [Hash]

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -95,6 +95,8 @@ module Pharos
         addon = addon_class.new(config, enabled: true, **options)
         addon.validate
         yield_addon_with_retry(addon, &block)
+        post_install_message = addon.post_install_message
+        @cluster_context['post_install_messages'][addon.name] = post_install_message if post_install_message
       end
 
       with_disabled_addons do |addon_class|

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -13,7 +13,9 @@ module Pharos
     def initialize(config, pastel: Pastel.new)
       @config = config
       @pastel = pastel
-      @context = {}
+      @context = {
+        'post_install_messages' => {}
+      }
     end
 
     # @return [Pharos::SSH::Manager]
@@ -142,6 +144,10 @@ module Pharos
 
         addon.apply
       end
+    end
+
+    def post_install_messages
+      @context['post_install_messages']
     end
 
     def save_config

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -116,8 +116,8 @@ module Pharos
       puts "    To configure kubectl for connecting to the cluster, use:"
       puts "      #{File.basename($PROGRAM_NAME)} kubeconfig #{defined_opts}> kubeconfig"
       puts "      export KUBECONFIG=./kubeconfig"
-      manager.post_install_messages.each do |addon, message|
-        puts "    Post-install message from #{addon}:"
+      manager.post_install_messages.each do |component, message|
+        puts "    Post-install message from #{component}:"
         message.split('\n').each do |line|
           puts "      #{line}"
         end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -113,15 +113,15 @@ module Pharos
       defined_opts = ARGV[1..-1].join(" ")
       defined_opts += " " unless defined_opts.empty?
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
-      puts "    To configure kubectl for connecting to the cluster, use:"
-      puts "      #{File.basename($PROGRAM_NAME)} kubeconfig #{defined_opts}> kubeconfig"
-      puts "      export KUBECONFIG=./kubeconfig"
       manager.post_install_messages.each do |component, message|
         puts "    Post-install message from #{component}:"
         message.lines.each do |line|
           puts "      #{line}"
         end
       end
+      puts "    To configure kubectl for connecting to the cluster, use:"
+      puts "      #{File.basename($PROGRAM_NAME)} kubeconfig #{defined_opts}> kubeconfig"
+      puts "      export KUBECONFIG=./kubeconfig"
       manager.disconnect
     end
 

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -118,7 +118,7 @@ module Pharos
       puts "      export KUBECONFIG=./kubeconfig"
       manager.post_install_messages.each do |component, message|
         puts "    Post-install message from #{component}:"
-        message.split('\n').each do |line|
+        message.split("\n").each do |line|
           puts "      #{line}"
         end
       end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -116,7 +116,12 @@ module Pharos
       puts "    To configure kubectl for connecting to the cluster, use:"
       puts "      #{File.basename($PROGRAM_NAME)} kubeconfig #{defined_opts}> kubeconfig"
       puts "      export KUBECONFIG=./kubeconfig"
-
+      manager.post_install_messages.each do |addon, message|
+        puts "    Post-install message from #{addon}:"
+        message.split('\n').each do |line|
+          puts "      #{line}"
+        end
+      end
       manager.disconnect
     end
 

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -118,7 +118,7 @@ module Pharos
       puts "      export KUBECONFIG=./kubeconfig"
       manager.post_install_messages.each do |component, message|
         puts "    Post-install message from #{component}:"
-        message.split("\n").each do |line|
+        message.lines.each do |line|
           puts "      #{line}"
         end
       end

--- a/spec/pharos/addon_spec.rb
+++ b/spec/pharos/addon_spec.rb
@@ -105,9 +105,9 @@ describe Pharos::Addon do
     end
   end
 
-  describe "#notify" do
-    it "sets post install message" do
-      subject.notify('installed')
+  describe "#post_install_message" do
+    it "sets post install message if message given" do
+      subject.post_install_message('installed')
       expect(subject.post_install_message).to eq('installed')
     end
   end

--- a/spec/pharos/addon_spec.rb
+++ b/spec/pharos/addon_spec.rb
@@ -104,4 +104,11 @@ describe Pharos::Addon do
       subject.apply_resources
     end
   end
+
+  describe "#notify" do
+    it "sets post install message" do
+      subject.notify('installed')
+      expect(subject.post_install_message).to eq('installed')
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for post install messages. This PR focus only on addons, but it can be easily leverage to cover also phases too.

PR adds `#post_install_message` method to `Addon` class and it can be used like this:
```ruby
# addon.rb
install {
    host = config.host || "lens.#{worker_node_ip}.nip.io"
    apply_resources(
      host: host
    )
    post_install_message("Kontena Lens is running at https://#{host}.")
  }
```

These post install messages are displayed after "Cluster has been crafted" messages
```
==> Cluster has been crafted! (took 1 minute 14 seconds)
    To configure kubectl for connecting to the cluster, use:
      pharos kubeconfig -c cluster.yml  > kubeconfig
      export KUBECONFIG=./kubeconfig
    Post-install message from kontena-lens:
      Kontena Lens is running at https://<url>.
```