### PR TITLE
Release v2.0.2

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.2-rc.1"
+  VERSION = "2.0.2"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.1

- cri-o v1.11.9 (#800)
- ingress-nginx: dynamic upstream config changes (#795)
- fix ingress-nginx default worker-shutdown-timeout (#810)
- fix cert-manager crash on issuer migration (#790)
- fix rhel version check (#804)
- use full hostname on vsphere (#812)
- don't dump backtrace in pharos ssh when no hosts defined (#792)
- fix kontena-lens create-config success check (#808)