### PR TITLE
Upgrade build environment bundler

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,7 @@ pipeline:
   test:
     image: ruby:2.4
     commands:
+      - gem install bundler --version="1.16.2" -Nf
       - bundle install --path bundler
       - bundle exec rspec spec/
       - bundle exec rspec non-oss/spec/

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ pipeline:
   test:
     image: ruby:2.4
     commands:
-      - gem install bundler --version="1.16.2" -Nf
+      - gem install bundler -Nf
       - bundle install --path bundler
       - bundle exec rspec spec/
       - bundle exec rspec non-oss/spec/


### PR DESCRIPTION
Removes this warning from drone logs:

```
Warning: the running version of Bundler (1.16.1) is older than the version that created the lockfile (1.16.2). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
```

