### PR TITLE
[POC/RFC] Per host phase before/after hooks

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -72,6 +72,8 @@ module Pharos
                 optional(:user).filled(:str?)
                 optional(:ssh_key_path).filled(:str?)
               end
+              optional(:before).filled
+              optional(:after).filled
             end
           end
         end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -62,6 +62,8 @@ module Pharos
       attribute :container_runtime, Pharos::Types::Strict::String.default('docker')
       attribute :environment, Pharos::Types::Strict::Hash
       attribute :bastion, Pharos::Configuration::Bastion
+      attribute :before, Pharos::Types::Strict::Hash
+      attribute :after, Pharos::Types::Strict::Hash
 
       attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks, :resolvconf, :routes
 

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -119,6 +119,7 @@ module Pharos
 
       logger.info { "Running #{state} #{klass_title} hooks .." }
       hooks.each do |hook|
+        logger.info { "Running #{hook} .." }
         case hook
         when Array
           ssh_client.exec!(hook.join(' '))
@@ -131,7 +132,6 @@ module Pharos
             ssh_client.file(to).write(File.open(local_file, 'r'))
           end
         end
-        logger.info { "Running #{hook} .." }
       end
     end
 

--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -89,7 +89,7 @@ module Pharos
       run(phases, parallel: parallel) do |phase|
         start = Time.now
 
-        phase.call
+        phase.run
 
         logger.debug { "Completed #{phase} in #{'%.3fs' % [Time.now - start]}" }
       end


### PR DESCRIPTION
```yaml
hosts:
  - address: 192.168.100.100
    private_address: 192.168.100.100 
    after:
      gather_facts:
        - ls -al /tmp
        - copy_from: *.yml
          to: /tmp
        - ls -al /tmp/
```

=>

```
    [192.168.100.100] Running after gather_facts hooks ..
    [192.168.100.100] Running ls -al /tmp ..
    $ ls -al /tmp
    total 32
    drwxrwxrwt  7 root    root    4096 Oct 31 11:17 .
    drwxr-xr-x 23 root    root    4096 Oct 23 08:00 ..
    ! 0
    [192.168.100.100] Uploading file /Users/kimmo/Projects/pc2/buster.yml to 192.168.100.100:/tmp/buster.yml
    [192.168.100.100] Running ls -al /tmp ..
    $ ls -al /tmp/
    total 36
    drwxrwxrwt  7 root    root    4096 Oct 31 11:17 .
    drwxr-xr-x 23 root    root    4096 Oct 23 08:00 ..
    -rw-rw-r--  1 vagrant vagrant 1009 Oct 31 11:17 buster.yml
    ! 0
```

TODO:
- figure out glob root so that `/tmp/**/*.yml -> /tmp/` will not upload everything to flat `/tmp/.
