### PR TITLE
Install `yum-utils` on EL7

### DIFF
--- a/lib/pharos/host/el7/scripts/configure-essentials.sh
+++ b/lib/pharos/host/el7/scripts/configure-essentials.sh
@@ -38,6 +38,10 @@ if ! rpm -qi iscsi-initiator-utils ; then
     yum install -y iscsi-initiator-utils
 fi
 
+if ! rpm -qi yum-utils ; then
+    yum install -y yum-utils
+fi
+
 env_file="/etc/environment"
 
 lineinfile "^LC_ALL=" "LC_ALL=en_US.utf-8" "$env_file"


### PR DESCRIPTION
The `needs-restarting` command (among others) is utilized throughout Pharos. This command is installed with `yum-utils` (not installed by default).

Without this, Kubelet reboots **silently fail** during upgrades.