### PR TITLE
add support for configuring insecure registries through cluster.yml

### DIFF
--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -13,6 +13,7 @@ require_relative 'configuration/kubelet'
 require_relative 'configuration/pod_security_policy'
 require_relative 'configuration/telemetry'
 require_relative 'configuration/admission_plugin'
+require_relative 'configuration/container_runtime'
 
 module Pharos
   class Config < Pharos::Configuration::Struct
@@ -50,6 +51,7 @@ module Pharos
     attribute :addon_paths, Pharos::Types::Array.default([])
     attribute :addons, Pharos::Types::Hash.default({})
     attribute :admission_plugins, Types::Coercible::Array.of(Pharos::Configuration::AdmissionPlugin)
+    attribute :container_runtime, Pharos::Configuration::ContainerRuntime
 
     attr_accessor :data
 

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -14,7 +14,8 @@ module Pharos
       'kubelet' => {},
       'telemetry' => {},
       'pod_security_policy' => {},
-      'addon_paths' => []
+      'addon_paths' => [],
+      'container_runtime' => {}
     }.freeze
 
     # @param data [Hash]
@@ -130,6 +131,9 @@ module Pharos
               optional(:enabled).filled(:bool?)
             end
           end
+        end
+        optional(:container_runtime).schema do
+          optional(:insecure_registries).each(type?: String)
         end
 
         validate(network_dns_replicas: [:network, :hosts]) do |network, hosts|

--- a/lib/pharos/configuration/container_runtime.rb
+++ b/lib/pharos/configuration/container_runtime.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Configuration
+    class ContainerRuntime < Pharos::Configuration::Struct
+      attribute :insecure_registries, Pharos::Types::Array.default([])
+    end
+  end
+end

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -95,6 +95,18 @@ module Pharos
         @host.custom_docker?
       end
 
+      # Return stringified json array for insecure registries
+      #
+      # @return [String]
+      def insecure_registries
+        if crio?
+          cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
+        else
+          # docker & custom docker
+          cluster_config.container_runtime.insecure_registries.to_json.inspect
+        end
+      end
+
       # @return [Pharos::Config,NilClass]
       def cluster_config
         self.class.cluster_config

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -95,7 +95,8 @@ module Pharos
         @host.custom_docker?
       end
 
-      # Return stringified json array for insecure registries
+      # Return stringified json array(ish) for insecure registries properly escaped for safe
+      # passing to scripts via ENV.
       #
       # @return [String]
       def insecure_registries
@@ -103,7 +104,7 @@ module Pharos
           cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
         else
           # docker & custom docker
-          cluster_config.container_runtime.insecure_registries.to_json.inspect
+          JSON.dump(cluster_config.container_runtime.insecure_registries).inspect
         end
       end
 

--- a/lib/pharos/host/debian/debian_stretch.rb
+++ b/lib/pharos/host/debian/debian_stretch.rb
@@ -26,7 +26,7 @@ module Pharos
 
       def configure_container_runtime
         raise Pharos::Error, "Unknown container runtime: #{host.container_runtime}" unless crio?
-        insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
+
         exec_script(
           'configure-cri-o.sh',
           CRIO_VERSION: Pharos::CRIO_VERSION,

--- a/lib/pharos/host/debian/debian_stretch.rb
+++ b/lib/pharos/host/debian/debian_stretch.rb
@@ -26,13 +26,14 @@ module Pharos
 
       def configure_container_runtime
         raise Pharos::Error, "Unknown container runtime: #{host.container_runtime}" unless crio?
-
+        insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
         exec_script(
           'configure-cri-o.sh',
           CRIO_VERSION: Pharos::CRIO_VERSION,
           CRIO_STREAM_ADDRESS: '127.0.0.1',
           CPU_ARCH: host.cpu_arch.name,
-          IMAGE_REPO: cluster_config.image_repository
+          IMAGE_REPO: cluster_config.image_repository,
+          INSECURE_REGISTRIES: insecure_registries
         )
       end
 

--- a/lib/pharos/host/debian/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/debian/scripts/configure-cri-o.sh
@@ -72,6 +72,7 @@ lineinfile "^cgroup_manager =" "cgroup_manager = \"cgroupfs\"" "/etc/crio/crio.c
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}\/pause-${CPU_ARCH}:3.1\"" "/etc/crio/crio.conf"
 lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"
+lineinfile "^insecure_registries =" "insecure_registries = [ $INSECURE_REGISTRIES" "/etc/crio/crio.conf"
 
 if ! systemctl is-active --quiet crio; then
     systemctl daemon-reload

--- a/lib/pharos/host/el7/el7.rb
+++ b/lib/pharos/host/el7/el7.rb
@@ -44,7 +44,6 @@ module Pharos
 
       def configure_container_runtime
         if docker?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             DOCKER_VERSION: DOCKER_VERSION,
@@ -52,13 +51,11 @@ module Pharos
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif crio?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,

--- a/lib/pharos/host/el7/el7.rb
+++ b/lib/pharos/host/el7/el7.rb
@@ -44,22 +44,28 @@ module Pharos
 
       def configure_container_runtime
         if docker?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             DOCKER_VERSION: DOCKER_VERSION,
-            DOCKER_REPO_NAME: docker_repo_name
+            DOCKER_REPO_NAME: docker_repo_name,
+            INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
-            'configure-docker.sh'
+            'configure-docker.sh',
+            INSECURE_REGISTRIES: insecure_registries
           )
         elsif crio?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
             CRIO_STREAM_ADDRESS: '127.0.0.1',
             CPU_ARCH: host.cpu_arch.name,
-            IMAGE_REPO: cluster_config.image_repository
+            IMAGE_REPO: cluster_config.image_repository,
+            INSECURE_REGISTRIES: insecure_registries
           )
         else
           raise Pharos::Error, "Unknown container runtime: #{host.container_runtime}"

--- a/lib/pharos/host/el7/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/el7/scripts/configure-cri-o.sh
@@ -69,6 +69,7 @@ lineinfile "^cgroup_manager =" "cgroup_manager = \"systemd\"" "/etc/crio/crio.co
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}/pause-${CPU_ARCH}:3.1\"" "/etc/crio/crio.conf"
 lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"
+lineinfile "^insecure_registries =" "insecure_registries = [ $INSECURE_REGISTRIES" "/etc/crio/crio.conf"
 
 if ! systemctl is-active --quiet crio; then
     systemctl daemon-reload

--- a/lib/pharos/host/el7/scripts/configure-docker.sh
+++ b/lib/pharos/host/el7/scripts/configure-docker.sh
@@ -33,7 +33,8 @@ cat <<EOF >/etc/docker/daemon.json
 {
     "live-restore": true,
     "iptables": false,
-    "ip-masq": false
+    "ip-masq": false,
+    "insecure-registries": $INSECURE_REGISTRIES
 }
 EOF
 

--- a/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
@@ -72,6 +72,7 @@ lineinfile "^cgroup_manager =" "cgroup_manager = \"cgroupfs\"" "/etc/crio/crio.c
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}\/pause-${CPU_ARCH}:3.1\"" "/etc/crio/crio.conf"
 lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"
+lineinfile "^insecure_registries =" "insecure_registries = [ $INSECURE_REGISTRIES" "/etc/crio/crio.conf"
 
 if ! systemctl is-active --quiet crio; then
     systemctl daemon-reload

--- a/lib/pharos/host/ubuntu/scripts/configure-docker.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-docker.sh
@@ -39,7 +39,8 @@ cat <<EOF >/etc/docker/daemon.json
     "log-opts": {
         "max-size": "20m",
         "max-file": "3"
-    }
+    },
+    "insecure-registries": $INSECURE_REGISTRIES
 }
 EOF
 

--- a/lib/pharos/host/ubuntu/ubuntu_bionic.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_bionic.rb
@@ -32,7 +32,6 @@ module Pharos
 
       def configure_container_runtime
         if docker?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
@@ -40,14 +39,11 @@ module Pharos
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif crio?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
-          puts "********* #{insecure_registries}"
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,

--- a/lib/pharos/host/ubuntu/ubuntu_bionic.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_bionic.rb
@@ -32,22 +32,29 @@ module Pharos
 
       def configure_container_runtime
         if docker?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1"
+            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1",
+            INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
-            'configure-docker.sh'
+            'configure-docker.sh',
+            INSECURE_REGISTRIES: insecure_registries
           )
         elsif crio?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
+          puts "********* #{insecure_registries}"
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
             CRIO_STREAM_ADDRESS: '127.0.0.1',
             CPU_ARCH: host.cpu_arch.name,
-            IMAGE_REPO: cluster_config.image_repository
+            IMAGE_REPO: cluster_config.image_repository,
+            INSECURE_REGISTRIES: insecure_registries
           )
         else
           raise Pharos::Error, "Unknown container runtime: #{host.container_runtime}"

--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -32,22 +32,28 @@ module Pharos
 
       def configure_container_runtime
         if docker?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu2~16.04.1"
+            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu2~16.04.1",
+            INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
-            'configure-docker.sh'
+            'configure-docker.sh',
+            INSECURE_REGISTRIES: insecure_registries
           )
         elsif crio?
+          insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
             CRIO_STREAM_ADDRESS: '127.0.0.1',
             CPU_ARCH: host.cpu_arch.name,
-            IMAGE_REPO: cluster_config.image_repository
+            IMAGE_REPO: cluster_config.image_repository,
+            INSECURE_REGISTRIES: insecure_registries
           )
         else
           raise Pharos::Error, "Unknown container runtime: #{host.container_runtime}"

--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -32,7 +32,6 @@ module Pharos
 
       def configure_container_runtime
         if docker?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
@@ -40,13 +39,11 @@ module Pharos
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.to_json.inspect
           exec_script(
             'configure-docker.sh',
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif crio?
-          insecure_registries = cluster_config.container_runtime.insecure_registries.map(&:inspect).join(",").inspect
           exec_script(
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -78,6 +78,7 @@ module Pharos
 
         cmd.concat(EXPORT_ENVS.merge(env).map { |key, value| "#{key}=\"#{value}\"" })
         cmd.concat(%w(bash --norc --noprofile -x -s))
+        logger.debug { "exec: #{cmd}" }
         exec!(cmd, stdin: script, source: name, **options)
       end
 

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -1,3 +1,5 @@
+require 'recursive-open-struct'
+
 describe Pharos::Host::Configurer do
   let(:test_config_class) do
     Class.new(described_class) do
@@ -82,5 +84,71 @@ describe Pharos::Host::Configurer do
         subject.update_env_file
       end
     end
+  end
+
+  describe '#insecure_registries' do
+
+    context 'for docker' do
+      before do
+        allow(host).to receive(:crio?).and_return(false)
+      end
+
+      it 'gives properly escaped json array string' do
+        cfg = RecursiveOpenStruct.new({
+          container_runtime: {
+            insecure_registries: [
+              "registry.foobar.acme",
+              "localhost:5000"
+            ]
+          }
+        })
+        expect(subject).to receive(:cluster_config).and_return(cfg)
+
+        expect(subject.insecure_registries).to eq("\"[\\\"registry.foobar.acme\\\",\\\"localhost:5000\\\"]\"")
+      end
+
+      it 'works for empty array' do
+        cfg = RecursiveOpenStruct.new({
+          container_runtime: {
+            insecure_registries: []
+          }
+        })
+        expect(subject).to receive(:cluster_config).and_return(cfg)
+
+        expect(subject.insecure_registries).to eq("\"[]\"")
+      end
+    end
+
+    context 'for crio' do
+      before do
+        allow(host).to receive(:crio?).and_return(true)
+      end
+
+      it 'gives properly escaped json array string with brackets stripped' do
+        cfg = RecursiveOpenStruct.new({
+          container_runtime: {
+            insecure_registries: [
+              "registry.foobar.acme",
+              "localhost:5000"
+            ]
+          }
+        })
+        expect(subject).to receive(:cluster_config).and_return(cfg)
+
+        expect(subject.insecure_registries).to eq("\"\\\"registry.foobar.acme\\\",\\\"localhost:5000\\\"\"")
+      end
+
+      it 'works for empty array' do
+        cfg = RecursiveOpenStruct.new({
+          container_runtime: {
+            insecure_registries: []
+          }
+        })
+        expect(subject).to receive(:cluster_config).and_return(cfg)
+
+        expect(subject.insecure_registries).to eq("\"\"")
+      end
+    end
+
   end
 end

--- a/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
+++ b/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
@@ -15,6 +15,7 @@ describe Pharos::Host::UbuntuXenial do
     context 'docker' do
       it 'configures docker' do
         allow(subject).to receive(:docker?).and_return(true)
+        allow(subject).to receive(:insecure_registries)
         expect(subject).to receive(:exec_script).with('configure-docker.sh', anything)
         subject.configure_container_runtime
       end
@@ -23,6 +24,7 @@ describe Pharos::Host::UbuntuXenial do
     context 'cri-o' do
       it 'configures cri-o' do
         allow(subject).to receive(:cluster_config).and_return(cluster_config)
+        allow(subject).to receive(:insecure_registries)
         allow(subject).to receive(:docker?).and_return(false)
         allow(subject).to receive(:crio?).and_return(true)
         expect(subject).to receive(:exec_script).with('configure-cri-o.sh', anything)


### PR DESCRIPTION
fixes #588 

Insecure registries can be configured with:
```
container_runtime:
  insecure_registries:
    - "localhost:5000"
    - "foobar:5000"
```

Covers both Docker & CRI-O on all supported distros.

The `inspect` "hacks" are bit leaking now to all configurers, maybe I need to figure out single common place to generate the appropriate string format.