### PR TITLE
Release v2.0.0-beta.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.0.0.alpha.1)
+    pharos-cluster (2.0.0.beta.1)
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
       dry-struct (= 0.5.0)

--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -10,7 +10,7 @@ chmod +x /usr/local/bin/rubyc
 gem install bundler
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}"
-sudo mkdir -p /root/.pharos/build
+mkdir -p /root/.pharos/build
 rubyc -o "$package" -d /root/.pharos/build --make-args=--silent pharos-cluster
 rm -rf /root/.pharos/build
 ./"$package" version

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.0-alpha.2"
+  VERSION = "2.0.0-beta.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.0-alpha.2

- add "pharos ssh" command to launch ssh into cluster hosts (#581)
- kontena-lens addon: add developer and devops roles (#698)
- fix version check to allow re-running up on prerelease versions (#704)
- extract common command options to reusable modules (#700)
- run shellcheck for all shell scripts during automated tests (#594)
- allow lens-operator to watch resources (#707)
- update kontena license (#708)
- support for configuring insecure registries through cluster.yml (#703)
- add +oss to OSS version string output (#710, #711)
- improved PATH manipulation in el7/centos configure-essentials.sh (#693)
- log waiting for etcd (#712)
- warn when cluster version is going to change during "pharos up" (#713)
