### PR TITLE
Correct replica location

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/04-user-management-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/04-user-management-deployment.yml.erb
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: user-management
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: user-management
@@ -17,7 +18,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: lens-operator
-      replicas: 2
       containers:
         - image: <%= image_repository %>/lens-idp:<%= version %>
           name: user-management


### PR DESCRIPTION
Currently, `.spec.spec.replicas` has no effect (it should be `.spec.replicas`):
![image](https://user-images.githubusercontent.com/616428/48484866-4ff84d80-e7e5-11e8-9fb4-9c4563cf4ee3.png)
