### PR TITLE
Randomize test case run order

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,5 @@
 --require spec_helper
+--order rand
+--format d
+--backtrace
+--profile

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -1,3 +1,4 @@
+require "pharos/host/configurer"
 require "pharos/phases/configure_kubelet"
 
 describe Pharos::Phases::ConfigureKubelet do
@@ -26,7 +27,8 @@ describe Pharos::Phases::ConfigureKubelet do
   let(:ssh) { instance_double(Pharos::SSH::Client) }
   subject { described_class.new(host, config: config, ssh: ssh) }
 
-  before(:each) do
+  before do
+    Pharos::HostConfigManager.load_configs(config)
     host.resolvconf = host_resolvconf
 
     allow(host).to receive(:cpu_arch).and_return(double(:cpu_arch, name: 'amd64'))

--- a/spec/pharos/phases/configure_telemetry_spec.rb
+++ b/spec/pharos/phases/configure_telemetry_spec.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 describe Pharos::Phases::ConfigureTelemetry do
   subject { described_class.new(double, config: double, ssh: double) }
 
-  describe '#customer_token' do
+  describe '#customer_token', fakefs: true do
     it 'returns empty string if not found' do
       FakeFS do
         expect(subject.customer_token).to eq('')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,4 +125,5 @@ RSpec.configure do |config|
   end
 
   config.include FixturesHelper
+  config.include FakeFS::SpecHelpers, fakefs: true
 end


### PR DESCRIPTION
Fixes #643

Enables the `--order rand` parameter in rspec to randomize spec run order. Fixes a couple of specs that randomly failed when run order is randomized or were run separately.

