### PR TITLE
Release v2.0.3

### DIFF
--- a/addons/cert-manager/addon.rb
+++ b/addons/cert-manager/addon.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Pharos.addon 'cert-manager' do
-  version '0.5.0'
+  version '0.5.2'
   license 'Apache License 2.0'
 
   issuer = custom_type {

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.2

- bundle an up-to-date cacert.pem file into binary during build (#827)
- fix --help (#830)
- fix multi-arch clusters (#818)
- cert-manager v0.5.2 (#820)
