### PR TITLE
Use systemd cgroup manager on bionic/cri-o (fresh installs)

### DIFF
--- a/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-cri-o.sh
@@ -47,7 +47,7 @@ apt-mark hold cri-o
 
 orig_config=$(cat /etc/crio/crio.conf)
 lineinfile "^stream_address =" "stream_address = \"${CRIO_STREAM_ADDRESS}\"" "/etc/crio/crio.conf"
-lineinfile "^cgroup_manager =" "cgroup_manager = \"cgroupfs\"" "/etc/crio/crio.conf"
+lineinfile "^cgroup_manager =" "cgroup_manager = \"${CRIO_CGROUP_MANAGER}\"" "/etc/crio/crio.conf"
 lineinfile "^log_size_max =" "log_size_max = 134217728" "/etc/crio/crio.conf"
 lineinfile "^pause_image =" "pause_image = \"${IMAGE_REPO}\/pause:3.1\"" "/etc/crio/crio.conf"
 lineinfile "^registries =" "registries = [ \"docker.io\"" "/etc/crio/crio.conf"

--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -48,6 +48,7 @@ module Pharos
             'configure-cri-o.sh',
             CRIO_VERSION: Pharos::CRIO_VERSION,
             CRIO_STREAM_ADDRESS: '127.0.0.1',
+            CRIO_CGROUP_MANAGER: 'cgroupfs',
             CPU_ARCH: host.cpu_arch.name,
             IMAGE_REPO: config.image_repository,
             INSECURE_REGISTRIES: insecure_registries


### PR DESCRIPTION
`cgroupfs` cgroup manager is buggy with cri-o runtime. This PR switches to use `systemd` cgroup manager on fresh Ubuntu Bionic installs.