### PR TITLE
Add developer and devops roles

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/developer-role.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/developer-role.yml
@@ -1,0 +1,29 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: developer
+rules:
+- apiGroups: ["", "extensions", "apps"]
+  resources: ["deployments", "replicasets", "pods", "daemonsets", "statefulsets", "configmaps", "secrets", "persistentvolumeclaims", "resourcequotas"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["", "extensions", "networking.k8s.io"]
+  resources: ["services", "ingresses", "networkpolicies"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: ["", "rbac.authorization.k8s.io"]
+  resources: ["serviceaccounts", "rolebindings", "roles"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get"]

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/devops-role.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/devops-role.yml
@@ -1,0 +1,8 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: devops
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]


### PR DESCRIPTION
This PR adds two roles `developer` and `devops`. 
With `developer` role user has read access to resources required by Kontena Lens. `devops` role is basically the same as `cluster-admin` but with it it's easy to give admin access to a certain namespace.