### PR TITLE
Remove -d --debug -f --force from kubeconfig hint

### DIFF
--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -5,6 +5,7 @@ module Pharos
     options :load_config, :yes?
 
     option ['-f', '--force'], :flag, "force upgrade"
+    STRIP_OPTIONS = %w(-y --yes -d --debug -f --force).freeze
 
     def execute
       puts pastel.bright_green("==> KONTENA PHAROS v#{Pharos.version} (Kubernetes v#{Pharos::KUBE_VERSION})")
@@ -53,7 +54,7 @@ module Pharos
       manager.save_config
 
       craft_time = Time.now - start_time
-      defined_opts = ARGV[1..-1].reject { |opt| %w(-y --yes).include?(opt) }.join(" ")
+      defined_opts = (ARGV[1..-1] - STRIP_OPTIONS).join(" ")
       defined_opts += " " unless defined_opts.empty?
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       manager.post_install_messages.each do |component, message|


### PR DESCRIPTION
Fixes #770 

The `-f | --force` would cause unknown option error and `-d | --debug` will cause the output to contain debug info and break the YAML.
