### PR TITLE
Release v2.1.0-rc.2

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.1.0-rc.1"
+  VERSION = "2.1.0-rc.2"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.1.0-rc.1

- Kontena Lens v1.3.1 (#889)
- cri-o v1.12.3 (#892)
- kontena-storage: fix passing of storage.directories to cluster crd (#891)
- kontena-storage: fix toolbox image registry (#893)