### PR TITLE
Fix version check to allow re-running up on prerelease versions

### DIFF
--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -63,7 +63,7 @@ module Pharos
 
       # Returns a requirement like "~>", "1.3.0"  which will match >= 1.3.0 && < 1.4.0
       def requirement
-        Gem::Requirement.new('~>' + pharos_version.segments.first(2).join('.') + '.0')
+        Gem::Requirement.new('~>' + pharos_version.segments.first(2).join('.') + (pharos_version.prerelease? ? '.0-alpha.0' : '.0'))
       end
     end
   end

--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -63,7 +63,7 @@ module Pharos
 
       # Returns a requirement like "~>", "1.3.0"  which will match >= 1.3.0 && < 1.4.0
       def requirement
-        Gem::Requirement.new('~>' + pharos_version.segments.first(2).join('.') + (pharos_version.prerelease? ? '.0-alpha.0' : '.0'))
+        Gem::Requirement.new('~>' + pharos_version.segments.first(2).join('.') + (pharos_version.prerelease? ? '.0-a' : '.0'))
       end
     end
   end

--- a/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
+++ b/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
@@ -1,0 +1,58 @@
+require 'pharos/phases/validate_version'
+require 'pharos_pro/phases/validate_version'
+
+describe Pharos::Phases::ValidateVersion do
+  let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.1', role: 'master') }
+  let(:network_config) { {} }
+  let(:config) { Pharos::Config.new(hosts: [host]) }
+  let(:ssh) { instance_double(Pharos::SSH::Client) }
+  subject { described_class.new(host, config: config, ssh: ssh) }
+
+  describe '#validate_version' do
+    it 'allows re-up for stable releases' do
+      stub_const('Pharos::VERSION', '1.3.3')
+      expect{subject.validate_version('1.3.3')}.not_to raise_error
+    end
+
+    it 'allows re-up for development releases' do
+      stub_const('Pharos::VERSION', '2.0.0-alpha.1')
+      expect{subject.validate_version('2.0.0-alpha.1')}.not_to raise_error
+    end
+
+    it 'allows upgrade from patch-release to another' do
+      stub_const('Pharos::VERSION', '2.0.1')
+      expect{subject.validate_version('2.0.0')}.not_to raise_error
+    end
+
+    it 'allows upgrade from patch-release to development patch-release' do
+      stub_const('Pharos::VERSION', '2.0.1-alpha.1')
+      expect{subject.validate_version('2.0.0')}.not_to raise_error
+    end
+
+    it 'does not allow downgrade on development releases' do
+      stub_const('Pharos::VERSION', '2.0.0-alpha.1')
+      expect{subject.validate_version('2.0.0-alpha.2')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'does not allow downgrade on stable releases' do
+      stub_const('Pharos::VERSION', '1.3.3')
+      expect{subject.validate_version('2.0.0')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'does not allow downgrade from stable to prerelease' do
+      stub_const('Pharos::VERSION', '2.0.0-alpha.1')
+      expect{subject.validate_version('2.0.0')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'does not allow downgrade from prerelease to stable' do
+      stub_const('Pharos::VERSION', '2.0.0')
+      expect{subject.validate_version('2.0.1-alpha.1')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'allows upgrade to point-release' do
+      stub_const('Pharos::VERSION', '2.1.0')
+      expect{subject.validate_version('2.0.0')}.not_to raise_error
+    end
+  end
+end
+

--- a/spec/pharos/phases/validate_version_spec.rb
+++ b/spec/pharos/phases/validate_version_spec.rb
@@ -1,0 +1,56 @@
+require 'pharos/phases/validate_version'
+
+describe Pharos::Phases::ValidateVersion do
+  let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.1', role: 'master') }
+  let(:network_config) { {} }
+  let(:config) { Pharos::Config.new(hosts: [host]) }
+  let(:ssh) { instance_double(Pharos::SSH::Client) }
+  subject { described_class.new(host, config: config, ssh: ssh) }
+
+  describe '#validate_version' do
+    it 'allows re-up for stable releases' do
+      stub_const('Pharos::VERSION', '1.3.3')
+      expect{subject.validate_version('1.3.3')}.not_to raise_error
+    end
+
+    it 'allows re-up for development releases' do
+      stub_const('Pharos::VERSION', '2.0.0-alpha.1')
+      expect{subject.validate_version('2.0.0-alpha.1')}.not_to raise_error
+    end
+
+    it 'allows upgrade from patch-release to another' do
+      stub_const('Pharos::VERSION', '2.0.1')
+      expect{subject.validate_version('2.0.0')}.not_to raise_error
+    end
+
+    it 'allows upgrade from patch-release to development patch-release' do
+      stub_const('Pharos::VERSION', '2.0.1-alpha.1')
+      expect{subject.validate_version('2.0.0')}.not_to raise_error
+    end
+
+    it 'does not allow downgrade on development releases' do
+      stub_const('Pharos::VERSION', '2.0.0-alpha.1')
+      expect{subject.validate_version('2.0.0-alpha.2')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'does not allow downgrade on stable releases' do
+      stub_const('Pharos::VERSION', '1.3.3')
+      expect{subject.validate_version('2.0.0')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'does not allow downgrade from stable to prerelease' do
+      stub_const('Pharos::VERSION', '2.0.0-alpha.1')
+      expect{subject.validate_version('2.0.0')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'does not allow downgrade from prerelease to stable' do
+      stub_const('Pharos::VERSION', '2.0.0')
+      expect{subject.validate_version('2.0.1-alpha.1')}.to raise_error(RuntimeError, "Downgrade not supported")
+    end
+
+    it 'does not allow upgrade to point-release' do
+      stub_const('Pharos::VERSION', '2.1.0')
+      expect{subject.validate_version('2.0.0')}.to raise_error(RuntimeError, "Upgrade path not supported")
+    end
+  end
+end


### PR DESCRIPTION
Sets the version requirement to `x.y.0-a` instead of `x.y.0` when the reported cluster version is a prerelease version. This makes a prerelease `Pharos::VERSION` like `2.0.0-alpha.1` satisfy the  requirement when the cluster version is something like `2.0.0-alpha.1`.

Includes specs.

```
> Gem::Requirement.new('~> 2.0.0').satisfied_by?(Gem::Version.new('2.0.0-alpha.1'))
=> false
> Gem::Requirement.new('~> 2.0.0-a').satisfied_by?(Gem::Version.new('2.0.0-alpha.1'))
=> true
```


