### PR TITLE
Release v2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.1.0.alpha.1)
+    pharos-cluster (2.1.0)
       bcrypt
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -52,6 +52,7 @@ module Pharos
           ipalloc_range: @config.network.pod_network_cidr,
           arch: @host.cpu_arch,
           version: WEAVE_VERSION,
+          flying_shuttle_enabled: @config.regions.size > 1,
           flying_shuttle_version: WEAVE_FLYING_SHUTTLE_VERSION
         )
       end

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -29,7 +29,7 @@ spec:
               value: "1"
             <% if !trusted_subnets.empty? %>
             - name: EXTRA_ARGS
-              value: "--no-discovery --trusted-subnets <%= trusted_subnets.join(',') %>"
+              value: "--trusted-subnets <%= trusted_subnets.join(',') %><% if flying_shuttle_enabled %> --no-discovery<% end %>"
             <% end %>
             - name: IPALLOC_RANGE
               value: "<%= ipalloc_range %>"
@@ -82,6 +82,7 @@ spec:
           volumeMounts:
             - name: xtables-lock
               mountPath: /run/xtables.lock
+        <% if flying_shuttle_enabled %>
         - name: weave-flying-shuttle
           env:
             - name: HOSTNAME
@@ -93,6 +94,7 @@ spec:
           resources:
             requests:
               cpu: 10m
+        <% end %>
       hostNetwork: true
       hostPID: true
       restartPolicy: Always

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.1.0-rc.2"
+  VERSION = "2.1.0"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.0.4

- Kubernetes 1.12.3 (#835, #872)
- Kontena Lens v1.3.1 (#842, #889)
- Region aware peer addresses (#768, #898)
- Update ingress-nginx to 0.21.0 (#860)
- Metrics-server v0.3.1 (#849)
- Weave Net v2.5.0 (#821)
- Cri-o v1.12.3 (#892)
- Update Ubuntu Bionic docker to v18.06.1 (#801)
- Kontena-storage: fix passing of storage.directories to cluster crd (#891)
- Kontena-storage: fix toolbox image registry (#893)
- Fix debian stretch docker version check (#866)
- Improve drain during runtime upgrade (#867)
- Refactor Pharos::Host::Configurer and drop HostConfigManager (#799)
- Fix cri-o systemd daemon reload (#868)
- Optionally configure proxies for control plane (#862)
- Install yum-utils on EL7 (#870)
- Use systemd cgroup manager on bionic/cri-o (fresh installs) (#869)
- Always remove cri-o bridge/loopback configs (#871)
- Use master host ip address in lens config (#876)
- Bump the required_ruby_version to 2.5 in gemspec (#877)
- Don't trap SIGPIPE (#879)
- Fix misbehaving cri-o upgrades (#878)
- Apply psp policies on upgrade if they were not previously enabled (#880)
- Improve SSH client thread safety (#881)
- Fix uninitialized constant Pharos::Host::Ubuntu::DOCKER_VERSION (#885)
- Add Lens tls.enabled option (#796)
- Transfer host environment variables from Terraform output (#852)
- Fix version check regex (#857)
- Set NO_PROXY into container runtime config (#851)
- K8s-client 0.6.3 (#846)
- Store kontena-lens config directly to the k8s api (#822)
- Validate cluster.yml address format (#816)
- Update build scripts for rubyc 0.5 + ruby 2.5 (#839)
- Remove Pharos::SSH::Manager in favor of simpler host.ssh accessor (#798)
- Improve reset logic (#826)
- Kontena-lens: fix user-management replica location (#865)
- Travis e2e (#840)
- Randomize test case run order (#797)
- Pharos::Command specs (#832)