### PR TITLE
Release v2.0.1-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.0"
+  VERSION = "2.0.1-rc.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.0

- more compatible localhost hostname validation (#778)
- remove -d --debug -f --force from kubeconfig hint (#771)
- fix kontena-storage device_filter (#779)