### PR TITLE
Region aware peer addresses

### DIFF
--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -99,12 +99,12 @@ module Pharos
 
     # @return [Array<String>]
     def etcd_regions
-      @etcd_regions ||= etcd_hosts.map(:&region).compact.uniq
+      @etcd_regions ||= etcd_hosts.map(&:region).compact.uniq
     end
 
     # @return [Array<String>]
     def regions
-      @regions ||= hosts.map(:&region).compact.uniq
+      @regions ||= hosts.map(&:region).compact.uniq
     end
 
     # @param kubeconfig [Hash]

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -99,7 +99,12 @@ module Pharos
 
     # @return [Array<String>]
     def etcd_regions
-      @regions ||= etcd_hosts.map { |host| host.region }.compact.uniq
+      @etcd_regions ||= etcd_hosts.map { |host| host.region }.compact.uniq
+    end
+
+    # @return [Array<String>]
+    def regions
+      @regions ||= hosts.map { |host| host.region }.compact.uniq
     end
 
     # @param kubeconfig [Hash]

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -87,7 +87,7 @@ module Pharos
       if etcd_hosts.empty?
         master_hosts.sort_by(&:etcd_sort_score)
       else
-        etcd_hosts..sort_by(&:etcd_sort_score)
+        etcd_hosts.sort_by(&:etcd_sort_score)
       end
     end
 

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -66,12 +66,12 @@ module Pharos
 
     # @return [Array<Pharos::Configuration::Node>]
     def master_hosts
-      @master_hosts ||= hosts.select { |h| h.role == 'master' }.sort_by(&:master_sort_score)
+      hosts.select { |h| h.role == 'master' }.sort_by(&:master_sort_score)
     end
 
     # @return [Pharos::Configuration::Node]
     def master_host
-      @master_host ||= master_hosts.first
+      master_hosts.first
     end
 
     # @return [Array<Pharos::Configuration::Node>]

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -99,12 +99,12 @@ module Pharos
 
     # @return [Array<String>]
     def etcd_regions
-      @etcd_regions ||= etcd_hosts.map { |host| host.region }.compact.uniq
+      @etcd_regions ||= etcd_hosts.map(:&region).compact.uniq
     end
 
     # @return [Array<String>]
     def regions
-      @regions ||= hosts.map { |host| host.region }.compact.uniq
+      @regions ||= hosts.map(:&region).compact.uniq
     end
 
     # @param kubeconfig [Hash]

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -36,6 +36,14 @@ module Pharos
       result.to_h
     end
 
+    module CustomPredicates
+      include Dry::Logic::Predicates
+
+      predicate(:hostname_or_ip?) do |value|
+        value.match?(/\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\z/) || value.match?(/\A[a-z0-9\-\.]+\z/)
+      end
+    end
+
     # @return [Dry::Validation::Schema]
     def self.build
       # rubocop:disable Lint/NestedMethodDefinition
@@ -43,15 +51,22 @@ module Pharos
         configure do
           def self.messages
             super.merge(
-              en: { errors: { network_dns_replicas: "network.dns_replicas cannot be larger than the number of hosts" } }
+              en: {
+                errors: {
+                  network_dns_replicas: "network.dns_replicas cannot be larger than the number of hosts",
+                  hostname_or_ip?: "is invalid"
+                }
+              }
             )
           end
         end
+
         required(:hosts).filled(min_size?: 1) do
           each do
             schema do
-              required(:address).filled
-              optional(:private_address).filled
+              predicates(CustomPredicates)
+              required(:address).filled(:str?, :hostname_or_ip?)
+              optional(:private_address).filled(:str?, :hostname_or_ip?)
               optional(:private_interface).filled
               required(:role).filled(included_in?: ['master', 'worker'])
               optional(:labels).filled

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -115,9 +115,12 @@ module Pharos
 
       # @return [Hash]
       def labels
-        return @attributes[:labels] || {} unless worker?
+        labels = @attributes[:labels] || {}
 
-        @attributes[:labels] || { 'node-role.kubernetes.io/worker': "" }
+        labels['node-address.pharos.sh/external-ip'] = address
+        labels['node-role.kubernetes.io/worker'] = '' if worker?
+
+        labels
       end
 
       # @return [Hash]

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -93,12 +93,27 @@ module Pharos
         api_endpoint || address
       end
 
+      # @return [String]
       def peer_address
         private_address || private_interface_address || address
       end
 
+      # @param host [Pharos::Configuration::Host]
+      # @return [String]
+      def peer_address_for(host)
+        if region == host.region
+          peer_address
+        else
+          address
+        end
+      end
+
+      def region
+        labels['failure-domain.beta.kubernetes.io/region'] || 'unknown'
+      end
+
       def labels
-        return @attributes[:labels] unless worker?
+        return @attributes[:labels] || {} unless worker?
 
         @attributes[:labels] || { 'node-role.kubernetes.io/worker': "" }
       end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -117,7 +117,7 @@ module Pharos
       def labels
         labels = @attributes[:labels] || {}
 
-        labels['node-address.pharos.sh/external-ip'] = address
+        labels['node-address.kontena.io/external-ip'] = address
         labels['node-role.kubernetes.io/worker'] = '' if worker?
 
         labels

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -108,16 +108,26 @@ module Pharos
         end
       end
 
+      # @return [String]
       def region
         labels['failure-domain.beta.kubernetes.io/region'] || 'unknown'
       end
 
+      # @return [Hash]
       def labels
         return @attributes[:labels] || {} unless worker?
 
         @attributes[:labels] || { 'node-role.kubernetes.io/worker': "" }
       end
 
+      # @return [Hash]
+      def checks
+        @checks ||= {}
+      end
+
+      # @param local_only [Boolean]
+      # @param cloud_provider [String, NilClass]
+      # @return [Array<String>]
       def kubelet_args(local_only: false, cloud_provider: nil)
         args = []
 

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -66,7 +66,8 @@ module Pharos
       attribute :environment, Pharos::Types::Strict::Hash
       attribute :bastion, Pharos::Configuration::Bastion
 
-      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :checks, :resolvconf, :routes
+      attr_accessor :os_release, :cpu_arch, :hostname, :api_endpoint, :private_interface_address, :resolvconf, :routes
+      attr_writer :checks
 
       def to_s
         short_hostname || address

--- a/lib/pharos/kubeadm.rb
+++ b/lib/pharos/kubeadm.rb
@@ -126,7 +126,7 @@ module Pharos
         config['etcd'] = {
           'external' => {
             'endpoints' => @config.etcd_hosts.map { |h|
-              "https://#{h.peer_address}:2379"
+              "https://#{@config.etcd_peer_address(h)}:2379"
             },
             'certFile'  => '/etc/pharos/pki/etcd/client.pem',
             'caFile'    => '/etc/pharos/pki/ca.pem',

--- a/lib/pharos/kubeadm.rb
+++ b/lib/pharos/kubeadm.rb
@@ -29,7 +29,7 @@ module Pharos
           'kubernetesVersion' => Pharos::KUBE_VERSION,
           'imageRepository' => @config.image_repository,
           'api' => {
-            'advertiseAddress' => @host.peer_address,
+            'advertiseAddress' => advertise_address,
             'controlPlaneEndpoint' => 'localhost'
           },
           'apiServerCertSANs' => build_extra_sans,
@@ -101,6 +101,11 @@ module Pharos
           'mountPath' => SECRETS_CFG_DIR
         }
         config
+      end
+
+      # @return [String]
+      def advertise_address
+        @config.regions.size == 1 ? @host.peer_address : @host.address
       end
 
       def master_taint?

--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -51,8 +51,9 @@ module Pharos
 
       # @return [Array<String>]
       def initial_cluster
+        first_host = @config.etcd_hosts.first
         @config.etcd_hosts.map { |h|
-          "#{peer_name(h)}=https://#{h.peer_address}:2380"
+          "#{peer_name(h)}=https://#{h.peer_address_for(first_host)}:2380"
         }
       end
 

--- a/lib/pharos/phases/configure_etcd.rb
+++ b/lib/pharos/phases/configure_etcd.rb
@@ -17,7 +17,7 @@ module Pharos
         logger.info { 'Configuring etcd certs ...' }
         exec_script(
           'configure-etcd-certs.sh',
-          PEER_IP: @host.peer_address,
+          PEER_IP: @config.etcd_peer_address(@host),
           PEER_NAME: peer_name(@host),
           ARCH: @host.cpu_arch.name
         )
@@ -25,7 +25,7 @@ module Pharos
         logger.info { 'Configuring etcd ...' }
         exec_script(
           'configure-etcd.sh',
-          PEER_IP: @host.peer_address,
+          PEER_IP: @config.etcd_peer_address(@host),
           INITIAL_CLUSTER: initial_cluster.join(','),
           IMAGE_REPO: @config.image_repository,
           ETCD_VERSION: Pharos::ETCD_VERSION,
@@ -45,15 +45,14 @@ module Pharos
         logger.info { 'Waiting for etcd to respond ...' }
         exec_script(
           'wait-etcd.sh',
-          PEER_IP: @host.peer_address
+          PEER_IP: @config.etcd_peer_address(@host)
         )
       end
 
       # @return [Array<String>]
       def initial_cluster
-        first_host = @config.etcd_hosts.first
         @config.etcd_hosts.map { |h|
-          "#{peer_name(h)}=https://#{h.peer_address_for(first_host)}:2380"
+          "#{peer_name(h)}=https://#{@config.etcd_peer_address(h)}:2380"
         }
       end
 

--- a/lib/pharos/phases/configure_etcd_changes.rb
+++ b/lib/pharos/phases/configure_etcd_changes.rb
@@ -33,14 +33,14 @@ module Pharos
         member_list = etcd.members
         new_members = @config.etcd_hosts.reject { |h|
           member_list.find { |m|
-            m['peerURLs'] == ["https://#{h.peer_address}:2380"]
+            m['peerURLs'] == ["https://#{h.peer_address_for(@config.etcd_hosts.first)}:2380"]
           }
         }
         if new_members.size > 1
           fail "Cannot add multiple etcd peers at once"
         end
         new_members.each do |h|
-          logger.info { "Adding new etcd peer https://#{h.peer_address}:2380 ..." }
+          logger.info { "Adding new etcd peer https://#{h.peer_address_for(@config.etcd_hosts.first)}:2380 ..." }
           etcd.add_member(h)
         end
 
@@ -51,7 +51,7 @@ module Pharos
         member_list = etcd.members
         remove_members = member_list.reject { |m|
           @config.etcd_hosts.find { |h|
-            m['peerURLs'] == ["https://#{h.peer_address}:2380"]
+            m['peerURLs'] == ["https://#{h.peer_address_for(@config.etcd_hosts.first)}:2380"]
           }
         }
         if remove_members.size / member_list.size.to_f >= 0.5

--- a/lib/pharos/phases/configure_etcd_changes.rb
+++ b/lib/pharos/phases/configure_etcd_changes.rb
@@ -33,14 +33,14 @@ module Pharos
         member_list = etcd.members
         new_members = @config.etcd_hosts.reject { |h|
           member_list.find { |m|
-            m['peerURLs'] == ["https://#{h.peer_address_for(@config.etcd_hosts.first)}:2380"]
+            m['peerURLs'] == ["https://#{@config.etcd_peer_address(h)}:2380"]
           }
         }
         if new_members.size > 1
           fail "Cannot add multiple etcd peers at once"
         end
         new_members.each do |h|
-          logger.info { "Adding new etcd peer https://#{h.peer_address_for(@config.etcd_hosts.first)}:2380 ..." }
+          logger.info { "Adding new etcd peer https://#{@config.etcd_peer_address(h)}:2380 ..." }
           etcd.add_member(h)
         end
 
@@ -51,7 +51,7 @@ module Pharos
         member_list = etcd.members
         remove_members = member_list.reject { |m|
           @config.etcd_hosts.find { |h|
-            m['peerURLs'] == ["https://#{h.peer_address_for(@config.etcd_hosts.first)}:2380"]
+            m['peerURLs'] == ["https://#{@config.etcd_peer_address(h)}:2380"]
           }
         }
         if remove_members.size / member_list.size.to_f >= 0.5

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -53,7 +53,7 @@ module Pharos
           IMAGE_REPO: @config.image_repository,
           ARCH: @host.cpu_arch.name,
           VERSION: Pharos::KUBELET_PROXY_VERSION,
-          MASTER_HOSTS: @config.master_hosts.map(&:peer_address).join(',')
+          MASTER_HOSTS: master_addresses.join(',')
         )
         host_configurer.ensure_kubelet(
           KUBELET_ARGS: @host.kubelet_args(local_only: true).join(" "),
@@ -64,6 +64,11 @@ module Pharos
         exec_script(
           'wait-kubelet-proxy.sh'
         )
+      end
+
+      # @return [Array<String>]
+      def master_addresses
+        @config.master_hosts.map { |master| master.peer_address_for(@host) }
       end
 
       def configure_kube

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -54,7 +54,7 @@ module Pharos
       def calculate_kube_peers
         peer_ips = Set.new
         @config.hosts.each do |host|
-          @config.hosts.select { |other_host| other_host != host}.each do |peer_host|
+          @config.hosts.reject { |other_host| other_host == host }.each do |peer_host|
             peer_ips << host.peer_address_for(peer_host)
           end
         end

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -45,21 +45,8 @@ module Pharos
           trusted_subnets: trusted_subnets,
           ipalloc_range: @config.network.pod_network_cidr,
           arch: @host.cpu_arch,
-          version: WEAVE_VERSION,
-          kube_peers: calculate_kube_peers
+          version: WEAVE_VERSION
         )
-      end
-
-      # @return [Array<String>]
-      def calculate_kube_peers
-        peer_ips = Set.new
-        @config.hosts.each do |host|
-          @config.hosts.reject { |other_host| other_host == host }.each do |peer_host|
-            peer_ips << host.peer_address_for(peer_host)
-          end
-        end
-
-        peer_ips.to_a
       end
 
       def generate_password

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -6,9 +6,15 @@ module Pharos
       title "Configure Weave network"
 
       WEAVE_VERSION = '2.5.0'
+      WEAVE_FLYING_SHUTTLE_VERSION = '0.1.1'
 
       register_component(
         name: 'weave-net', version: WEAVE_VERSION, license: 'Apache License 2.0',
+        enabled: proc { |c| c.network.provider == 'weave' }
+      )
+
+      register_component(
+        name: 'weave-flying-shuttle', version: WEAVE_VERSION, license: 'Apache License 2.0',
         enabled: proc { |c| c.network.provider == 'weave' }
       )
 
@@ -45,7 +51,8 @@ module Pharos
           trusted_subnets: trusted_subnets,
           ipalloc_range: @config.network.pod_network_cidr,
           arch: @host.cpu_arch,
-          version: WEAVE_VERSION
+          version: WEAVE_VERSION,
+          flying_shuttle_version: WEAVE_FLYING_SHUTTLE_VERSION
         )
       end
 

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -45,8 +45,21 @@ module Pharos
           trusted_subnets: trusted_subnets,
           ipalloc_range: @config.network.pod_network_cidr,
           arch: @host.cpu_arch,
-          version: WEAVE_VERSION
+          version: WEAVE_VERSION,
+          kube_peers: calculate_kube_peers
         )
+      end
+
+      # @return [Array<String>]
+      def calculate_kube_peers
+        peer_ips = Set.new
+        @config.hosts.each do |host|
+          @config.hosts.select { |other_host| other_host != host}.each do |peer_host|
+            peer_ips << host.peer_address_for(peer_host)
+          end
+        end
+
+        peer_ips.to_a
       end
 
       def generate_password

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -21,24 +21,20 @@ module Pharos
 
       # @param node [K8s::Resource]
       def patch_labels(node)
-        kube_nodes.update_resource(
-          node.merge(
-            metadata: {
-              labels: @host.labels
-            }
-          )
-        )
+        kube_nodes.merge_patch(node.metadata.name, {
+          metadata: {
+            labels: @host.labels
+          }
+        })
       end
 
       # @param node [K8s::Resource]
       def patch_taints(node)
-        kube_nodes.update_resource(
-          node.merge(
-            spec: {
-              taints: @host.taints.map(&:to_h)
-            }
-          )
-        )
+        kube_nodes.merge_patch(node.metadata.name, {
+          metadata: {
+            taints: @host.taints.map(&:to_h)
+          }
+        })
       end
 
       def find_node

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -21,20 +21,24 @@ module Pharos
 
       # @param node [K8s::Resource]
       def patch_labels(node)
-        kube_nodes.merge_patch(node.metadata.name, {
-          metadata: {
-            labels: @host.labels
-          }
-        })
+        kube_nodes.update_resource(
+          node.merge(
+            metadata: {
+              labels: @host.labels
+            }
+          )
+        )
       end
 
       # @param node [K8s::Resource]
       def patch_taints(node)
-        kube_nodes.merge_patch(node.metadata.name, {
-          metadata: {
-            taints: @host.taints.map(&:to_h)
-          }
-        })
+        kube_nodes.update_resource(
+          node.merge(
+            spec: {
+              taints: @host.taints.map(&:to_h)
+            }
+          )
+        )
       end
 
       def find_node

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Label nodes"
 
       def call
-        unless @host.labels || @host.taints
+        if @host.labels.empty? && @host.taints.nil?
           logger.info { "No labels or taints set ... " }
           return
         end
@@ -15,7 +15,7 @@ module Pharos
         raise Pharos::Error, "Cannot set labels, node not found" if node.nil?
 
         logger.info { "Configuring node labels and taints ... " }
-        patch_labels(node) if @host.labels
+        patch_labels(node) unless @host.labels.empty?
         patch_taints(node) if @host.taints
       end
 

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -83,6 +83,9 @@ module Pharos
         host_addresses = ssh.exec!("sudo hostname --all-ip-addresses").split(" ")
 
         fail "Peer address #{@host.peer_address} does not seem to be a node local address" unless host_addresses.include?(@host.peer_address)
+
+        etcd_peer_address = @config.etcd_peer_address(@host)
+        fail "Etcd peer address #{etcd_peer_address} does not seem to be a node local address" unless host_addresses.include?(etcd_peer_address)
       end
     end
   end

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -31,6 +31,8 @@ spec:
             - name: EXTRA_ARGS
               value: "--trusted-subnets <%= trusted_subnets.join(',') %>"
             <% end %>
+            - name: KUBE_PEERS
+              value: "<%= kube_peers.join(' ') %>"
             - name: IPALLOC_RANGE
               value: "<%= ipalloc_range %>"
             - name: WEAVE_PASSWORD

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -89,7 +89,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          image: 'quay.io/jakolehm/weave-flying-shuttle:latest'
+          image: '<%= image_repository %>/weave-flying-shuttle:<%= flying_shuttle_version %>'
           resources:
             requests:
               cpu: 10m

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -29,10 +29,8 @@ spec:
               value: "1"
             <% if !trusted_subnets.empty? %>
             - name: EXTRA_ARGS
-              value: "--trusted-subnets <%= trusted_subnets.join(',') %>"
+              value: "--no-discovery --trusted-subnets <%= trusted_subnets.join(',') %>"
             <% end %>
-            - name: KUBE_PEERS
-              value: "<%= kube_peers.join(' ') %>"
             - name: IPALLOC_RANGE
               value: "<%= ipalloc_range %>"
             - name: WEAVE_PASSWORD
@@ -84,6 +82,17 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+        - name: weave-flying-shuttle
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          image: 'quay.io/jakolehm/weave-flying-shuttle:latest'
+          resources:
+            requests:
+              cpu: 10m
       hostNetwork: true
       hostPID: true
       restartPolicy: Always

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -9,6 +9,29 @@ describe Pharos::Config do
   subject { described_class.load(data) }
 
   describe 'hosts' do
+    context 'invalid host address' do
+      let(:hosts) { [
+        { 'address' => ' 192.0.2.1', 'role' => 'master' },
+      ] }
+      it 'fails to load' do
+        expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
+          expect(exc.errors[:hosts][0][:address][0]).to eq "is invalid"
+        end
+      end
+    end
+
+    context 'invalid host private address' do
+      let(:hosts) { [
+        { 'address' => '192.0.2.1', 'private_address' => '"127.0.0.1"', 'role' => 'master' },
+      ] }
+      it 'fails to load' do
+        expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
+          expect(exc.errors[:hosts][0][:private_address][0]).to eq "is invalid"
+        end
+      end
+    end
+
+
     context 'without hosts' do
       let(:data) { {} }
 

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -146,6 +146,27 @@ describe Pharos::Config do
     end
   end
 
+  describe '#etcd_hosts' do
+    let(:data) { {
+      'hosts' => [
+        { 'address' => '192.0.2.1', 'role' => 'master'},
+        { 'address' => '192.0.2.2', 'role' => 'master'},
+        { 'address' => '192.0.2.3', 'role' => 'worker'},
+      ]
+    } }
+
+    it 'returns hosts with role=master' do
+      expect(subject.etcd_hosts.size).to eq(2)
+      expect(subject.etcd_hosts.first.address).to eq('192.0.2.1')
+      expect(subject.etcd_hosts.last.address).to eq('192.0.2.2')
+    end
+
+    it 'sorts etcd hosts by score' do
+      subject.hosts[1].checks['etcd_healthy'] = true
+      expect(subject.etcd_hosts.first.address).to eq('192.0.2.2')
+    end
+  end
+
   describe 'kube_proxy' do
     it 'defaults to iptables' do
       expect(subject.kube_proxy.mode).to eq 'iptables'

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -125,6 +125,27 @@ describe Pharos::Config do
     end
   end
 
+  describe '#master_hosts' do
+    let(:data) { {
+      'hosts' => [
+        { 'address' => '192.0.2.1', 'role' => 'master'},
+        { 'address' => '192.0.2.2', 'role' => 'master'},
+        { 'address' => '192.0.2.3', 'role' => 'worker'},
+      ]
+    } }
+
+    it 'returns hosts with role=master' do
+      expect(subject.master_hosts.size).to eq(2)
+      expect(subject.master_hosts.first.address).to eq('192.0.2.1')
+      expect(subject.master_hosts.last.address).to eq('192.0.2.2')
+    end
+
+    it 'sorts masters by score' do
+      subject.hosts[1].checks['api_healthy'] = true
+      expect(subject.master_hosts.first.address).to eq('192.0.2.2')
+    end
+  end
+
   describe 'kube_proxy' do
     it 'defaults to iptables' do
       expect(subject.kube_proxy.mode).to eq 'iptables'

--- a/spec/pharos/configuration/host_spec.rb
+++ b/spec/pharos/configuration/host_spec.rb
@@ -12,13 +12,15 @@ describe Pharos::Configuration::Host do
 
   describe '#labels' do
     context 'for master' do
-      it 'returns empty labels by default' do
+      it 'returns external-ip and role label by default' do
         subject = described_class.new(
           address: '192.168.100.100',
           role: 'master',
           user: 'root'
         )
-        expect(subject.labels).to eq({})
+        expect(subject.labels).to eq({
+          'node-address.kontena.io/external-ip' => '192.168.100.100'
+        })
       end
 
       it 'returns given labels' do
@@ -31,7 +33,7 @@ describe Pharos::Configuration::Host do
             baz: 'baf'
           }
         )
-        expect(subject.labels).to eq({foo: 'bar', baz: 'baf'})
+        expect(subject.labels).to include(foo: 'bar', baz: 'baf')
       end
     end
 
@@ -46,7 +48,7 @@ describe Pharos::Configuration::Host do
             baz: 'baf'
           }
         )
-        expect(subject.labels).to eq({foo: 'bar', baz: 'baf'})
+        expect(subject.labels).to include(foo: 'bar', baz: 'baf')
       end
 
       it 'returns default worker label' do
@@ -55,7 +57,7 @@ describe Pharos::Configuration::Host do
           role: 'worker',
           user: 'root'
         )
-        expect(subject.labels).to eq({ 'node-role.kubernetes.io/worker': "" })
+        expect(subject.labels).to include('node-role.kubernetes.io/worker' => "")
       end
     end
   end

--- a/spec/pharos/configuration/host_spec.rb
+++ b/spec/pharos/configuration/host_spec.rb
@@ -18,7 +18,7 @@ describe Pharos::Configuration::Host do
           role: 'master',
           user: 'root'
         )
-        expect(subject.labels).to eq(nil)
+        expect(subject.labels).to eq({})
       end
 
       it 'returns given labels' do

--- a/spec/pharos/phases/label_node_spec.rb
+++ b/spec/pharos/phases/label_node_spec.rb
@@ -46,16 +46,6 @@ describe Pharos::Phases::LabelNode do
       allow(subject).to receive(:find_node).and_return(node)
     end
 
-    context 'without any host labels' do
-      let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.2') }
-
-      it 'does nothing' do
-        expect(subject).not_to receive(:find_node)
-
-        subject.call
-      end
-    end
-
     context 'without kube node' do
       before do
         allow(subject).to receive(:find_node).and_return(nil)
@@ -75,7 +65,7 @@ describe Pharos::Phases::LabelNode do
       it 'patches node' do
         expect(node).to receive(:merge).with(
           metadata: {
-            labels: { :foo => 'bar' },
+            labels: { :foo => 'bar', 'node-address.kontena.io/external-ip' => '192.0.2.2' },
           },
         ).and_return(node)
 
@@ -94,6 +84,7 @@ describe Pharos::Phases::LabelNode do
       ) }
 
       it 'patches node' do
+        allow(subject).to receive(:patch_labels)
         expect(node).to receive(:merge).with(
           spec: {
             taints: [ { key: 'node-role.kubernetes.io/master', effect: 'NoSchedule' } ],
@@ -118,7 +109,7 @@ describe Pharos::Phases::LabelNode do
       it 'patches node twice' do
         expect(node).to receive(:merge).with(
           metadata: {
-            labels: { :foo => 'bar' },
+            labels: { :foo => 'bar', 'node-address.kontena.io/external-ip' => '192.0.2.2' },
           },
         ).and_return(node)
         expect(node).to receive(:merge).with(


### PR DESCRIPTION
- Resolves used peer address (etcd, master, weave) from `failure-domain.beta.kubernetes.io/region` label.
- adds [Flying Shuttle](https://github.com/kontena/weave-flying-shuttle) sidecar to Weave Net, allowing dynamic peer configuration based on node region/external-ip labels