### PR TITLE
Raise UnknownAddon error earlier if add-on class not found

### DIFF
--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -52,6 +52,7 @@ module Pharos
     def configs
       @configs ||= @config.addons.sort_by { |name, _config|
         addon_class = addon_classes.find { |a| a.addon_name == name }
+        raise UnknownAddon, "unknown addon: #{name}" if addon_class.nil?
         addon_class.priority
       }.to_h
     end
@@ -131,8 +132,6 @@ module Pharos
         klass = addon_classes.find { |a| a.addon_name == name }
         if klass && config["enabled"]
           yield(klass, config)
-        elsif klass.nil?
-          raise UnknownAddon, "unknown addon: #{name}"
         end
       end
     end


### PR DESCRIPTION
This PR raises `UnknownAddon` error when loading addon configs and sorting them based on priority. Previously if addon class was not found, it failed with `NoMethodError : undefined method 'priority' for nil:NilClass`