### PR TITLE
Release v2.0.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.1-rc.1"
+  VERSION = "2.0.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.0

- fix kontena-storage placement settings (#786)
- allow to use Kontena Lens with custom host without tls option (#784)
- fix etcd_version_matches (#783)
- fix kontena-storage device_filter (#779)
- remove -d --debug -f --force from kubeconfig hint (#771)
- more compatible localhost hostname validation (#778)