### PR TITLE
Transfer host environment variables from Terraform output

### DIFF
--- a/lib/pharos/terraform/json_parser.rb
+++ b/lib/pharos/terraform/json_parser.rb
@@ -60,6 +60,7 @@ module Pharos
         host[:private_interface] = bundle['private_interface'][index] if bundle['private_interface']
         host[:labels] = bundle['label'][0] if bundle['label']
         host[:taints] = bundle['taint'] if bundle['taint']
+        host[:environment] = bundle['environment'] if bundle['environment']
         host[:user] = bundle['user'] if bundle['user']
         host[:ssh_key_path] = bundle['ssh_key_path'] if bundle['ssh_key_path']
         host[:bastion] = bundle['bastion'][0] if bundle['bastion']


### PR DESCRIPTION
Environment variables (like `HTTP_PROXY`) can be configured for hosts but are currently not transferred from Terraform JSON outputs.