### PR TITLE
[wip/poc] Persist addon files into secrets

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -164,6 +164,7 @@ module Pharos
     def save_config
       master_host = config.master_host
       apply_phase(Phases::StoreClusterConfiguration, [master_host], master: master_host)
+      apply_phase(Phases::StoreAddonFiles, [master_host], master: master_host) unless config.addon_file_paths.empty?
     end
 
     def disconnect

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -62,6 +62,15 @@ module Pharos
 
     attr_accessor :data
 
+    def addon_file_paths
+      @addon_file_paths ||= (addon_paths + %w(pharos-addons)).uniq.flat_map do |addon_path|
+        base_path = File.join(Dir.pwd, addon_path) + "/"
+        Dir.glob(File.join(base_path, '**', '*')).select(&File.method(:file?)).map do |path|
+          [path.delete_prefix(base_path), path]
+        end
+      end.to_h
+    end
+
     # @return [Integer]
     def dns_replicas
       return network.dns_replicas if network.dns_replicas

--- a/lib/pharos/phases/store_addon_files.rb
+++ b/lib/pharos/phases/store_addon_files.rb
@@ -28,7 +28,7 @@ module Pharos
             @config.addon_file_paths.map do |relative_path, real_path|
               tar.add_file_simple(
                 File.join('pharos-addons', relative_path),
-                File.stat(real_path).mode & 0777,
+                File.stat(real_path).mode & 0o777,
                 File.size(real_path)
               ) do |io|
                 logger.info { "Adding #{real_path} as addons.tar.gz:#{relative_path}" }
@@ -61,4 +61,3 @@ module Pharos
     end
   end
 end
-

--- a/lib/pharos/phases/store_addon_files.rb
+++ b/lib/pharos/phases/store_addon_files.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Gem
+  autoload :Package, 'rubygems/package'
+end
+
+autoload :Zlib, 'zlib'
+
+module Pharos
+  module Phases
+    class StoreAddonFiles < Pharos::Phase
+      require 'rubygems/package'
+      title "Store addon files"
+
+      def call
+        secret = resource
+        logger.info { "Storing addons.tar.gz as pharos-addon-files secret ..." }
+        ensure_resource(secret)
+      end
+
+      private
+
+      def addons_tar_gz
+        logger.info { "Creating addons.tar.gz archive .." }
+        buffer = StringIO.new
+        Zlib::GzipWriter.wrap(buffer) do |gz|
+          Gem::Package::TarWriter.new(gz) do |tar|
+            @config.addon_file_paths.map do |relative_path, real_path|
+              tar.add_file_simple(
+                File.join('pharos-addons', relative_path),
+                File.stat(real_path).mode & 0777,
+                File.size(real_path)
+              ) do |io|
+                logger.info { "Adding #{real_path} as addons.tar.gz:#{relative_path}" }
+                io.write(File.read(real_path))
+              end
+            end
+          end
+        end
+        logger.debug { "Archive size: #{buffer.size} byges" }
+        buffer.string
+      end
+
+      def resource
+        K8s::Resource.new(
+          apiVersion: 'v1',
+          kind: 'Secret',
+          metadata: { name: 'pharos-addon-files', namespace: 'kube-system' },
+          type: 'Opaque',
+          data: {
+            "addons.tar.gz" => Base64.encode64(addons_tar_gz)
+          }
+        )
+      end
+
+      def ensure_resource(resource)
+        kube_client.update_resource(resource)
+      rescue K8s::Error::NotFound
+        kube_client.create_resource(resource)
+      end
+    end
+  end
+end
+

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -109,6 +109,13 @@ module Pharos
         puts
       end
 
+      unless config.addon_file_paths.empty?
+        puts pastel.green("==> The following addon-files will be stored as secrets on cluster:")
+        config.addon_file_paths.each do |relative_path, real_path|
+          puts "- #{real_path}"
+        end
+      end
+
       confirm_yes!('Continue?', default: true)
     end
   end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -111,7 +111,7 @@ module Pharos
 
       unless config.addon_file_paths.empty?
         puts pastel.green("==> The following addon-files will be stored as secrets on cluster:")
-        config.addon_file_paths.each do |relative_path, real_path|
+        config.addon_file_paths.each do |_relative_path, real_path|
           puts "- #{real_path}"
         end
       end


### PR DESCRIPTION
Stores addon files into kube-system namespace secrets as `pharos-addon-files` with the key `addons.tar.gz` as a `tar.gz` package.

This should make it possible to run the `up` with the same config on another host in the future.

The cluster config yaml (including the hosts from terraform) is already stored into ConfigMap.

