### PR TITLE
[WIP/POC/RFC] Hide sensitive data in debug logs

### DIFF
--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -45,7 +45,7 @@ module Pharos
 
       # @return [String]
       def read_kubeconfig
-        @ssh.file(REMOTE_KUBECONFIG).read
+        @ssh.file(REMOTE_KUBECONFIG, hide: /\w+-\w+-data: .+?$/m).read
       end
 
       # @return [Hash]

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -106,8 +106,8 @@ module Pharos
         exec(cmd, **options).success?
       end
 
-      def file(path)
-        Pharos::SSH::RemoteFile.new(self, path)
+      def file(path, **exec_options)
+        Pharos::SSH::RemoteFile.new(self, path, **exec_options)
       end
 
       def interactive_session


### PR DESCRIPTION
Adds `hide:` option to ssh commands to hide sensitive data from debug logs

TODO: use where needed, currently only in `ValidateVersion`, which now looks like:

![image](https://user-images.githubusercontent.com/224971/48711350-bd581400-ec13-11e8-8d63-8be165730ecc.png)
