### PR TITLE
(PoC) Add non-oss directory to LOAD_PATH

### DIFF
--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -15,4 +15,21 @@ module Pharos
   KUBELET_PROXY_VERSION = '0.3.7'
   COREDNS_VERSION = '1.1.3'
   TELEMETRY_VERSION = '0.1.0'
+
+  # @return [Boolean] true when running the OSS licensed version
+  def self.oss?
+    true
+  end
+end
+
+unless ENV['PHAROS_DISABLE_NON_OSS']
+  require 'pathname'
+  non_oss_path = File.expand_path('../../non-oss', Pathname.new(__FILE__).realpath)
+  $LOAD_PATH.unshift non_oss_path unless $LOAD_PATH.include?(non_oss_path)
+  # rubocop:disable Lint/HandleExceptions
+  begin
+    require 'pharos_cluster_non_oss'
+  rescue LoadError
+  end
+  # rubocop:enable Lint/HandleExceptions
 end

--- a/non-oss/pharos_cluster_non_oss.rb
+++ b/non-oss/pharos_cluster_non_oss.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Pharos
+  # @return [Boolean] true when running the OSS licensed version
+  def self.oss?
+    false
+  end
+end
+
+Dir.glob(File.join(__dir__, 'commands/*.rb')).each { |file| require file }


### PR DESCRIPTION
This would ease the subcommand registration in something like #667 or #634  and provide means to monkey-patch or replace the oss-implementations of classes.

When the `non-oss/` directory is in `$LOAD_PATH` before the `lib/` path, something like:

```ruby
require 'pharos/phases/upgrade_host'
```

 or

```ruby
module Pharos
  module Phases
    autoload :UpgradeHost, 'pharos/phases/upgrade_host'
  end
end
``` 

will load the file from `non-oss/pharos/phases/upgrade_host.rb` instead of `lib/pharos/phases/upgrade_host.rb` if it exists there.

