### PR TITLE
Reduce unnecessary extending in StringCasing refinement

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -3,11 +3,12 @@
 module Pharos
   class Command < Clamp::Command
     include Pharos::Logging
+    using Pharos::CoreExt::StringCasing
 
     # @param [Array<Symbol>] a list of CommandOption module names in snake_case, for example :filtered_hosts
     def self.options(*option_names)
       option_names.each do |option_name|
-        module_name = option_name.to_s.gsub(/\?$/, '').extend(Pharos::CoreExt::StringCasing).camelcase.to_sym
+        module_name = option_name.to_s.gsub(/\?$/, '').camelcase.to_sym
         send(:include, Pharos::CommandOptions.const_get(module_name))
       end
     end

--- a/lib/pharos/core-ext/deep_transform_keys.rb
+++ b/lib/pharos/core-ext/deep_transform_keys.rb
@@ -10,30 +10,36 @@ module Pharos
         when Array
           value.map { |v| deep_transform_keys(v, &block) }
         when Hash
-          Hash[value.map { |k, v| [yield(k.dup), deep_transform_keys(v, &block)] }]
+          Hash[value.map { |k, v| [yield(k.frozen? ? k.dup : k), deep_transform_keys(v, &block)] }]
         else
           value
         end
       end
 
-      def deep_transform_keys(&block)
-        ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &block)
-      end
-
-      def deep_transform_keys!(&block)
-        replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &block))
-      end
-
-      def deep_stringify_keys
-        ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_s)
-      end
-
-      def deep_stringify_keys!
-        replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_s))
-      end
-
       refine Hash do
-        include ::Pharos::CoreExt::DeepTransformKeys
+        def deep_transform_keys(&block)
+          ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &block)
+        end
+
+        def deep_transform_keys!(&block)
+          replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &block))
+        end
+
+        def deep_stringify_keys
+          ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_s)
+        end
+
+        def deep_stringify_keys!
+          replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_s))
+        end
+
+        def deep_symbolize_keys
+          ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_sym)
+        end
+
+        def deep_symbolize_keys!
+          replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_sym))
+        end
       end
     end
   end

--- a/lib/pharos/core-ext/string_casing.rb
+++ b/lib/pharos/core-ext/string_casing.rb
@@ -3,48 +3,46 @@
 module Pharos
   module CoreExt
     module StringCasing
-      def underscore
-        return self if empty?
-
-        result = gsub(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
-        result.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-        result.tr!('-', '_')
-        result.gsub!(/\s+/, '_')
-        result.gsub!(/__+/, '_')
-        result.downcase!
-        result
-      end
-
-      def camelcase
-        return self if empty?
-
-        extend(StringCasing).underscore.split('_').map(&:capitalize).join
-      end
-
-      def camelback
-        return self if empty?
-
-        camelcased = extend(StringCasing).camelcase
-        camelcased[0] = camelcased[0].downcase
-        camelcased
-      end
-
-      %i(underscore camelcase camelback).each do |meth|
-        define_method("#{meth}!") do
+      refine String do
+        def underscore
           return self if empty?
 
-          replace(extend(StringCasing).send(meth))
+          result = gsub(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+          result.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+          result.tr!('-', '_')
+          result.gsub!(/\s+/, '_')
+          result.gsub!(/__+/, '_')
+          result.downcase!
+          result
         end
-      end
 
-      refine String do
-        include StringCasing
+        def camelcase
+          return self if empty?
+
+          underscore.split('_').map(&:capitalize).join
+        end
+
+        def camelback
+          return self if empty?
+
+          camelcased = camelcase
+          camelcased[0] = camelcased[0].downcase
+          camelcased
+        end
+
+        %i(underscore camelcase camelback).each do |meth|
+          define_method("#{meth}!") do
+            return self if empty?
+
+            replace(send(meth))
+          end
+        end
       end
 
       refine Symbol do
         %i(underscore camelcase camelback).each do |meth|
           define_method(meth) do
-            to_s.extend(StringCasing).send(meth)
+            to_s.send(meth)
           end
         end
       end

--- a/spec/pharos/core_ext/deep_transform_keys_spec.rb
+++ b/spec/pharos/core_ext/deep_transform_keys_spec.rb
@@ -1,15 +1,5 @@
 describe Pharos::CoreExt::DeepTransformKeys do
   describe '#deep_transform_keys' do
-    context 'as a module' do
-      subject { { foo: { bar: [ { baz: 1 } ] } } }
-      it 'deep transforms keys' do
-        subject.extend(described_class)
-        expect(subject.deep_transform_keys(&:to_s)).to eq(
-          { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } }
-        )
-      end
-    end
-
     context 'as a refinement' do
       using Pharos::CoreExt::DeepTransformKeys
       subject { { foo: { bar: [ { baz: 1 } ] } } }
@@ -29,16 +19,6 @@ describe Pharos::CoreExt::DeepTransformKeys do
   end
 
   describe '#deep_stringify_keys' do
-    context 'as a module' do
-      subject { { foo: { bar: [ { baz: 1 } ] } } }
-      it 'deep stringifies keys' do
-        subject.extend(described_class)
-        expect(subject.deep_stringify_keys).to eq(
-          { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } }
-        )
-      end
-    end
-
     context 'as a refinement' do
       using Pharos::CoreExt::DeepTransformKeys
       subject { { foo: { bar: [ { baz: 1 } ] } } }
@@ -46,6 +26,19 @@ describe Pharos::CoreExt::DeepTransformKeys do
       it 'deep stringifies keys' do
         expect(subject.deep_stringify_keys).to eq(
           { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } }
+        )
+      end
+    end
+  end
+
+  describe '#deep_symbolize_keys' do
+    context 'as a refinement' do
+      using Pharos::CoreExt::DeepTransformKeys
+      subject { { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } } }
+
+      it 'deep symbolizes keys' do
+        expect(subject.deep_symbolize_keys).to eq(
+          { foo: { bar: [ { baz: 1 } ] } }
         )
       end
     end

--- a/spec/pharos/core_ext/string_casing_spec.rb
+++ b/spec/pharos/core_ext/string_casing_spec.rb
@@ -1,11 +1,4 @@
 describe Pharos::CoreExt::StringCasing do
-  context 'as a module' do
-    subject { "fooBar".extend(described_class) }
-    it 'underscores a string' do
-      expect(subject.underscore).to eq "foo_bar"
-    end
-  end
-
   context 'as a refinement' do
     using Pharos::CoreExt::StringCasing
 


### PR DESCRIPTION
Refinements are strange as is. Trying to make a refinement that can also work as an extendable module is not a working solution. The methods inside the module do not seem to be in the scope of the `refine`.

This PR changes the `Pharos::CoreExt::StringCasing` and `DeepTransformKeys` to be regular refinements, not to be used with `extend` at all. 


