### PR TITLE
Fix SSH command filtered hosts usage

### DIFF
--- a/lib/pharos/ssh_command.rb
+++ b/lib/pharos/ssh_command.rb
@@ -11,7 +11,7 @@ module Pharos
 
     def execute
       exit run_interactive if command_list.empty?
-      exit run_single(hosts.first) if hosts.size == 1
+      exit run_single(filtered_hosts.first) if filtered_hosts.size == 1
       exit run_parallel
     end
 


### PR DESCRIPTION
Fixes #716 

The #700 broke `pharos ssh` usage on a single target host.
