### PR TITLE
Bundle an up-to-date cacert.pem file into binary during build

### DIFF
--- a/bin/pharos-cluster
+++ b/bin/pharos-cluster
@@ -12,7 +12,6 @@ STDOUT.sync = true
 # cacert.pem from excon's data/ dir.
 if ENV['SSL_CERT_PATH'].to_s.empty?
   cert_file = File.expand_path('../data/cacert.pem', __dir__)
-  puts File.exist?(cert_file).inspect
   ENV['SSL_CERT_PATH'] = cert_file if File.exist?(cert_file)
 end
 

--- a/bin/pharos-cluster
+++ b/bin/pharos-cluster
@@ -8,6 +8,14 @@ $LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
 
 STDOUT.sync = true
 
+# Excon will pick these when setting up SSL. If none are found, it will use the bundled
+# cacert.pem from excon's data/ dir.
+if ENV['SSL_CERT_PATH'].to_s.empty?
+  cert_file = File.expand_path('../data/cacert.pem', __dir__)
+  puts File.exist?(cert_file).inspect
+  ENV['SSL_CERT_PATH'] = cert_file if File.exist?(cert_file)
+end
+
 require 'pharos_cluster'
 Signal.trap("SIGPIPE", "SYSTEM_DEFAULT")
 Pharos::RootCommand.run

--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -7,6 +7,10 @@ apt-get update -y
 apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-core texinfo curl
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
+
+# Download updated SSL certs
+curl -sL https://curl.haxx.se/ca/cacert.pem > data/cacert.pem
+
 gem install bundler
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}"

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -10,6 +10,10 @@ rm -rf non-oss/
 # build binary
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
+
+# Download updated SSL certs
+curl -sL https://curl.haxx.se/ca/cacert.pem > data/cacert.pem
+
 gem install bundler
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}+oss"

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -7,6 +7,10 @@ export PHAROS_NON_OSS=true
 brew install squashfs
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
+
+# Download updated SSL certs
+curl -sL https://curl.haxx.se/ca/cacert.pem > data/cacert.pem
+
 version=${TRAVIS_TAG#"v"}
 package="pharos-cluster-darwin-amd64-${version}"
 rubyc -o "$package" --make-args=--silent pharos-cluster

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -6,7 +6,12 @@ rm -rf non-oss/
 
 brew install squashfs
 curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://curl.haxx.se/ca/cacert.pem > data/cacert.pem
 chmod +x /usr/local/bin/rubyc
+
+# Download updated SSL certs
+curl -sL https://curl.haxx.se/ca/cacert.pem > data/cacert.pem
+
 version=${TRAVIS_TAG#"v"}
 package="pharos-cluster-darwin-amd64-${version}+oss"
 rubyc -o "$package" --make-args=--silent pharos-cluster

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "pharos/version"
 
-files = Dir['README.md', 'LICENSE', 'licenses/*', 'bin/*', 'lib/**/*', 'addons/**/*']
+files = Dir['README.md', 'LICENSE', 'licenses/*', 'bin/*', 'lib/**/*', 'addons/**/*', 'data/**/*']
 require_paths = ['lib']
 if ENV['PHAROS_NON_OSS'] == 'true'
   files += Dir['non-oss/**/*']


### PR DESCRIPTION
Fixes #813 

Excon has a `cacert.pem` bundled in but it's outdated.

This PR downloads the latest `cacert.pem` from the curl homepage and bundles it into `data/cacert.pem` from where it will be used unless `ENV['SSL_CERT_PATH']` is set.

Excon will use that ENV as the default path.
