### PR TITLE
Run all phases in parallel

### DIFF
--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -53,6 +53,7 @@ module Pharos
       @configs ||= @config.addons.sort_by { |name, _config|
         addon_class = addon_classes.find { |a| a.addon_name == name }
         raise UnknownAddon, "unknown addon: #{name}" if addon_class.nil?
+
         addon_class.priority
       }.to_h
     end

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -58,7 +58,7 @@ module Pharos
 
     def gather_facts
       apply_phase(Phases::GatherFacts, config.hosts)
-      apply_phase(Phases::ConfigureClient, [config.master_host], master: sorted_master_hosts.first, optional: true)
+      apply_phase(Phases::ConfigureClient, [config.master_host], master: config.master_host, optional: true)
     end
 
     def validate

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -61,8 +61,10 @@ module Pharos
     def humanize_duration(secs)
       [[60, :second], [60, :minute], [24, :hour], [1000, :day]].map{ |count, name|
         next unless secs.positive?
+
         secs, n = secs.divmod(count).map(&:to_i)
         next if n.zero?
+
         "#{n} #{name}#{'s' unless n == 1}"
       }.compact.reverse.join(' ')
     end

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -64,6 +64,7 @@ module Pharos
     def dns_replicas
       return network.dns_replicas if network.dns_replicas
       return 1 if hosts.length == 1
+
       1 + (hosts.length / HOSTS_PER_DNS_REPLICA.to_f).ceil
     end
 
@@ -131,6 +132,7 @@ module Pharos
     # @raise [Pharos::ConfigError]
     def set(key, value)
       raise Pharos::Error, "Cannot override #{key}." if data[key.to_s]
+
       attributes[key] = value
     end
 

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -33,6 +33,7 @@ module Pharos
       schema = build
       result = schema.call(DEFAULT_DATA.merge(data))
       raise Pharos::ConfigError, result.messages unless result.success?
+
       result.to_h
     end
 

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -148,6 +148,7 @@ module Pharos
           host_env_file.read.lines.each do |line|
             line.strip!
             next if line.start_with?('#')
+
             key, val = line.split('=', 2)
             val = nil if val.to_s.empty?
             original_data[key] = val

--- a/lib/pharos/kubeadm.rb
+++ b/lib/pharos/kubeadm.rb
@@ -133,9 +133,9 @@ module Pharos
             'endpoints' => @config.etcd_hosts.map { |h|
               "https://#{@config.etcd_peer_address(h)}:2379"
             },
-            'certFile'  => '/etc/pharos/pki/etcd/client.pem',
-            'caFile'    => '/etc/pharos/pki/ca.pem',
-            'keyFile'   => '/etc/pharos/pki/etcd/client-key.pem'
+            'certFile' => '/etc/pharos/pki/etcd/client.pem',
+            'caFile' => '/etc/pharos/pki/ca.pem',
+            'keyFile' => '/etc/pharos/pki/etcd/client-key.pem'
           }
         }
       end

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -13,7 +13,7 @@ module Pharos
     end
 
     def to_s
-      "#{self.class.title} @ #{@host}"
+      "#{self.class.title} @ #{host}"
     end
 
     def self.register_component(component)
@@ -33,12 +33,12 @@ module Pharos
     end
 
     def ssh
-      @host.ssh
+      host.ssh
     end
 
     def logger
       @logger ||= Logger.new($stdout).tap do |logger|
-        logger.progname = @host.to_s
+        logger.progname = host.to_s
         logger.level = ENV["DEBUG"] ? Logger::DEBUG : Logger::INFO
         logger.formatter = proc do |_severity, _datetime, progname, msg|
           "    [%<progname>s] %<msg>s\n" % { progname: progname, msg: msg }
@@ -75,12 +75,13 @@ module Pharos
 
     # @return [Pharos::Host::Configurer]
     def host_configurer
-      @host_configurer ||= @host.configurer
+      @host_configurer ||= host.configurer
     end
 
     # @return [Pharos::SSH::Client]
     def master_ssh
       return cluster_context['master-ssh'] if cluster_context['master-ssh']
+
       fail "Phase #{self.class.name} does not have master ssh"
     end
 

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -20,7 +20,7 @@ module Pharos
       Pharos::Phases.register_component(component)
     end
 
-    attr_reader :cluster_context, :host
+    attr_reader :cluster_context, :host, :config
 
     # @param host [Pharos::Configuration::Host]
     # @param config [Pharos::Config]

--- a/lib/pharos/phases/configure_etcd_changes.rb
+++ b/lib/pharos/phases/configure_etcd_changes.rb
@@ -39,6 +39,7 @@ module Pharos
         if new_members.size > 1
           fail "Cannot add multiple etcd peers at once"
         end
+
         new_members.each do |h|
           logger.info { "Adding new etcd peer https://#{@config.etcd_peer_address(h)}:2380 ..." }
           etcd.add_member(h)
@@ -57,6 +58,7 @@ module Pharos
         if remove_members.size / member_list.size.to_f >= 0.5
           fail "Cannot remove majority of etcd peers"
         end
+
         remove_members.each do |m|
           logger.info { "Removing old etcd peer #{m['peerURLs'].join(', ')} ..." }
           etcd.remove_member(m['id'])

--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Configure hosts"
 
       def call
-        unless @host.environment.nil? || @host.environment.empty?
+        unless host.environment.nil? || host.environment.empty?
           logger.info { "Updating environment file ..." }
           host_configurer.update_env_file
         end

--- a/lib/pharos/phases/configure_secrets_encryption.rb
+++ b/lib/pharos/phases/configure_secrets_encryption.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "base64"
-
 module Pharos
   module Phases
     class ConfigureSecretsEncryption < Pharos::Phase
@@ -12,51 +10,10 @@ module Pharos
       SECRETS_CFG_FILE = (SECRETS_CFG_DIR + '/config.yml').freeze
 
       def call
-        keys = cluster_context['secrets_encryption'] || read_config_keys || generate_keys
-
-        ensure_config(keys)
-
-        cluster_context['secrets_encryption'] = keys
-      end
-
-      # @return [Hash, nil]
-      def read_config_keys
-        logger.debug { "Checking if secrets encryption is already configured ..." }
-        file = ssh.file(SECRETS_CFG_FILE)
-        return nil unless file.exist?
-
-        logger.debug { "Reusing existing encryption keys ..." }
-        config = Pharos::YamlFile.new(file).load
-
-        keys = {}
-        config['resources'].each do |resource|
-          resource['providers'].each do |provider|
-            next unless provider['aescbc']
-
-            provider['aescbc']['keys'].each do |key|
-              keys[key['name']] = key['secret']
-            end
-          end
-        end
-        keys
-      end
-
-      # @return [Hash]
-      def generate_keys
-        logger.info { "Generating new encryption keys ..." }
-
-        {
-          'key1' => Base64.strict_encode64(SecureRandom.random_bytes(32))
-        }
-      end
-
-      def ensure_config(keys)
-        cfg_file = ssh.file(SECRETS_CFG_FILE)
-        return if cfg_file.exist?
-
-        logger.info { "Creating secrets encryption configuration ..." }
+        logger.info { "Writing secrets encryption configuration ..." }
         ssh.exec!("test -d #{SECRETS_CFG_DIR} || sudo install -m 0700 -d #{SECRETS_CFG_DIR}")
-        cfg_file.write(parse_resource_file('secrets/encryption-config.yml.erb', keys))
+        cfg_file = ssh.file(SECRETS_CFG_FILE)
+        cfg_file.write(cluster_context['secrets_encryption'])
         cfg_file.chmod('0700')
       end
     end

--- a/lib/pharos/phases/configure_telemetry.rb
+++ b/lib/pharos/phases/configure_telemetry.rb
@@ -26,6 +26,7 @@ module Pharos
       # @return [String]
       def customer_token
         return '' unless File.exist?(TOKEN_FILE)
+
         match = File.read(TOKEN_FILE).match(/^CHPHAROS_TOKEN="(.+)"$/)
         return '' unless match
 

--- a/lib/pharos/phases/delete_host.rb
+++ b/lib/pharos/phases/delete_host.rb
@@ -7,6 +7,10 @@ module Pharos
 
       def call
         logger.info { "deleting node from kubernetes api ..." }
+        mutex.synchronize { perform }
+      end
+
+      def perform
         master_ssh.exec!("kubectl delete node #{@host.hostname}")
       rescue Pharos::SSH::RemoteCommand::ExecError => ex
         logger.error { "failed to delete node: #{ex.message}" }

--- a/lib/pharos/phases/drain.rb
+++ b/lib/pharos/phases/drain.rb
@@ -7,6 +7,10 @@ module Pharos
 
       def call
         logger.info { "draining ..." }
+        mutex.synchronize { perform }
+      end
+
+      def perform
         master_ssh.exec!("kubectl drain --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-local-data #{@host.hostname}")
       rescue Pharos::SSH::RemoteCommand::ExecError => ex
         logger.error { "failed to drain node: #{ex.message}" }

--- a/lib/pharos/phases/generate_secrets_encryption_keys.rb
+++ b/lib/pharos/phases/generate_secrets_encryption_keys.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module Pharos
+  module Phases
+    class GenerateSecretsEncryptionKeys < Pharos::Phase
+      title "Generate secrets encryption keys"
+
+      def call
+        cluster_context['secrets_encryption'] = generate_keys
+      end
+
+      # @return [Hash]
+      def generate_keys
+        logger.info { "Generating new encryption keys ..." }
+
+        parse_resource_file(
+          'secrets/encryption-config.yml.erb',
+          'key1' => Base64.strict_encode64(SecureRandom.random_bytes(32))
+        )
+      end
+    end
+  end
+end

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -10,10 +10,6 @@ module Pharos
       end
 
       def perform
-          logger.info { "No labels or taints set ... " }
-          return
-        end
-
         config.hosts.each do |host|
           if host.labels.empty? && @host.taints.nil?
             logger.info { "No labels or taints set for #{host} ... " }

--- a/lib/pharos/phases/label_node.rb
+++ b/lib/pharos/phases/label_node.rb
@@ -6,47 +6,58 @@ module Pharos
       title "Label nodes"
 
       def call
-        if @host.labels.empty? && @host.taints.nil?
+        mutex.synchronize { perform }
+      end
+
+      def perform
           logger.info { "No labels or taints set ... " }
           return
         end
 
-        node = find_node
-        raise Pharos::Error, "Cannot set labels, node not found" if node.nil?
+        config.hosts.each do |host|
+          if host.labels.empty? && @host.taints.nil?
+            logger.info { "No labels or taints set for #{host} ... " }
+          end
 
-        logger.info { "Configuring node labels and taints ... " }
-        patch_labels(node) unless @host.labels.empty?
-        patch_taints(node) if @host.taints
+          node = find_node(host)
+          raise Pharos::Error, "Cannot set labels, node not found" if node.nil?
+
+          logger.info { "Configuring node labels and taints for #{host.address} ... " }
+          patch_labels(node, host) if host.labels
+          patch_taints(node, host) if host.taints
+        end
       end
 
       # @param node [K8s::Resource]
-      def patch_labels(node)
+      # @param host [Pharos::Configuration::Host]
+      def patch_labels(node, host)
         kube_nodes.update_resource(
           node.merge(
             metadata: {
-              labels: @host.labels
+              labels: host.labels
             }
           )
         )
       end
 
       # @param node [K8s::Resource]
-      def patch_taints(node)
+      # @param host [Pharos::Configuration::Host]
+      def patch_taints(node, host)
         kube_nodes.update_resource(
           node.merge(
             spec: {
-              taints: @host.taints.map(&:to_h)
+              taints: host.taints.map(&:to_h)
             }
           )
         )
       end
 
-      def find_node
+      def find_node(host)
         node = nil
         retries = 0
         while node.nil? && retries < 10
           begin
-            node = kube_nodes.get(@host.hostname)
+            node = kube_nodes.get(host.hostname)
           rescue K8s::Error::NotFound
             retries += 1
             sleep 2
@@ -59,7 +70,7 @@ module Pharos
       end
 
       def kube_nodes
-        kube_client.api('v1').resource('nodes')
+        @kube_nodes ||= kube_client.api('v1').resource('nodes')
       end
     end
   end

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -30,6 +30,7 @@ module Pharos
 
       def check_cpu_arch
         return if @host.cpu_arch.supported?
+
         raise Pharos::InvalidHostError, "Cpu architecture not supported: #{@host.cpu_arch.id}"
       end
 
@@ -51,6 +52,7 @@ module Pharos
 
       def validate_localhost_resolve
         return if ssh.exec?("ping -c 1 -r -w 1 localhost")
+
         raise Pharos::InvalidHostError, "Hostname 'localhost' does not seem to resolve to an address on the local host"
       end
 

--- a/lib/pharos/phases/validate_secrets_encryption.rb
+++ b/lib/pharos/phases/validate_secrets_encryption.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Phases
+    class ValidateSecretsEncryption < Pharos::Phase
+      title "Validate secrets encryption"
+
+      PHAROS_DIR = '/etc/pharos'
+      SECRETS_CFG_DIR = (PHAROS_DIR + '/secrets-encryption').freeze
+      SECRETS_CFG_FILE = (SECRETS_CFG_DIR + '/config.yml').freeze
+
+      def call
+        mutex.synchronize do
+          return if cluster_context['secrets_encryption']
+
+          if existing_keys_valid?
+            cluster_context['secrets_encryption'] = existing_content
+          end
+        end
+      end
+
+      # @return [String,NilClass]
+      def existing_content
+        return @existing_content if @existing_content
+
+        file = ssh.file(SECRETS_CFG_FILE)
+        return nil unless file.exist?
+
+        @existing_content = file.read
+      end
+
+      # @return [TrueClass,FalseClass]
+      def existing_keys_valid?
+        logger.debug { "Checking if secrets encryption is already configured ..." }
+
+        content = existing_content
+        return false unless content
+
+        logger.debug { "Validating existing encryption keys ..." }
+        config = Pharos::YamlFile.new(StringIO.new(content)).load
+
+        config['resources'].each do |resource|
+          resource['providers'].each do |provider|
+            next unless provider['aescbc']
+
+            if !provider['aescbc'].fetch('keys', []).empty?
+              logger.debug { "Reusing existing encryption keys ..." }
+              return true
+            end
+          end
+        end
+        false
+      end
+    end
+  end
+end

--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -9,6 +9,7 @@ module Pharos
 
       def call
         return unless kubeconfig?
+
         if @host.master_sort_score.positive?
           logger.warn { "Master seems unhealthy, can't detect cluster version." }
           return

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -64,6 +64,7 @@ module Pharos
       def run!
         result = run
         raise ExecError.new(@source || cmd, result.exit_status, result.output) if result.error?
+
         result
       end
 

--- a/lib/pharos/yaml_file.rb
+++ b/lib/pharos/yaml_file.rb
@@ -31,6 +31,7 @@ module Pharos
       if result.is_a?(String)
         raise ParseError, "File #{"#{@filename} " if @filename}does not appear to be in YAML format"
       end
+
       result
     rescue Psych::SyntaxError => ex
       raise ParseError, ex.message

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -9,15 +9,17 @@ describe Pharos::Host::Configurer do
   end
 
   let(:host) { double(:host) }
-  let(:ssh) { instance_double(Pharos::SSH::Client) }
-  let(:subject) { described_class.new(host) }
-
-  let(:configurers) { [] }
 
   before do
-    allow(host).to receive(:ssh).and_return(ssh)
-    allow(test_config_class).to receive(:configs).and_return(configurers)
+    Pharos::Host::Configurer.configurers.delete_if { |c| c.supported_os_releases&.first&.id == 'test' }
+    test_config_class
   end
+
+  after do
+    Pharos::Host::Configurer.configurers.delete_if { |c| c == test_config_class }
+  end
+
+  subject { described_class.new(host) }
 
   describe '#register_config' do
     it 'registers multiple versions to configs' do

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -9,17 +9,15 @@ describe Pharos::Host::Configurer do
   end
 
   let(:host) { double(:host) }
+  let(:ssh) { instance_double(Pharos::SSH::Client) }
+  let(:subject) { described_class.new(host) }
+
+  let(:configurers) { [] }
 
   before do
-    Pharos::Host::Configurer.configurers.delete_if { |c| c.supported_os_releases&.first&.id == 'test' }
-    test_config_class
+    allow(host).to receive(:ssh).and_return(ssh)
+    allow(test_config_class).to receive(:configs).and_return(configurers)
   end
-
-  after do
-    Pharos::Host::Configurer.configurers.delete_if { |c| c == test_config_class }
-  end
-
-  subject { described_class.new(host) }
 
   describe '#register_config' do
     it 'registers multiple versions to configs' do

--- a/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
+++ b/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
@@ -10,8 +10,10 @@ describe Pharos::Host::UbuntuXenial do
   let(:ssh) { double(:ssh) }
   let(:cluster_config) { double(:cluster_config, image_repository: 'quay.io/kontena') }
   let(:subject) { described_class.new(host) }
+
   before do
     allow(host).to receive(:config).and_return(cluster_config)
+    allow(host).to receive(:ssh).and_return(ssh)
   end
 
   describe '#configure_container_runtime' do

--- a/spec/pharos/phases/generate_secrets_encryption_keys_spec.rb
+++ b/spec/pharos/phases/generate_secrets_encryption_keys_spec.rb
@@ -1,0 +1,38 @@
+require "pharos/phases/generate_secrets_encryption_keys"
+
+describe Pharos::Phases::GenerateSecretsEncryptionKeys do
+  let(:master) { Pharos::Configuration::Host.new(address: 'test', private_address: 'private', role: 'master') }
+  let(:config_hosts_count) { 1 }
+
+  let(:config) { Pharos::Config.new(
+    hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new(role: 'worker') },
+    network: {
+      service_cidr: '1.2.3.4/16',
+      pod_network_cidr: '10.0.0.0/16'
+    },
+    addons: {},
+    etcd: {}
+  ) }
+  let(:context) { double(:context) }
+
+  subject { described_class.new(master, config: config) }
+
+  describe '#call' do
+    it 'updates cluster_context' do
+      expect(subject).to receive(:generate_keys).and_return("test")
+      expect(subject).to receive(:cluster_context).and_return(context)
+      expect(context).to receive(:[]=).with('secrets_encryption', 'test')
+      subject.call
+    end
+  end
+
+  describe '#generate_keys' do
+    it 'creates valid keys' do
+      result = YAML.load(subject.generate_keys)
+      key = result['resources'].first['providers'].first['aescbc']['keys'].first
+      expect(key['name']).to eq 'key1'
+      expect(key['secret'].empty?).to be_falsey
+      expect{Base64.strict_decode64(key['secret'])}.not_to raise_error
+    end
+  end
+end

--- a/spec/pharos/phases/label_node_spec.rb
+++ b/spec/pharos/phases/label_node_spec.rb
@@ -3,7 +3,8 @@ require 'pharos/phases/label_node'
 describe Pharos::Phases::LabelNode do
   let(:master) { Pharos::Configuration::Host.new(address: '192.0.2.1') }
   let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.2', labels: { foo: 'bar' } ) }
-  let(:subject) { described_class.new(host, master: master) }
+  let(:config) { Pharos::Config.new(hosts: [host]) }
+  let(:subject) { described_class.new(host, master: master, config: config) }
 
   let(:kube_client) { instance_double(K8s::Client) }
   let(:kube_api_v1) { instance_double(K8s::APIClient) }
@@ -29,13 +30,13 @@ describe Pharos::Phases::LabelNode do
           }
         })
       ])
-      expect(subject.find_node).not_to be_nil
+      expect(subject.find_node(host)).not_to be_nil
     end
 
     it 'returns nil if node not found' do
       host.hostname = 'host-01'
       allow(kube_nodes).to receive(:get).with('host-01').and_raise(K8s::Error::NotFound.new('GET', '/asdf', 404, "Not Found", K8s::API::MetaV1::Status.new(metadata: {})))
-      expect(subject.find_node).to be_nil
+      expect(subject.find_node(host)).to be_nil
     end
   end
 

--- a/spec/pharos/phases/validate_secrets_encryption_spec.rb
+++ b/spec/pharos/phases/validate_secrets_encryption_spec.rb
@@ -1,0 +1,43 @@
+require "pharos/phases/validate_secrets_encryption"
+
+describe Pharos::Phases::ValidateSecretsEncryption do
+  let(:config_hosts_count) { 1 }
+  let(:host) { Pharos::Configuration::Host.new(role: 'master', address: 'test', private_address: 'private' ) }
+
+  let(:config) { Pharos::Config.new(
+    hosts: [host],
+    network: {
+      service_cidr: '1.2.3.4/16',
+      pod_network_cidr: '10.0.0.0/16'
+    },
+    addons: {},
+    etcd: {}
+  ) }
+
+  let(:ssh) { instance_double(Pharos::SSH::Client) }
+  subject { described_class.new(host, config: config) }
+
+  before do
+    allow(host).to receive(:ssh).and_return(ssh)
+  end
+
+  describe '#existing_keys_valid?' do
+    let(:file) { instance_double(Pharos::SSH::RemoteFile) }
+
+    before do
+      allow(ssh).to receive(:file).with('/etc/pharos/secrets-encryption/config.yml').and_return(file)
+    end
+
+    it 'returns false if no config file existing' do
+      expect(file).to receive(:exist?).and_return(false)
+
+      expect(subject.existing_keys_valid?).to be_falsey
+    end
+
+    it 'returns true if aescbc keys configured' do
+      expect(file).to receive(:exist?).and_return(true)
+      expect(file).to receive(:read).and_return(fixture("secrets_cfg.yaml"))
+      expect(subject.existing_keys_valid?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Removes the `parallel: [true|false]` option from phases. 

It's the responsibility of the phase to know when to run exclusively, not cluster manager's.

Also, most of the `parallel: false` phases were run on a single host, so `parallel: false` did essentially nothing apart from not creating a thread for the runner.

The parts of phases that should not be run parallelly can utilize the phase mutex brought in by #749
