### PR TITLE
update ingress-nginx to 0.20.0

### DIFF
--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Pharos.addon 'ingress-nginx' do
-  version '0.17.1'
+  version '0.20.0'
   license 'Apache License 2.0'
 
   config {
@@ -13,6 +13,7 @@ Pharos.addon 'ingress-nginx' do
       'image' => 'registry.pharos.sh/kontenapharos/pharos-default-backend:0.0.3'
     )
     attribute :tolerations, Pharos::Types::Array.default([])
+    attribute :enable_dynamic_certificates, Pharos::Types::Bool.default(false)
   }
 
   config_schema {
@@ -22,6 +23,7 @@ Pharos.addon 'ingress-nginx' do
       optional(:image).filled(:str?)
     }
     optional(:tolerations).each(:hash?)
+    optional(:enable_dynamic_certificates).filled(:bool?)
   }
 
   install {
@@ -29,7 +31,8 @@ Pharos.addon 'ingress-nginx' do
       configmap: config.configmap || {},
       node_selector: config.node_selector || {},
       default_backend_image: config.default_backend['image'],
-      default_backend_replicas: default_backend_replicas
+      default_backend_replicas: default_backend_replicas,
+      enable_dynamic_certificates: config.enable_dynamic_certificates
     )
   }
 

--- a/addons/ingress-nginx/resources/daemonset.yml.erb
+++ b/addons/ingress-nginx/resources/daemonset.yml.erb
@@ -56,6 +56,10 @@ spec:
             - --annotations-prefix=nginx.ingress.kubernetes.io
             - --enable-dynamic-configuration
             - --sort-backends
+            <% if config.enable_dynamic_certificates %>
+            - --enable-dynamic-certificates
+            - --enable-ssl-chain-completion=false
+            <% end %>
           securityContext:
             capabilities:
                 drop:


### PR DESCRIPTION
Looking at the release notes, wasn't able to spot any other new configs needed than `enable_dynamic_certificates`.


fixes #723 