### PR TITLE
Don't trap SIGPIPE

### DIFF
--- a/bin/pharos-cluster
+++ b/bin/pharos-cluster
@@ -9,5 +9,4 @@ $LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
 STDOUT.sync = true
 
 require 'pharos_cluster'
-Signal.trap("SIGPIPE", "SYSTEM_DEFAULT")
 Pharos::RootCommand.run

--- a/e2e/travis.sh
+++ b/e2e/travis.sh
@@ -15,6 +15,5 @@ bundle exec bin/pharos-cluster -v
 bundle exec bin/pharos-cluster version
 bundle exec bin/pharos-cluster up -d -y -c cluster.yml
 bundle exec bin/pharos-cluster ssh --role master -c cluster.yml -- kubectl get nodes
-# TODO: re-up dies with exit code 141
-#bundle exec bin/pharos-cluster up -d -y -c cluster.yml
+bundle exec bin/pharos-cluster up -d -y -c cluster.yml
 bundle exec bin/pharos-cluster reset -d -y -c cluster.yml

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -16,6 +16,9 @@ module Pharos
       super
     rescue Clamp::HelpWanted, Clamp::ExecutionError, Clamp::UsageError
       raise
+    rescue Errno::EPIPE
+      raise unless ENV['DEBUG'].to_s.empty?
+      exit 141
     rescue Pharos::ConfigError => exc
       warn "==> #{exc}"
       exit 11

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -16,14 +16,16 @@ module Pharos
       super
     rescue Clamp::HelpWanted, Clamp::ExecutionError, Clamp::UsageError
       raise
-    rescue Errno::EPIPE
-      raise unless ENV['DEBUG'].to_s.empty?
+    rescue Errno::EPIPE => ex
+      raise if debug?
+
+      warn "ERROR: #{ex.class.name} : #{ex.message}" if $stdout.tty?
       exit 141
     rescue Pharos::ConfigError => exc
       warn "==> #{exc}"
       exit 11
     rescue StandardError => ex
-      raise unless ENV['DEBUG'].to_s.empty?
+      raise if debug?
 
       signal_error "#{ex.class.name} : #{ex.message}"
     end


### PR DESCRIPTION
Trapping SIGPIPE will make ssh/http connections sometimes skip their own error handling because an exception is not raised and instead pharos exits silently without printing any reason for doing so, except `echo $?` telling it was because of `141` which comes from`SIGPIPE`.
