### PR TITLE
Validate cluster.yml address format

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fugit'
 require 'dry-validation'
 

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -9,6 +9,29 @@ describe Pharos::Config do
   subject { described_class.load(data) }
 
   describe 'hosts' do
+    context 'invalid host address' do
+      let(:hosts) { [
+        { 'address' => ' 192.0.2.1', 'role' => 'master' },
+      ] }
+      it 'fails to load' do
+        expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
+          expect(exc.errors[:hosts][0][:address][0]).to eq "is invalid"
+        end
+      end
+    end
+
+    context 'invalid host private address' do
+      let(:hosts) { [
+        { 'address' => '192.0.2.1', 'private_address' => '"127.0.0.1"', 'role' => 'master' },
+      ] }
+      it 'fails to load' do
+        expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
+          expect(exc.errors[:hosts][0][:private_address][0]).to eq "is invalid"
+        end
+      end
+    end
+
+
     context 'without hosts' do
       let(:data) { {} }
 


### PR DESCRIPTION
Validates host address and private_address syntax.

Would have fixed #811 
