### PR TITLE
[RFC] Add global: keyword for global host settings

### DIFF
--- a/cluster.example.yml
+++ b/cluster.example.yml
@@ -1,3 +1,5 @@
+global:
+  role: worker
 hosts:
   - address: 1.1.1.1
     private_interface: eth1
@@ -7,13 +9,11 @@ hosts:
     container_runtime: cri-o
   - address: 2.2.2.2
     private_interface: eth1
-    role: worker
     container_runtime: cri-o
     labels:
       disk: hdd
   - address: 3.3.3.3
     private_address: 10.10.1.3
-    role: worker
     container_runtime: cri-o
     labels:
       disk: ssd

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -27,6 +27,14 @@ module Pharos
     # @raise [Pharos::ConfigError]
     # @return [Pharos::Config]
     def self.load(raw_data)
+      raw_data.deep_stringify_keys!
+      if raw_data['global'] && raw_data['hosts']
+        raw_data['hosts'] = raw_data['hosts'].map do |host|
+          raw_data['global'].merge(host)
+        end
+        raw_data.delete('global')
+      end
+
       schema_data = Pharos::ConfigSchema.load(raw_data)
 
       config = new(schema_data)

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -31,6 +31,31 @@ describe Pharos::Config do
       end
     end
 
+    context 'with host globals' do
+      let(:data) {
+        {
+          'global' => {
+            'user' => 'root',
+            'role' => 'worker'
+          },
+          'hosts' => [
+            { 'address' => '127.0.0.1', role: 'master' },
+            { 'address' => '127.0.0.2' },
+            { 'address' => '127.0.0.3', 'user' => 'ubuntu' }
+          ]
+        }
+      }
+
+      it 'merges global config to each host' do
+        expect(subject.hosts[0].user).to eq 'root'
+        expect(subject.hosts[1].user).to eq 'root'
+        expect(subject.hosts[2].user).to eq 'ubuntu'
+        expect(subject.hosts[0].role).to eq 'master'
+        expect(subject.hosts[1].role).to eq 'worker'
+        expect(subject.hosts[2].role).to eq 'worker'
+      end
+    end
+
     describe 'taints' do
       let(:data) { {
         'hosts' => [


### PR DESCRIPTION
Reduce config repetition by adding a `global:` keyword that applies to all hosts.

If a host redefines a key, it will override the global.

TODO:
- should maybe do a deep merge to allow for example to override something inside a nested hash instead of replacing the whole hash.

