### PR TITLE
[PoC] Plugin as subcommand

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -32,5 +32,19 @@ module Pharos
     def stdin_eof?
       $stdin.eof?
     end
+
+    def subcommand_missing(subcommand)
+      require 'mkmf'
+      plugin_subcommand = find_executable "pharos-#{subcommand}" # TODO: this quick-which-hack outputs to terminal and leaves behind a mkmf.log
+      signal_usage_error "Unknown subcommand: #{subcommand}" unless plugin_subcommand
+      ruby_path = RbConfig::CONFIG['bindir']
+      ENV.update(
+        'PHAROS_RUBY_PATH' => ruby_path,
+        'PHAROS_BIN_PATH' => File.expand_path(File.dirname(File.expand_path($PROGRAM_NAME))),
+        'PHAROS_BIN' => File.expand_path($PROGRAM_NAME),
+        'PHAROS_VERSION' => Pharos::VERSION
+      )
+      exec(plugin_subcommand, *ARGV[1..-1])
+    end
   end
 end


### PR DESCRIPTION
As discussed.


With this you can do something like:

```
$ cat <<EOF > /usr/local/bin/pharos-foofoo
#!/bin/bash

echo "Hello!"
EOF
$ chmod +x  /usr/local/bin/pharos-foofoo
$ pharos foofoo
Hello
```

Also it could be possible to scan the PATH for `pharos-*`and inject a wrapper-subcommand. This way there would also be a mention of any installed plugins in the main command help.

I don't know if there's any benefit.
