### PR TITLE
Improve drain during runtime upgrade

### DIFF
--- a/non-oss/pharos_pro/phases/configure_host.rb
+++ b/non-oss/pharos_pro/phases/configure_host.rb
@@ -24,7 +24,7 @@ module Pharos
             host_configurer.configure_container_runtime
             if master_healthy?
               logger.info { "Uncordoning node ..." }
-              master_ssh.exec!("kubectl uncordon #{@host.hostname}")
+              sleep 1 until master_ssh.exec("kubectl uncordon #{@host.hostname}")
               logger.info { "Waiting for node to be ready ..." }
               sleep 10 until master_ssh.exec("kubectl get nodes -o jsonpath=\"{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}\" | grep 'Ready=True'").success?
             end


### PR DESCRIPTION
Sometimes (probably because of volume mounts) drain does not succeed... this pr handles these cases by adding harder drain (without grace period) if error or timeout occurs.