### PR TITLE
Fix upgrade from previous versions

### DIFF
--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -23,11 +23,14 @@ module Pharos
 
         logger.info { "Checking if Kubernetes control plane is already initialized ..." }
         if install?
-          logger.info { "Kubernetes control plane is not initialized" }
+          logger.info { "Kubernetes control plane is not initialized." }
           install
           install_kubeconfig
-        else
+        elsif !cluster_context['api_upgraded']
+          logger.info { "Kubernetes control plane is up to date." }
           reconfigure
+        else
+
         end
 
         cluster_context['master-certs'] = pull_kube_certs unless cluster_context['master-certs']

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -27,10 +27,9 @@ module Pharos
           install
           install_kubeconfig
         elsif !cluster_context['api_upgraded']
-          logger.info { "Kubernetes control plane is up to date." }
           reconfigure
         else
-
+          logger.info { "Kubernetes control plane is up to date." }
         end
 
         cluster_context['master-certs'] = pull_kube_certs unless cluster_context['master-certs']

--- a/lib/pharos/phases/configure_master.rb
+++ b/lib/pharos/phases/configure_master.rb
@@ -36,7 +36,7 @@ module Pharos
       def install
         cfg = kubeadm.generate_config
 
-        logger.info { "Initializing control plane ..." }
+        logger.info { "Initializing control plane (v#{Pharos::KUBE_VERSION}) ..." }
         logger.debug { cfg.to_yaml }
 
         @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
@@ -59,7 +59,7 @@ module Pharos
 
         cfg = kubeadm.generate_config
 
-        logger.info { "Configuring control plane ..." }
+        logger.info { "Reconfiguring control plane (v#{Pharos::KUBE_VERSION})..." }
         logger.debug { cfg.to_yaml }
 
         @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|
@@ -144,13 +144,13 @@ module Pharos
           logger.debug { "apiserver cert is up to update: #{sans}" }
           return false
         else
-          logger.debug { "apisever cert is missing SANs: #{missing_sans} (extra: #{extra_sans})" }
+          logger.debug { "apiserver cert is missing SANs: #{missing_sans} (extra: #{extra_sans})" }
           return true
         end
       end
 
       def replace_cert
-        logger.info { "Replacing apisever cert" }
+        logger.info { "Replacing apiserver cert" }
 
         @ssh.file(APISERVER_CERT).rm
         @ssh.file(APISERVER_KEY).rm

--- a/lib/pharos/phases/upgrade_master.rb
+++ b/lib/pharos/phases/upgrade_master.rb
@@ -12,9 +12,19 @@ module Pharos
       def upgrade?
         file = @ssh.file('/etc/kubernetes/manifests/kube-apiserver.yaml')
         return false unless file.exist?
-        return false if file.read.match?(/kube-apiserver-.+:v#{Pharos::KUBE_VERSION}/)
+
+        match = file.read.match(/kube-apiserver-.+:v(.+)/)
+        current_major_minor = parse_major_minor(match[1])
+        new_major_minor = parse_major_minor(Pharos::KUBE_VERSION)
+        return false if current_major_minor == new_major_minor
 
         true
+      end
+
+      # @param version [String]
+      # @return [String]
+      def parse_major_minor(version)
+        version.split('.')[0...2].join('.')
       end
 
       def call
@@ -33,7 +43,7 @@ module Pharos
       def upgrade
         cfg = kubeadm.generate_config
 
-        logger.info { "Upgrading control plane ..." }
+        logger.info { "Upgrading control plane to v#{Pharos::KUBE_VERSION} ..." }
         logger.debug { cfg.to_yaml }
 
         @ssh.tempfile(content: cfg.to_yaml, prefix: "kubeadm.cfg") do |tmp_file|

--- a/lib/pharos/phases/upgrade_master.rb
+++ b/lib/pharos/phases/upgrade_master.rb
@@ -51,6 +51,7 @@ module Pharos
         end
 
         logger.info { "Control plane upgrade succeeded!" }
+        cluster_context['api_upgraded'] = true
       end
     end
   end


### PR DESCRIPTION
Upgrade from kubernetes 1.11.3 to 1.11.4 hangs when done via `kubeadm upgrade`. This PR changes the upgrade behaviour in following ways:

- no need to do full upgrade if major.minor is same
- no need to run reconfigure if previous phase has already configured control-plane