### PR TITLE
cri-o v1.11.9

### DIFF
--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -8,7 +8,7 @@ require_relative "pharos/error"
 require_relative "pharos/root_command"
 
 module Pharos
-  CRIO_VERSION = '1.11.6'
+  CRIO_VERSION = '1.11.9'
   KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.11.4' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.2.18' }


### PR DESCRIPTION
https://github.com/kubernetes-sigs/cri-o/compare/v1.11.6...v1.11.9?expand=1

Should fix upgrade from Pharos 1.3.x.