### PR TITLE
More compatible localhost hostname validation

### DIFF
--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -51,8 +51,8 @@ module Pharos
       end
 
       def validate_localhost_resolve
-        localhost_ip = @ssh.exec!("ping -c 1 localhost | grep -Eo -m 1 '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}';")
-        raise Pharos::InvalidHostError, "Localhost ip does not look right: #{localhost_ip}" unless localhost_ip.start_with?('127.')
+        return if @ssh.exec?("ping -c 1 -r -w 1 localhost")
+        raise Pharos::InvalidHostError, "Hostname 'localhost' does not seem to resolve to an address on the local host"
       end
 
       # @param cidr [String]


### PR DESCRIPTION
Fixes #777 

Uses the exit status of `ping -c 1 -w 1 -r localhost` to validate that `localhost` resolves to an address on the local host.

```
-r     Bypass the normal routing tables and send directly to a host on an attached interface.  If the host is not on a directly-attached network, an error is returned.  This option  can  be  used  to
              ping a local host through an interface that has no route through it provided the option -I is also used.
```

