### PR TITLE
Improve kontena-lens addon

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -119,6 +119,10 @@ module Pharos
         hooks[:uninstall] = block
       end
 
+      def modify_cluster_config(&block)
+        hooks[:modify_cluster_config] = block
+      end
+
       def validation
         Dry::Validation.Params(Schema) { yield }
       end
@@ -186,6 +190,10 @@ module Pharos
       else
         delete_resources
       end
+    end
+
+    def apply_modify_cluster_config
+      instance_eval(&hooks[:modify_cluster_config]) if hooks[:modify_cluster_config]
     end
 
     def post_install_message(msg = nil)

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -78,7 +78,10 @@ module Pharos
 
     # @return [K8s::Client]
     def kube_client
-      @kube_client ||= Pharos::Kube.client(@config.master_host.api_address, @cluster_context['kubeconfig'])
+      if !@kubeclient && @cluster_context['kubeconfig']
+        @kube_client = Pharos::Kube.client(@config.master_host.api_address, @cluster_context['kubeconfig'])
+      end
+      @kube_client
     end
 
     def options
@@ -95,8 +98,6 @@ module Pharos
         addon = addon_class.new(config, enabled: true, **options)
         addon.validate
         yield_addon_with_retry(addon, &block)
-        post_install_message = addon.post_install_message
-        @cluster_context['post_install_messages'][addon.name] = post_install_message if post_install_message
       end
 
       with_disabled_addons do |addon_class|

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -130,6 +130,17 @@ module Pharos
       apply_phase(Phases::ResetHost, config.hosts, ssh: true, parallel: true)
     end
 
+    def apply_addons_cluster_config_modifications
+      addon_manager.each do |addon|
+        begin
+          addon.apply_modify_cluster_config
+        rescue Pharos::Error => e
+          error_msg = "#{addon.name} => " + e.message
+          raise Pharos::AddonManager::InvalidConfig, error_msg
+        end
+      end
+    end
+
     # @param phase_class [Pharos::Phase]
     # @param hosts [Array<Pharos::Configuration::Host>]
     def apply_phase(phase_class, hosts, **options)
@@ -145,6 +156,7 @@ module Pharos
         puts @pastel.cyan("==> #{addon.enabled? ? 'Enabling' : 'Disabling'} addon #{addon.name}")
 
         addon.apply
+        post_install_messages[addon.name] = addon.post_install_message if addon.post_install_message
       end
     end
 

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -87,6 +87,11 @@ module Pharos
       end
     end
 
+    def set(key, value)
+      raise Pharos::Error, "Cannot override #{key}." if data[key.to_s]
+      attributes[key] = value
+    end
+
     # @return [String]
     def to_yaml
       YAML.dump(to_h.deep_stringify_keys)

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -87,6 +87,9 @@ module Pharos
       end
     end
 
+    # @param key [Symbol]
+    # @param value [Pharos::Configuration::Struct]
+    # @raise [Pharos::ConfigError]
     def set(key, value)
       raise Pharos::Error, "Cannot override #{key}." if data[key.to_s]
       attributes[key] = value

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -96,9 +96,9 @@ module Pharos
       puts pastel.green("==> Sharpening tools ...")
       manager.load
       manager.validate
-
       show_component_versions(config)
       show_addon_versions(manager)
+      manager.apply_addons_cluster_config_modifications
       prompt_continue(config)
 
       puts pastel.green("==> Starting to craft cluster ...")

--- a/non-oss/addons/kontena-lens/addon.rb
+++ b/non-oss/addons/kontena-lens/addon.rb
@@ -74,7 +74,7 @@ Pharos.addon 'kontena-lens' do
 
   def wait_for_dashboard(host)
     puts "    Waiting for Kontena Lens to get up and running"
-    command = "sudo curl -kIs -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" https://localhost" # rubocop:disable Style/FormatStringToken
+    command = "sudo curl -Is -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" http://localhost/api/config" # rubocop:disable Style/FormatStringToken
     response = ssh.exec(command)
     i = 1
     until response.success? && response.output.to_i == 200
@@ -105,7 +105,7 @@ Pharos.addon 'kontena-lens' do
       clusterUrl: "https://#{master_host_ip}:6443",
       adminPassword: admin_password
     }
-    command = "sudo curl -X POST -d '#{cluster_config.to_json}' -ks -H \"Host: #{host}\" -H \"Content-Type: application/json\" https://localhost/api/cluster"
+    command = "sudo curl -X POST -d '#{cluster_config.to_json}' -s -H \"Host: #{host}\" -H \"Content-Type: application/json\" http://localhost/api/cluster"
     ssh.exec(command)
   end
 

--- a/non-oss/addons/kontena-lens/addon.rb
+++ b/non-oss/addons/kontena-lens/addon.rb
@@ -73,7 +73,7 @@ Pharos.addon 'kontena-lens' do
   end
 
   def wait_for_dashboard(host)
-    puts "    Waiting for Kontena Lens to get up and running"
+    puts "    Waiting for Kontena Lens to get up and running ..."
     command = "sudo curl -LkIs -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" http://localhost/" # rubocop:disable Style/FormatStringToken
     response = ssh.exec(command)
     i = 1

--- a/non-oss/addons/kontena-lens/addon.rb
+++ b/non-oss/addons/kontena-lens/addon.rb
@@ -5,20 +5,115 @@ Pharos.addon 'kontena-lens' do
   license 'Kontena License'
 
   config_schema {
+    optional(:name).filled(:str?)
     optional(:host).filled(:str?)
-    optional(:email).filled(:str?)
+    optional(:tls).schema do
+      optional(:email).filled(:str?)
+    end
+    optional(:user_management).schema do
+      optional(:enabled).filled(:bool?)
+    end
   }
 
+  modify_cluster_config {
+    if user_management_enabled?
+      configure_token_authentication_webhook
+    end
+  }
+
+  install {
+    Excon.defaults[:ssl_verify_peer] = false # Allow ingress controller default cert
+    host = config.host || "lens.#{worker_node_ip}.nip.io"
+
+    name = config.name || 'pharos-cluster'
+    apply_resources(
+      host: host,
+      email: config.tls&.email,
+      user_management: user_management_enabled?
+    )
+    wait_for_dashboard(host)
+    message = "Kontena Lens is running at: " + pastel.cyan("https://#{host}")
+    unless configmap
+      init_cluster(name, host)
+      message << "\nYou can sign in with admin credentials: " + pastel.cyan("admin / #{admin_password}")
+    end
+    post_install_message(message)
+    Excon.defaults[:ssl_verify_peer] = true
+  }
+
+  def pastel
+    @pastel ||= Pastel.new
+  end
+
+  def worker_node
+    cluster_config.worker_hosts.first
+  end
+
   def worker_node_ip
-    worker_node = cluster_config.worker_hosts.first
     worker_node&.address
   end
 
-  install {
-    host = config.host || "lens.#{worker_node_ip}.nip.io"
-    apply_resources(
-      host: host
+  def master_host_ip
+    cluster_config.master_host&.address
+  end
+
+  def user_management_enabled?
+    config.user_management&.enabled != false
+  end
+
+  def configure_token_authentication_webhook
+    token_webhook_config = Pharos::Configuration::TokenWebhook.new(
+      config: {
+        cluster: {
+          name: 'lens-authenticator',
+          server: 'http://localhost:9292/token'
+        },
+        user: {
+          name: 'kube-apiserver'
+        }
+      }
     )
-    post_install_message("Kontena Lens is running at: https://#{host}")
-  }
+    cluster_config.set(:authentication, Pharos::Configuration::Authentication.new(token_webhook: token_webhook_config))
+  end
+
+  def wait_for_dashboard(host)
+    puts "    Waiting for Kontena Lens to get up and running"
+    command = "sudo curl -kIs -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" https://localhost" ## rubocop:disable Style/FormatStringToken
+    response = ssh.exec(command)
+    i = 1
+    until response.success? && response.output.to_i == 200
+      sleep 10
+      puts "    Still waiting... (#{i * 10}s elapsed)"
+      i += 1
+      response = ssh.exec(command)
+    end
+  end
+
+  def admin_password
+    @admin_password ||= SecureRandom.hex(8)
+  end
+
+  def cluster_initialized?
+    configmap.nil?
+  end
+
+  def configmap
+    @configmap ||= kube_client.api('v1').resource('configmaps', namespace: 'kontena-lens').get('config')
+  rescue K8s::Error::NotFound
+    nil
+  end
+
+  def init_cluster(name, host)
+    cluster_config = {
+      clusterName: name,
+      clusterUrl: "https://#{master_host_ip}:6443",
+      adminPassword: admin_password
+    }
+    command = "sudo curl -X POST -d '#{cluster_config.to_json}' -ks -H \"Host: #{host}\" -H \"Content-Type: application/json\" https://localhost/api/cluster"
+    ssh.exec(command)
+  end
+
+  def ssh
+    @ssh ||= Pharos::SSH::Manager.new.client_for(worker_node)
+  end
 end

--- a/non-oss/addons/kontena-lens/addon.rb
+++ b/non-oss/addons/kontena-lens/addon.rb
@@ -74,10 +74,10 @@ Pharos.addon 'kontena-lens' do
 
   def wait_for_dashboard(host)
     puts "    Waiting for Kontena Lens to get up and running"
-    command = "sudo curl -Is -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" http://localhost/api/config" # rubocop:disable Style/FormatStringToken
+    command = "sudo curl -LkIs -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" http://localhost/" # rubocop:disable Style/FormatStringToken
     response = ssh.exec(command)
     i = 1
-    until response.success? && response.output.to_i == 200
+    until response.output.to_i == 200
       sleep 10
       puts "    Still waiting... (#{i * 10}s elapsed)"
       i += 1
@@ -105,7 +105,7 @@ Pharos.addon 'kontena-lens' do
       clusterUrl: "https://#{master_host_ip}:6443",
       adminPassword: admin_password
     }
-    command = "sudo curl -X POST -d '#{cluster_config.to_json}' -s -H \"Host: #{host}\" -H \"Content-Type: application/json\" http://localhost/api/cluster"
+    command = "sudo curl -k -L -X POST -d '#{cluster_config.to_json}' -s -H \"Host: #{host}\" -H \"Content-Type: application/json\" http://localhost/api/cluster"
     ssh.exec(command)
   end
 

--- a/non-oss/addons/kontena-lens/addon.rb
+++ b/non-oss/addons/kontena-lens/addon.rb
@@ -74,7 +74,7 @@ Pharos.addon 'kontena-lens' do
 
   def wait_for_dashboard(host)
     puts "    Waiting for Kontena Lens to get up and running"
-    command = "sudo curl -kIs -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" https://localhost" ## rubocop:disable Style/FormatStringToken
+    command = "sudo curl -kIs -o /dev/null -w \"%{http_code}\" -H \"Host: #{host}\" https://localhost" # rubocop:disable Style/FormatStringToken
     response = ssh.exec(command)
     i = 1
     until response.success? && response.output.to_i == 200
@@ -90,7 +90,7 @@ Pharos.addon 'kontena-lens' do
   end
 
   def lens_configured?
-    configmap.nil?
+    !configmap.nil?
   end
 
   def configmap

--- a/non-oss/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
+++ b/non-oss/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: lens-operator
       restartPolicy: Always
       containers:
-        - image: quay.io/kontena/lens:<%= version %>
+        - image: quay.io/kontena/lens:latest
           name: dashboard
           imagePullPolicy: Always
           env:
@@ -28,7 +28,7 @@ spec:
             - name: REDIS_CLIENT_HOST
               value: redis
             - name: USER_MANAGEMENT_ENABLED
-              value: "<%=  (config.user_management.nil? || config.user_management) ? "true" : "false" %>"
+              value: "<%=  user_management ? "true" : "false" %>"
           resources:
             requests:
               memory: "256Mi"

--- a/non-oss/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
+++ b/non-oss/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: lens-operator
       restartPolicy: Always
       containers:
-        - image: quay.io/kontena/lens:latest
+        - image: quay.io/kontena/lens:<%= version %>
           name: dashboard
           imagePullPolicy: Always
           env:

--- a/non-oss/addons/kontena-lens/resources/14-issuer.yml.erb
+++ b/non-oss/addons/kontena-lens/resources/14-issuer.yml.erb
@@ -1,4 +1,4 @@
-<% if config.email %>
+<% if email %>
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:

--- a/non-oss/addons/kontena-lens/resources/14-issuer.yml.erb
+++ b/non-oss/addons/kontena-lens/resources/14-issuer.yml.erb
@@ -7,9 +7,9 @@ metadata:
 spec:
   acme:
     # The ACME server URL
-    server: https://acme-v01.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
-    email: <%= config.email %>
+    email: <%= email %>
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt


### PR DESCRIPTION
This PR improves Kontena Lens addon by enabling token authentication webhook and creating lens config during the installation.

It also changes addon configuration a bit:
```
kontena-lens:
  enabled: true
  name: 'name of the cluster' # default 'pharos-cluster'
  host: 'https://lens-host' # default 'https://<worker-ip->.nip.io'
  user_management:
    enabled: true|false # default true
  tls:
    email: john@example.org # email used for LE certificate fetching, not required if host is not defined
```
This PR adds new `modify_cluster_config` hook to `Pharos::Addon`. Hook allows addon to set cluster configuration option if it is not set yet. `kontena-lens` addon adds token authentication webhook to point `lens-authenticator` pod running on master hosts if user management is enabled. 

## Todo
- [x] test without host option
- [x] test with custom domain