### PR TITLE
Release v2.0.0-rc.3

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.0-rc.2"
+  VERSION = "2.0.0-rc.3"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.0-rc.2

- upgrade Kontena Lens to 1.2.0 (#751)
- improve runtime upgrade/downgrade + downgrade cri-o to 1.11.6 (#749)
- allow to pass default value to confirm_yes! method (#737)
- allow to override used shell image (#740)
- validate localhost dns resolve (#739)
- validate hosts peer address being node local address (#742)
- fix Kontena Lens dashboard templates (#747)
- raise UnknownAddon error earlier if add-on class not found (#754)
- enhance lens-authenticator manifest (#750)
- retry if lens configuration creation fails (#748)
- don't validate cluster version if api down (#755)
- allow developer role to list events (#757)
- fix ssh manager regression/error (#756)
- update digitalocean example to 2.0 (#758)
- update terraform-aws to 2.0 (#759)
- fix ubuntu configurer error when docker is used (#760)
- allow telemetry to read license token (#743)