### PR TITLE
Improve SSH password / passphrase prompting

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -57,6 +57,8 @@ module Pharos
     end
 
     def gather_facts
+      apply_phase(Phases::ConnectSSH, config.hosts, parallel: true)
+      apply_phase(Phases::AuthenticateSSH, config.hosts.reject(&:ssh?), parallel: false)
       apply_phase(Phases::GatherFacts, config.hosts, parallel: true)
       apply_phase(Phases::ConfigureClient, [config.master_host], master: config.master_host, parallel: false, optional: true)
     end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -88,7 +88,7 @@ module Pharos
         opts[:proxy] = Net::SSH::Proxy::Command.new(ssh_proxy_command) if ssh_proxy_command
         opts[:bastion] = bastion if bastion
         @ssh = Pharos::SSH::Client.new(address, user, opts.merge(options)).tap(&:connect)
-      rescue StadardError
+      rescue StandardError
         @ssh = nil
         raise
       end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -94,7 +94,7 @@ module Pharos
       end
 
       def ssh?
-        @ssh && @ssh.session && !@ssh.session.closed?
+        @ssh && !@ssh.session.closed?
       end
 
       def api_address

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -88,7 +88,7 @@ module Pharos
         opts[:proxy] = Net::SSH::Proxy::Command.new(ssh_proxy_command) if ssh_proxy_command
         opts[:bastion] = bastion if bastion
         @ssh = Pharos::SSH::Client.new(address, user, opts.merge(options)).tap(&:connect)
-      rescue => ex
+      rescue StadardError
         @ssh = nil
         raise
       end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -78,7 +78,8 @@ module Pharos
         hostname.split('.').first
       end
 
-      def ssh
+      # param options [Hash] extra options for the SSH client, see Net::SSH#start
+      def ssh(**options)
         return @ssh if @ssh
 
         opts = {}
@@ -86,7 +87,14 @@ module Pharos
         opts[:send_env] = [] # override default to not send LC_* envs
         opts[:proxy] = Net::SSH::Proxy::Command.new(ssh_proxy_command) if ssh_proxy_command
         opts[:bastion] = bastion if bastion
-        @ssh = Pharos::SSH::Client.new(address, user, opts).tap(&:connect)
+        @ssh = Pharos::SSH::Client.new(address, user, opts.merge(options)).tap(&:connect)
+      rescue => ex
+        @ssh = nil
+        raise
+      end
+
+      def ssh?
+        @ssh && @ssh.session && !@ssh.session.closed?
       end
 
       def api_address

--- a/lib/pharos/phases/authenticate_ssh.rb
+++ b/lib/pharos/phases/authenticate_ssh.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_stritiong_literal: true
-
 module Pharos
   module Phases
     class AuthenticateSSH < Pharos::Phase

--- a/lib/pharos/phases/authenticate_ssh.rb
+++ b/lib/pharos/phases/authenticate_ssh.rb
@@ -1,0 +1,15 @@
+# frozen_stritiong_literal: true
+
+module Pharos
+  module Phases
+    class AuthenticateSSH < Pharos::Phase
+      title "Authenticate SSH connection"
+
+      def call
+        host.ssh(non_interactive: false)
+        logger.info { "Authenticated as #{host.user}@#{host}" }
+      end
+    end
+  end
+end
+

--- a/lib/pharos/phases/authenticate_ssh.rb
+++ b/lib/pharos/phases/authenticate_ssh.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # frozen_stritiong_literal: true
 
 module Pharos
@@ -12,4 +14,3 @@ module Pharos
     end
   end
 end
-

--- a/lib/pharos/phases/connect_ssh.rb
+++ b/lib/pharos/phases/connect_ssh.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_stritiong_literal: true
-
 module Pharos
   module Phases
     class ConnectSSH < Pharos::Phase

--- a/lib/pharos/phases/connect_ssh.rb
+++ b/lib/pharos/phases/connect_ssh.rb
@@ -1,0 +1,15 @@
+# frozen_stritiong_literal: true
+
+module Pharos
+  module Phases
+    class ConnectSSH < Pharos::Phase
+      title "Open SSH connection"
+
+      def call
+        host.ssh(non_interactive: true)
+      rescue Net::SSH::AuthenticationFailed, Net::SSH::Authentication::KeyManagerError
+        logger.error { "Authentication failed for #{host.user}@#{host}" }
+      end
+    end
+  end
+end

--- a/lib/pharos/phases/connect_ssh.rb
+++ b/lib/pharos/phases/connect_ssh.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # frozen_stritiong_literal: true
 
 module Pharos

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -41,6 +41,7 @@ module Pharos
         @bastion ||= @opts.delete(:bastion)
       end
 
+      # @param options [Hash] see Net::SSH#start
       def connect(**options)
         synchronize do
           logger.debug { "connect: #{@user}@#{@host} (#{@opts})" }

--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -41,16 +41,16 @@ module Pharos
         @bastion ||= @opts.delete(:bastion)
       end
 
-      def connect
+      def connect(**options)
         synchronize do
           logger.debug { "connect: #{@user}@#{@host} (#{@opts})" }
           if bastion
             gw_opts = {}
             gw_opts[:keys] = [bastion.ssh_key_path] if bastion.ssh_key_path
             gateway = Net::SSH::Gateway.new(bastion.address, bastion.user, gw_opts)
-            @session = gateway.ssh(@host, @user, @opts)
+            @session = gateway.ssh(@host, @user, @opts.merge(options))
           else
-            @session = Net::SSH.start(@host, @user, @opts)
+            @session = Net::SSH.start(@host, @user, @opts.merge(options))
           end
         end
       end

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -78,7 +78,9 @@ describe Pharos::Host::Configurer do
       let(:config_environment) { { 'TEST' => 'foo' } }
 
       it 'adds a line to /etc/environment' do
-        expect(file).to receive(:write).with("TEST=foo\nPATH=/bin:/usr/local/bin\n")
+        expect(file).to receive(:write).with("TEST=\"foo\"\nPATH=\"/bin:/usr/local/bin\"\n")
+        expect(ssh).to receive(:exec!).with("export TEST=\"foo\"")
+        expect(ssh).to receive(:exec!).with("export PATH=\"/bin:/usr/local/bin\"")
         subject.update_env_file
       end
     end
@@ -87,16 +89,19 @@ describe Pharos::Host::Configurer do
       let(:config_environment) { { 'PATH' => '/bin' } }
 
       it 'modifies a line in /etc/environment' do
-        expect(file).to receive(:write).with("PATH=/bin\n")
+        expect(file).to receive(:write).with("PATH=\"/bin\"\n")
+        expect(ssh).to receive(:exec!).with("export PATH=\"/bin\"")
         subject.update_env_file
       end
     end
 
     context 'delete keys' do
+      let(:host_env_content) { "PATH=/bin\nTEST=foo\n" }
       let(:config_environment) { { 'PATH' => nil } }
 
       it 'removes a line in /etc/environment' do
-        expect(file).to receive(:write).with("\n")
+        expect(ssh).to receive(:exec!).with("export TEST=\"foo\"")
+        expect(file).to receive(:write).with("TEST=\"foo\"\n")
         subject.update_env_file
       end
     end


### PR DESCRIPTION
Fixes #909

Adds `ConnectSSH` phase that tries first to open an SSH connection to each host in non-interactive mode, which will skip any password / passphrase prompts and `AuthenticateSSH` which connects non-parallelly one by one in interactive mode to hosts that failed to connect non-interactively in the first phase.

This makes the password prompts not to get lost by appearing in the middle of other output.

Also changes the `update_env_file` of `ConfigureHost` to re-read the environment without reconnecting, which removes the need to input password / passphrase again.
