### PR TITLE
Restore version back to 2.0.0-alpha.2

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.5"
+  VERSION = "2.0.0-alpha.2"
+
   def self.version
     VERSION + "+oss"
   end

--- a/non-oss/spec/pharos_pro/commands/version_command_spec.rb
+++ b/non-oss/spec/pharos_pro/commands/version_command_spec.rb
@@ -1,13 +1,17 @@
 describe Pharos::VersionCommand do
   subject { described_class.new('') }
 
+  it 'outputs pharos version' do
+    expect{subject.run([])}.to output(/Kontena Pharos:\n[^\n]+?(\d+\.\d+\.\d+)/).to_stdout
+  end
+
   it 'outputs version without +oss' do
-    expect{subject.run([])}.to output(/Kontena Pharos:\n.+?version \d+\.\d+\.\d+(?:\-[\+]+)?\n/m).to_stdout
+    expect{subject.run([])}.not_to output(/\+oss$/m).to_stdout
   end
 
   context '--version' do
     it 'outputs version with +oss' do
-      expect{subject.run(['--version'])}.to output(/.+?version \d+\.\d+\.\d+(?:\-[\+]+)?\n/).to_stdout
+      expect{subject.run(['--version'])}.not_to output(/\+oss$/m).to_stdout
     end
   end
 end


### PR DESCRIPTION
#710 slipped in a future version number

And apparently the spec did not work on prerelease-versions.
