### PR TITLE
Release v2.1.0-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.1.0-beta.1"
+  VERSION = "2.1.0-rc.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.1.0-beta.1

- kubernetes 1.12.3 (#872)
- fix debian stretch docker version check (#866)
- improve drain during runtime upgrade (#867)
- refactor Pharos::Host::Configurer and drop HostConfigManager (#799)
- fix cri-o systemd daemon reload (#868)
- optionally configure proxies for control plane (#862)
- install yum-utils on EL7 (#870)
- use systemd cgroup manager on bionic/cri-o (fresh installs) (#869)
- always remove cri-o bridge/loopback configs (#871)
- use master host ip address in lens config (#876)
- bump the required_ruby_version to 2.5 in gemspec (#877)
- don't trap SIGPIPE (#879)
- fix misbehaving cri-o upgrades (#878)
- apply psp policies on upgrade if they were not previously enabled (#880)
- improve SSH client thread safety (#881)
- fix uninitialized constant Pharos::Host::Ubuntu::DOCKER_VERSION (#885)