### PR TITLE
Shell auto-completions

### DIFF
--- a/lib/pharos/complete_command.rb
+++ b/lib/pharos/complete_command.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Pharos
+  class CompleteCommand < Pharos::Command
+    SUPPORTED_SHELLS = %w(bash zsh)
+
+    banner "outputs shell auto-completion script. to load, use:\n  source <(#{File.basename($PROGRAM_NAME)} complete)"
+
+    option %w(-s --shell), "[#{SUPPORTED_SHELLS.join('|')}]", "shell to export completions for", environment_variable: 'SHELL', default: 'bash' do |shell|
+      shell = File.basename(shell) if shell.include?('/')
+      if SUPPORTED_SHELLS.include?(shell)
+        shell
+      else
+        warn "(using 'bash' because #{shell} can not be identified as one of: #{SUPPORTED_SHELLS.join(',')})"
+        "bash"
+      end
+    end
+
+    def execute
+      send(shell)
+    end
+
+    def bash
+      puts Pharos::YamlFile.new(
+        File.open(File.join(__dir__, 'completions', 'bash.sh.erb'))
+      ).erb_result(tree: tree)
+    end
+    alias zsh bash
+
+    # Flattens the hash from { command: { subcommand: [] } } to { "command subcommand" => [] }
+    # Also doubles the --[no-]-xyz options into separate --xyz and --no-xyz
+    #
+    # Outcome is something like:
+    # { ["pharos-cluster", "license" "assign"] =>
+    #   [{:switch=>"--description", :description=>"license description", :param=>"TEXT"},
+    #    {:switch=>"--config", :description=>"path to config file (default: cluster.yml)", :param=>"YAML_FILE"},
+    #    ...
+    #   ]
+    # }
+    def tree(base = nil, command = [File.basename($PROGRAM_NAME)])
+      base ||= subcommand_tree
+      result = {}
+      case base
+      when Hash
+        base.each do |cmd, leaf|
+          result.merge!(tree(leaf, command + [cmd]))
+        end
+      when Array
+        new_array = []
+        base.each do |option|
+          if option[:switch].include?('[no-]')
+            new_array << option.merge(switch: option[:switch].sub('[no-]', ''))
+            new_array << option.merge(switch: option[:switch].sub('[no-]', 'no-'))
+          else
+            new_array << option
+          end
+        end
+        result[command] = new_array
+      else
+        result[command] = base
+      end
+      result
+    end
+
+    # Builds a nested hash of subcommands and their options
+    def subcommand_tree(base = Pharos::RootCommand)
+      if base.has_subcommands?
+        base.recognised_subcommands.map do |sc|
+          [sc.names.first, subcommand_tree(sc.subcommand_class)]
+        end.to_h
+      else
+        base.recognised_options.map do |opt|
+          {
+            switch: opt.long_switch,
+            description: opt.description,
+            param: opt.type == :flag ? nil : opt.type
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/pharos/completions/bash.sh.erb
+++ b/lib/pharos/completions/bash.sh.erb
@@ -1,0 +1,57 @@
+_pharos () {
+  local cur prev ret subcmd
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  subcmd="${COMP_WORDS[1]}"
+
+  if [ "$COMP_CWORD" = "1" ]; then
+    if [[ ${cur} == -* ]] ; then
+      COMPREPLY=( $(compgen -W "--help --version" -- ${cur}) )
+      return 0
+    fi
+
+    COMPREPLY=( $(compgen -W "<%= tree.keys.select { |k| k.size == 2 }.map(&:last).join(' ') %>" -- ${cur}) )
+  else
+    case "$subcmd" in
+      <%- tree.keys.select { |k| k.size == 3 }.map { |k| k.last(2) }.group_by(&:first).each do |cmd, subcmds| -%>
+      <%= cmd %>)
+        COMPREPLY=( $(compgen -W "<%= subcmds.map(&:last).join(' ') %>" -- ${cur}) )
+        return 0
+        ;;
+      <%- end -%>
+      <%- tree.select { |k, _| k.size == 2 }.each do |cmd, options| -%>
+      <%= cmd.last %>)
+        if [[ ${cur} == -* ]] ; then
+          COMPREPLY=( $(compgen -W "<%= options.map { |o| o[:switch] }.join(' ') %>" -- ${cur}) )
+          return 0
+        fi
+        <%- unless options.select { |o| o[:param] }.empty? -%>
+        case "$prev" in
+          <%- options.select { |o| o[:param] }.each do |option| -%>
+          <%= option[:switch] %>)
+            <%= case option[:param]
+                when 'YAML_FILE'
+                  "COMPREPLY+=( $( compgen -o plusdirs -f -X '!*.yml' -- ${cur} ))"
+                when 'JSON_FILE'
+                  "COMPREPLY+=( $( compgen -o plusdirs -f -X '!*.json' -- ${cur} ))"
+                when 'FILE'
+                  "COMPREPLY+=( $( compgen -o plusdirs -f -- ${cur} ))"
+                when /\[.+?\|.+?/
+                  "COMPREPLY=( $( compgen -W '#{ option[:param].tr('[]', '').split('|').join(' ') }' -- ${cur} ) )"
+                else
+                  "COMPREPLY=()"
+                end %>
+              return 0
+              ;;
+            <%- end -%>
+          esac
+          return 0
+          ;;
+          <%- end -%>
+      <%- end -%>
+    esac
+  fi
+}
+
+complete -o filenames -F _pharos <%= tree.keys.first.first %>


### PR DESCRIPTION
wip

Fixes #679 

Automatically generated shell completions, loaded like kube completions: `source <(pharos-cluster complete)`

Chpharos needs to be modified to load the completions upon `chpharos use` if `pharos complete` does not exit with error.
