### PR TITLE
Warn when cluster version is going to change during "pharos up"

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -6,7 +6,7 @@ module Pharos
   class ClusterManager
     include Pharos::Logging
 
-    attr_reader :config
+    attr_reader :config, :context
 
     def self.phase_dirs
       @phase_dirs ||= [
@@ -64,6 +64,7 @@ module Pharos
 
     def gather_facts
       apply_phase(Phases::GatherFacts, config.hosts, ssh: true, parallel: true)
+      apply_phase(Phases::ConfigureClient, [sorted_master_hosts.first], ssh: true, master: sorted_master_hosts.first, parallel: false, optional: true)
     end
 
     def validate

--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -13,7 +13,9 @@ module Pharos
         cluster_context['kubeconfig'] = kubeconfig
         config_map = previous_config_map
         if config_map
-          validate_version(config_map.data['pharos-version'])
+          existing_version = config_map.data['pharos-version']
+          cluster_context['existing-pharos-version'] = existing_version
+          validate_version(existing_version)
         else
           logger.info { 'No version detected' }
         end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -96,7 +96,7 @@ module Pharos
       end
       if existing_version && Pharos::VERSION != existing_version
         puts
-        puts pastel.yellow("Cluster is currently running Pharos version #{existing_version} and will be upgraded to #{Pharos.version}")
+        puts pastel.yellow("Cluster is currently running Kontea Pharos version #{existing_version} and will be upgraded to #{Pharos.version}")
         puts
       end
       if tty? && !yes?

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -94,7 +94,7 @@ module Pharos
       else
         puts config.to_yaml
       end
-      if existing_version && Pharos::VERSION != existing_version
+      if existing_version && Pharos.version != existing_version
         puts
         puts pastel.yellow("Cluster is currently running Kontea Pharos version #{existing_version} and will be upgraded to #{Pharos.version}")
         puts

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -37,7 +37,7 @@ module Pharos
       show_component_versions(config)
       show_addon_versions(manager)
       manager.apply_addons_cluster_config_modifications
-      prompt_continue(config)
+      prompt_continue(config, manager.context['existing-pharos-version'])
 
       puts pastel.green("==> Starting to craft cluster ...")
       manager.apply_phases
@@ -84,7 +84,8 @@ module Pharos
     end
 
     # @param config [Pharos::Config]
-    def prompt_continue(config)
+    # @param existing_version [String]
+    def prompt_continue(config, existing_version)
       lexer = Rouge::Lexers::YAML.new
       puts pastel.green("==> Configuration is generated and shown below:")
       if color?
@@ -92,6 +93,11 @@ module Pharos
         puts ""
       else
         puts config.to_yaml
+      end
+      if existing_version && Pharos::VERSION != existing_version
+        puts
+        puts pastel.yellow("Cluster is currently running Pharos version #{existing_version} and will be upgraded to #{Pharos.version}")
+        puts
       end
       if tty? && !yes?
         exit 1 unless prompt.yes?('Continue?')

--- a/spec/pharos/up_command_spec.rb
+++ b/spec/pharos/up_command_spec.rb
@@ -19,27 +19,41 @@ describe Pharos::UpCommand do
       allow(subject).to receive(:tty?).and_return(true)
       expect(subject).to receive(:prompt).and_return(prompt)
       expect(prompt).to receive(:yes?)
-      subject.prompt_continue(config)
+      subject.prompt_continue(config, Pharos.version)
     end
 
     it 'does not prompt with --yes' do
       allow(subject).to receive(:yes?).and_return(true)
       expect(subject).not_to receive(:prompt)
-      subject.prompt_continue(config)
+      subject.prompt_continue(config, Pharos.version)
     end
 
     it 'shows config' do
       allow(subject).to receive(:yes?).and_return(true)
       expect(subject).to receive(:color?).and_return(true).at_least(1).times
       expect(config).to receive(:to_yaml).and_return('---')
-      subject.prompt_continue(config)
+      subject.prompt_continue(config, Pharos.version)
     end
 
     it 'shows config without color' do
       allow(subject).to receive(:yes?).and_return(true)
       expect(subject).to receive(:color?).and_return(false).at_least(1).times
       expect(config).to receive(:to_yaml).and_return('---')
-      subject.prompt_continue(config)
+      subject.prompt_continue(config, Pharos.version)
+    end
+
+    it 'shows a warning when the cluster is going to be upgraded' do
+      allow(subject).to receive(:yes?).and_return(true)
+      expect(subject).to receive(:color?).and_return(false).at_least(1).times
+      expect(config).to receive(:to_yaml).and_return('---')
+      expect{subject.prompt_continue(config, '0.0.0')}.to output(/will be upgraded/).to_stdout
+    end
+
+    it 'does not show a warning when the cluster is going to be upgraded' do
+      allow(subject).to receive(:yes?).and_return(true)
+      expect(subject).to receive(:color?).and_return(false).at_least(1).times
+      expect(config).to receive(:to_yaml).and_return('---')
+      expect{subject.prompt_continue(config, Pharos.version)}.not_to output(/will be upgraded/).to_stdout
     end
   end
 end


### PR DESCRIPTION
Fixes #325

Adds a warning when `pharos up` will cause an upgrade from the currently running version.

```
$ pharos up
...
...
addons:
  ingress-nginx:
    enabled: true

Cluster is currently running Pharos version 2.0.1 and will be upgraded to 2.5.0

Continue? (Y/n)
```
