### PR TITLE
Release v2.0.0-rc.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.0.0.beta.1)
+    pharos-cluster (2.0.0.rc.4)
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
       dry-struct (= 0.5.0)
@@ -120,7 +120,7 @@ GEM
       hitimes
     tty-color (0.4.3)
     tty-cursor (0.6.0)
-    tty-prompt (0.17.1)
+    tty-prompt (0.17.2)
       necromancer (~> 0.4.0)
       pastel (~> 0.7.0)
       timers (~> 4.0)

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.0-rc.3"
+  VERSION = "2.0.0-rc.4"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since 2.0.0-rc.3

- fix upgrade from previous versions (#765)
- enable rhel 7.6 (#766)
- telemetry 0.2.0 (#767)
- add --force to "pharos up" to force upgrade from an unsupported version (#762)
- fix el7 kubeadm upgrade download (#764)
- fix version upgrade warning message typo (#769)
- fix kubeconfig post install hint arguments (#753)
