### PR TITLE
Release v2.0.2-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.1"
+  VERSION = "2.0.2-rc.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.1

- fix cert-manager crash on issuer migration (#790)
- ingress-nginx: dynamic upstream config changes (#795)
- cri-o v1.11.9 (#800)
- don't dump backtrace in pharos ssh when no hosts defined (#792)
- fix rhel version check (#804)