### PR TITLE
Don't dump backtrace in pharos ssh when no hosts defined

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -12,7 +12,7 @@ module Pharos
       end
     end
 
-    def run(*_)
+    def run(*_args)
       super
     rescue Pharos::ConfigError => exc
       warn "==> #{exc}"

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -12,6 +12,17 @@ module Pharos
       end
     end
 
+    def run(*_)
+      super
+    rescue Pharos::ConfigError => exc
+      warn "==> #{exc}"
+      exit 11
+    rescue StandardError => ex
+      raise unless ENV['DEBUG'].to_s.empty?
+
+      signal_error "#{ex.class.name} : #{ex.message}"
+    end
+
     option '--[no-]color', :flag, "colorize output", default: $stdout.tty?
 
     option ['-v', '--version'], :flag, "print #{File.basename($PROGRAM_NAME)} version" do

--- a/lib/pharos/reset_command.rb
+++ b/lib/pharos/reset_command.rb
@@ -14,14 +14,6 @@ module Pharos
         filtered_hosts.size == load_config.hosts.size ? reset_all : reset_hosts
       end
       cluster_manager.disconnect
-    rescue Pharos::ConfigError => exc
-      warn "==> #{exc}"
-      exit 11
-    rescue StandardError => ex
-      raise unless ENV['DEBUG'].to_s.empty?
-
-      warn "#{ex.class.name} : #{ex.message}"
-      exit 1
     end
 
     def reset_hosts

--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -15,12 +15,5 @@ module Pharos
     subcommand "reset", "reset cluster", ResetCommand
     subcommand "ssh", "start an ssh session to a server in a pharos cluster", SSHCommand
     subcommand "version", "show version information", VersionCommand
-
-    def self.run
-      super
-    rescue StandardError => exc
-      warn exc.message
-      warn exc.backtrace.join("\n")
-    end
   end
 end

--- a/lib/pharos/ssh_command.rb
+++ b/lib/pharos/ssh_command.rb
@@ -16,8 +16,10 @@ module Pharos
         exit 0
       end
 
-      exit run_single(filtered_hosts.first) if filtered_hosts.size == 1
-      exit run_parallel
+      Dir.chdir(config_yaml.dirname) do
+        exit run_single(filtered_hosts.first) if filtered_hosts.size == 1
+        exit run_parallel
+      end
     end
 
     private

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -19,14 +19,6 @@ module Pharos
       Dir.chdir(config_yaml.dirname) do
         configure(config)
       end
-    rescue Pharos::ConfigError => exc
-      warn "==> #{exc}"
-      exit 11
-    rescue StandardError => ex
-      raise unless ENV['DEBUG'].to_s.empty?
-
-      warn "#{ex.class.name} : #{ex.message}"
-      exit 1
     end
 
     # @param config [Pharos::Config]


### PR DESCRIPTION
Fixes #791 
 
Moves the error handling to `Pharos::Command` for all commands.
