### PR TITLE
Allow configuring of tolerations for ingress-nginx daemonset

### DIFF
--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -10,6 +10,7 @@ Pharos.addon 'ingress-nginx' do
     attribute :default_backend, Pharos::Types::Hash.default(
       'image' => 'registry.pharos.sh/kontenapharos/pharos-default-backend:0.0.3'
     )
+    attribute :tolerations, Pharos::Types::Array.default([])
   }
 
   config_schema {
@@ -18,6 +19,7 @@ Pharos.addon 'ingress-nginx' do
     optional(:default_backend).schema {
       optional(:image).filled(:str?)
     }
+    optional(:tolerations).each(:hash?)
   }
 
   install {

--- a/addons/ingress-nginx/resources/daemonset.yml.erb
+++ b/addons/ingress-nginx/resources/daemonset.yml.erb
@@ -25,12 +25,14 @@ spec:
       <%- end -%>
       serviceAccountName: nginx-ingress-serviceaccount
       hostNetwork: true
+      <%- unless config.tolerations.empty? -%>
       tolerations:
       <%- config.tolerations.each do |t| -%>
         -
           <%- t.each do |k,v| -%>
           <%= k %>: <%= v %>
           <%- end -%>
+      <%- end -%>
       <%- end -%>
       initContainers:
       - command:

--- a/addons/ingress-nginx/resources/daemonset.yml.erb
+++ b/addons/ingress-nginx/resources/daemonset.yml.erb
@@ -25,6 +25,13 @@ spec:
       <%- end -%>
       serviceAccountName: nginx-ingress-serviceaccount
       hostNetwork: true
+      tolerations:
+      <%- config.tolerations.each do |t| -%>
+        -
+          <%- t.each do |k,v| -%>
+          <%= k %>: <%= v %>
+          <%- end -%>
+      <%- end -%>
       initContainers:
       - command:
         - sh


### PR DESCRIPTION
fixes #720 

Tolerations can be configured using something like:
```
addons:
  ingress-nginx:
    enabled: true
    tolerations:
      - key: "key"
        operator: "Equal"
        value: "value"
        effect: "NoSchedule"
```