### PR TITLE
Add +oss to OSS version string output

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -15,7 +15,7 @@ module Pharos
     option '--[no-]color', :flag, "colorize output", default: $stdout.tty?
 
     option ['-v', '--version'], :flag, "print #{File.basename($PROGRAM_NAME)} version" do
-      puts "#{File.basename($PROGRAM_NAME)} #{Pharos::VERSION}"
+      puts "#{File.basename($PROGRAM_NAME)} #{Pharos.version}"
       exit 0
     end
 

--- a/lib/pharos/phases/store_cluster_configuration.rb
+++ b/lib/pharos/phases/store_cluster_configuration.rb
@@ -25,7 +25,7 @@ module Pharos
           },
           data: {
             'cluster.yml' => data.to_yaml,
-            'pharos-version' => Pharos::VERSION,
+            'pharos-version' => Pharos.version,
             'pharos-components.yml' => components.to_yaml,
             'pharos-addons.yml' => addons.to_yaml
           }

--- a/lib/pharos/phases/upgrade_check.rb
+++ b/lib/pharos/phases/upgrade_check.rb
@@ -33,13 +33,13 @@ module Pharos
 
         version = Excon.get(
           VERSION_URL,
-          headers: { 'User-Agent' => "pharos/#{Pharos::VERSION}" },
+          headers: { 'User-Agent' => "pharos/#{Pharos.version}" },
           query: channel_query
         ).body
 
         raise "Invalid version response format: #{version}" unless version.match?(/^\d+\.\d+\.\d+(\-\S+)?$/)
 
-        @latest_version = Gem::Version.new(version)
+        @latest_version = Gem::Version.new(version.gsub(/\+.*/, ''))
       end
 
       def channel_query

--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -21,7 +21,7 @@ module Pharos
 
       # @param cluster_version [String]
       def validate_version(cluster_version)
-        cluster_version = Gem::Version.new(cluster_version)
+        cluster_version = Gem::Version.new(cluster_version.gsub(/\+.*/, ''))
         raise "Downgrade not supported" if cluster_version > pharos_version
         raise "Upgrade path not supported" unless requirement.satisfied_by?(cluster_version)
 

--- a/lib/pharos/reset_command.rb
+++ b/lib/pharos/reset_command.rb
@@ -3,7 +3,7 @@
 module Pharos
   class ResetCommand < UpCommand
     def execute
-      puts pastel.bright_green("==> KONTENA PHAROS v#{Pharos::VERSION} (Kubernetes v#{Pharos::KUBE_VERSION})")
+      puts pastel.bright_green("==> KONTENA PHAROS v#{Pharos.version} (Kubernetes v#{Pharos::KUBE_VERSION})")
       puts pastel.green("==> Reading instructions ...")
       config = load_config
 

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -5,7 +5,7 @@ module Pharos
     options :load_config, :yes?
 
     def execute
-      puts pastel.bright_green("==> KONTENA PHAROS v#{Pharos::VERSION} (Kubernetes v#{Pharos::KUBE_VERSION})")
+      puts pastel.bright_green("==> KONTENA PHAROS v#{Pharos.version} (Kubernetes v#{Pharos::KUBE_VERSION})")
 
       Pharos::Kube.init_logging!
 

--- a/lib/pharos/version_command.rb
+++ b/lib/pharos/version_command.rb
@@ -4,7 +4,7 @@ module Pharos
   class VersionCommand < Pharos::Command
     def execute
       puts "Kontena Pharos:"
-      puts "  - #{File.basename($PROGRAM_NAME)} version #{Pharos::VERSION}"
+      puts "  - #{File.basename($PROGRAM_NAME)} version #{Pharos.version}"
       ClusterManager.new(Pharos::Config.new({}), pastel: false).load
 
       phases.each do |os, phases|

--- a/non-oss/pharos_non_oss.rb
+++ b/non-oss/pharos_non_oss.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pharos_pro/version'
+
 Pharos::ClusterManager.phase_dirs << File.join(__dir__, 'pharos_pro', 'phases')
 Pharos::ClusterManager.addon_dirs << File.join(__dir__, 'pharos_pro', 'addons')
 

--- a/non-oss/pharos_pro/commands/license_assign_command.rb
+++ b/non-oss/pharos_pro/commands/license_assign_command.rb
@@ -10,7 +10,7 @@ module Pharos
     option '--description', 'DESCRIPTION', "license description"
 
     def default_description
-      "pharos version #{Pharos::VERSION} on #{master_host.address}"
+      "pharos version #{Pharos.version} on #{master_host.address}"
     end
 
     def default_license_key
@@ -54,7 +54,7 @@ module Pharos
         headers: {
           'Accept' => 'application/json',
           'Content-Type' => 'application/json',
-          'User-Agent' => "pharos-cluster/#{Pharos::VERSION}"
+          'User-Agent' => "pharos-cluster/#{Pharos.version}"
         }
       )
     end

--- a/non-oss/pharos_pro/version.rb
+++ b/non-oss/pharos_pro/version.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.5"
   def self.version
-    VERSION + "+oss"
+    VERSION
   end
 end

--- a/non-oss/spec/pharos_pro/commands/version_command_spec.rb
+++ b/non-oss/spec/pharos_pro/commands/version_command_spec.rb
@@ -1,0 +1,14 @@
+describe Pharos::VersionCommand do
+  subject { described_class.new('') }
+
+  it 'outputs version without +oss' do
+    expect{subject.run([])}.to output(/Kontena Pharos:\n.+?version \d+\.\d+\.\d+(?:\-[\+]+)?\n/m).to_stdout
+  end
+
+  context '--version' do
+    it 'outputs version with +oss' do
+      expect{subject.run(['--version'])}.to output(/.+?version \d+\.\d+\.\d+(?:\-[\+]+)?\n/).to_stdout
+    end
+  end
+end
+

--- a/spec/pharos/version_command_spec.rb
+++ b/spec/pharos/version_command_spec.rb
@@ -1,0 +1,13 @@
+describe Pharos::VersionCommand do
+  subject { described_class.new('') }
+
+  it 'outputs version with +oss' do
+    expect{subject.run([])}.to output(/Kontena Pharos:\n.+?version (\S+)\+oss/m).to_stdout
+  end
+
+  context '--version' do
+    it 'outputs version with +oss' do
+      expect{subject.run(['--version'])}.to output(/.+?version (\S+)\+oss/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Adds the `+oss` build tag to version string outputs

```
$ PHAROS_NON_OSS=true bundle exec bin/pharos-cluster --version
pharos-cluster 2.0.5
 $ PHAROS_NON_OSS=false bundle exec bin/pharos-cluster --version
pharos-cluster 2.0.5+oss
```
