### PR TITLE
Fix rhel version check

### DIFF
--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -156,10 +156,15 @@ module Pharos
           Pharos::Phases.register_component(component)
         end
 
+        # @param name [String]
+        # @param version [String]
         def register_config(name, version)
           @os_name = name
           @os_version = version
-          configs << self
+          configs << Class.new(self) do
+            @os_name = name
+            @os_version = version
+          end
           self
         end
 

--- a/spec/pharos/configuration/host_spec.rb
+++ b/spec/pharos/configuration/host_spec.rb
@@ -97,7 +97,7 @@ describe Pharos::Configuration::Host do
     it 'returns os release when supported' do
       Pharos::HostConfigManager.load_configs(double(:cluster_config))
       allow(subject).to receive(:os_release).and_return(double(:os_release, id: 'ubuntu', version: '16.04'))
-      expect(subject.configurer(double(:ssh))).to be_instance_of(Pharos::Host::UbuntuXenial)
+      expect(subject.configurer(double(:ssh))).to be_kind_of(Pharos::Host::UbuntuXenial)
     end
   end
 

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -19,9 +19,16 @@ describe Pharos::Host::Configurer do
     end
 
     it 'registers multiple versions to configs' do
-      expect(described_class.configs.size).to eq(2)
-      expect(described_class.configs.first.os_version).to eq('1.0.0')
-      expect(described_class.configs.last.os_version).to eq('1.1.0')
+      expect(
+        described_class.config_for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '1.0.0')
+        )
+      ).not_to be_nil
+      expect(
+        described_class.config_for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '1.1.0')
+        )
+      ).not_to be_nil
     end
 
     it 'registers config class' do

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -3,6 +3,7 @@ require 'recursive-open-struct'
 describe Pharos::Host::Configurer do
   let(:test_config_class) do
     Class.new(described_class) do
+      register_config 'test', '1.0.0'
       register_config 'test', '1.1.0'
     end
   end
@@ -17,9 +18,15 @@ describe Pharos::Host::Configurer do
       expect(test_config_class.os_version).to eq('1.1.0')
     end
 
+    it 'registers multiple versions to configs' do
+      expect(described_class.configs.size).to eq(2)
+      expect(described_class.configs.first.os_version).to eq('1.0.0')
+      expect(described_class.configs.last.os_version).to eq('1.1.0')
+    end
+
     it 'registers config class' do
       test_config_class # load
-      expect(described_class.configs.last).to eq(test_config_class)
+      expect(described_class.configs.last.superclass).to eq(test_config_class)
     end
   end
 


### PR DESCRIPTION
Quick fix for the RHEL version compare issue. We should refactor this logic in 2.1. 

Fixes #803 .