### PR TITLE
Release v2.0.0-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.0-beta.1"
+  VERSION = "2.0.0-rc.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.0-beta.1

- bastion host (#719)
- run the interactive ssh through Net::SSH (#727)
- support docker as container_runtime in debian (#701)
- kontena-lens 1.1.0 (#722)
- cri-o v1.11.7 (#726)
- fix SSH command filtered hosts usage (#718)
- allow configuring of tolerations for ingress-nginx daemonset (#721)
- update k8s-client to 0.4.2 (#725)