### PR TITLE
Run e2e tests without bundler

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,8 +22,6 @@ pipeline:
   e2e:
     image: ruby:2.5
     commands:
-      - gem install bundler -Nf
-      - bundle install --path bundler
       - ./e2e/drone.sh
     when:
       event: [ push ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ jobs:
   include:
     - stage: e2e
       name: "e2e: docker with weave"
+      install:
+        - gem build pharos-cluster.gemspec
+        - gem install pharos-cluster*.gem
       script: ./e2e/travis.sh
       rvm: 2.5
       dist: xenial
@@ -18,6 +21,9 @@ jobs:
         - NETWORK_PROVIDER=weave
     - stage: e2e
       name: "e2e: docker with calico"
+      install:
+        - gem build pharos-cluster.gemspec
+        - gem install pharos-cluster*.gem
       script: ./e2e/travis.sh
       rvm: 2.5
       dist: xenial
@@ -26,6 +32,9 @@ jobs:
         - NETWORK_PROVIDER=calico
     - stage: e2e
       name: "e2e: cri-o with weave"
+      install:
+        - gem build pharos-cluster.gemspec
+        - gem install pharos-cluster*.gem
       script: ./e2e/travis.sh
       rvm: 2.5
       dist: xenial
@@ -34,6 +43,9 @@ jobs:
         - NETWORK_PROVIDER=weave
     - stage: e2e
       name: "e2e: cri-o with calico"
+      install:
+        - gem build pharos-cluster.gemspec
+        - gem install pharos-cluster*.gem
       script: ./e2e/travis.sh
       rvm: 2.5
       dist: xenial

--- a/e2e/drone.sh
+++ b/e2e/drone.sh
@@ -4,7 +4,6 @@ set -ue
 
 export PHAROS_NON_OSS=true
 
-bundle install
 gem build pharos-cluster.gemspec
 gem install pharos-cluster*.gem
 pharos-cluster

--- a/e2e/travis.sh
+++ b/e2e/travis.sh
@@ -10,10 +10,10 @@ ifconfig
 
 envsubst < e2e/cluster.yml > cluster.yml
 
-bundle exec bin/pharos-cluster
-bundle exec bin/pharos-cluster -v
-bundle exec bin/pharos-cluster version
-bundle exec bin/pharos-cluster up -d -y -c cluster.yml
-bundle exec bin/pharos-cluster ssh --role master -c cluster.yml -- kubectl get nodes
-bundle exec bin/pharos-cluster up -d -y -c cluster.yml
-bundle exec bin/pharos-cluster reset -d -y -c cluster.yml
+pharos-cluster
+pharos-cluster -v
+pharos-cluster version
+pharos-cluster up -d -y -c cluster.yml
+pharos-cluster ssh --role master -c cluster.yml -- kubectl get nodes
+pharos-cluster up -d -y -c cluster.yml
+pharos-cluster reset -d -y -c cluster.yml


### PR DESCRIPTION
#883 still left in the `bundle install` before `gem build`.

Changes all e2e suites to `gem build` + `gem install` and skip bundler.

