### PR TITLE
Allow to use master host as Lens gateway

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -29,7 +29,7 @@ Pharos.addon 'kontena-lens' do
   }
 
   install {
-    host = config.host || "lens.#{worker_node_ip}.nip.io"
+    host = config.host || "lens.#{gateway_node_ip}.nip.io"
     name = config.name || 'pharos-cluster'
     apply_resources(
       host: host,
@@ -53,12 +53,12 @@ Pharos.addon 'kontena-lens' do
     @pastel ||= Pastel.new
   end
 
-  def worker_node
-    cluster_config.worker_hosts.first
+  def gateway_node
+    cluster_config.worker_hosts.first || cluster_config.master_hosts.first
   end
 
-  def worker_node_ip
-    worker_node&.address
+  def gateway_node_ip
+    gateway_node&.address
   end
 
   def master_host_ip
@@ -137,6 +137,6 @@ Pharos.addon 'kontena-lens' do
   end
 
   def ssh
-    @ssh ||= Pharos::SSH::Manager.instance.client_for(worker_node)
+    @ssh ||= Pharos::SSH::Manager.instance.client_for(gateway_node)
   end
 end


### PR DESCRIPTION
Previously when configuring Kontena Lens, pharos needs ssh access to worker nodes. If worker nodes are not present, up command errors out `NoMethodError : undefined method `ssh_key_path' for nil:NilClass`. This PR allows to use master host as gateway host unless worker nodes are not present. In this case, user must also add master node tolerations to Ingress Controller