### PR TITLE
Improve SSH client thread safety

### DIFF
--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -19,7 +19,6 @@ module Pharos
     }.freeze
 
     class Client
-
       include MonitorMixin
 
       attr_reader :session

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -3,6 +3,7 @@
 require 'net/ssh'
 require 'net/ssh/gateway'
 require 'shellwords'
+require 'monitor'
 
 module Pharos
   module SSH
@@ -18,9 +19,13 @@ module Pharos
     }.freeze
 
     class Client
+
+      include MonitorMixin
+
       attr_reader :session
 
       def initialize(host, user = nil, opts = {})
+        super()
         @host = host
         @user = user
         @opts = opts
@@ -38,21 +43,22 @@ module Pharos
       end
 
       def connect
-        logger.debug { "connect: #{@user}@#{@host} (#{@opts})" }
-        if bastion
-          gw_opts = {}
-          gw_opts[:keys] = [bastion.ssh_key_path] if bastion.ssh_key_path
-          gateway = Net::SSH::Gateway.new(bastion.address, bastion.user, gw_opts)
-          @session = gateway.ssh(@host, @user, @opts)
-        else
-          @session = Net::SSH.start(@host, @user, @opts)
+        synchronize do
+          logger.debug { "connect: #{@user}@#{@host} (#{@opts})" }
+          if bastion
+            gw_opts = {}
+            gw_opts[:keys] = [bastion.ssh_key_path] if bastion.ssh_key_path
+            gateway = Net::SSH::Gateway.new(bastion.address, bastion.user, gw_opts)
+            @session = gateway.ssh(@host, @user, @opts)
+          else
+            @session = Net::SSH.start(@host, @user, @opts)
+          end
         end
       end
 
       # @return [Integer] local port number
       def gateway(host, port)
-        gateway = Net::SSH::Gateway.new(@host, @user, @opts)
-        gateway.open(host, port)
+        synchronize { Net::SSH::Gateway.new(@host, @user, @opts).open(host, port) }
       end
 
       # @example
@@ -69,14 +75,14 @@ module Pharos
       # @return [Pharos::SSH::Tempfile]
       # @yield [Pharos::SSH::Tempfile]
       def tempfile(prefix: "pharos", content: nil, &block)
-        Tempfile.new(self, prefix: prefix, content: content, &block)
+        synchronize { Tempfile.new(self, prefix: prefix, content: content, &block) }
       end
 
       # @param cmd [String] command to execute
       # @return [Pharos::Command::Result]
       def exec(cmd, **options)
         require_session!
-        RemoteCommand.new(self, cmd, **options).run
+        synchronize { RemoteCommand.new(self, cmd, **options).run }
       end
 
       # @param cmd [String] command to execute
@@ -84,7 +90,7 @@ module Pharos
       # @return [String] stdout
       def exec!(cmd, **options)
         require_session!
-        RemoteCommand.new(self, cmd, **options).run!.stdout
+        synchronize { RemoteCommand.new(self, cmd, **options).run!.stdout }
       end
 
       # @param script [String] name of script
@@ -98,13 +104,13 @@ module Pharos
         cmd.concat(EXPORT_ENVS.merge(env).map { |key, value| "#{key}=\"#{value}\"" })
         cmd.concat(%w(bash --norc --noprofile -x -s))
         logger.debug { "exec: #{cmd}" }
-        exec!(cmd, stdin: script, source: name, **options)
+        synchronize { exec!(cmd, stdin: script, source: name, **options) }
       end
 
       # @param cmd [String] command to execute
       # @return [Boolean]
       def exec?(cmd, **options)
-        exec(cmd, **options).success?
+        synchronize { exec(cmd, **options).success? }
       end
 
       def file(path)
@@ -112,21 +118,21 @@ module Pharos
       end
 
       def interactive_session
-        Pharos::SSH::InteractiveSession.new(self).run
+        synchronize { Pharos::SSH::InteractiveSession.new(self).run }
       end
 
       def connected?
-        @session && !@session.closed?
+        synchronize { @session && !@session.closed? }
       end
 
       def disconnect
-        @session.close if @session && !@session.closed?
+        synchronize { @session.close if @session && !@session.closed? }
       end
 
       private
 
       def require_session!
-        raise Error, "Connection not established" unless @session
+        raise Error, "Connection not established" if @session.nil? || @session.closed?
       end
     end
   end

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -57,7 +57,7 @@ module Pharos
 
       # @return [Integer] local port number
       def gateway(host, port)
-        synchronize { Net::SSH::Gateway.new(@host, @user, @opts).open(host, port) }
+        Net::SSH::Gateway.new(@host, @user, @opts).open(host, port)
       end
 
       # @example
@@ -103,13 +103,13 @@ module Pharos
         cmd.concat(EXPORT_ENVS.merge(env).map { |key, value| "#{key}=\"#{value}\"" })
         cmd.concat(%w(bash --norc --noprofile -x -s))
         logger.debug { "exec: #{cmd}" }
-        synchronize { exec!(cmd, stdin: script, source: name, **options) }
+        exec!(cmd, stdin: script, source: name, **options)
       end
 
       # @param cmd [String] command to execute
       # @return [Boolean]
       def exec?(cmd, **options)
-        synchronize { exec(cmd, **options).success? }
+        exec(cmd, **options).success?
       end
 
       def file(path)


### PR DESCRIPTION
Adds a mutex/monitor to `SSH::Client` and wraps the `exec` methods et al inside `synchronize {}`.

Simultaneous connection usage should currently happen almost nowhere, except maybe to the master host via `cluster_context['master-ssh']` or `master_host.ssh`, so this could be worth nothing. 
