### PR TITLE
Prefix debug output with ssh hostname

### DIFF
--- a/lib/pharos/ssh/client.rb
+++ b/lib/pharos/ssh/client.rb
@@ -21,8 +21,11 @@ module Pharos
     class Client
       include MonitorMixin
 
-      attr_reader :session
+      attr_reader :session, :host
 
+      # @param host [String]
+      # @param user [String, NilClass]
+      # @param opts [Hash]
       def initialize(host, user = nil, opts = {})
         super()
         @host = host
@@ -37,6 +40,7 @@ module Pharos
         end
       end
 
+      # @return [Hash,NilClass]
       def bastion
         @bastion ||= @opts.delete(:bastion)
       end
@@ -55,6 +59,8 @@ module Pharos
         end
       end
 
+      # @param host [String]
+      # @param port [Integer]
       # @return [Integer] local port number
       def gateway(host, port)
         Net::SSH::Gateway.new(@host, @user, @opts).open(host, port)
@@ -78,6 +84,7 @@ module Pharos
       end
 
       # @param cmd [String] command to execute
+      # @param options [Hash]
       # @return [Pharos::Command::Result]
       def exec(cmd, **options)
         require_session!
@@ -85,6 +92,7 @@ module Pharos
       end
 
       # @param cmd [String] command to execute
+      # @param options [Hash]
       # @raise [Pharos::SSH::RemoteCommand::ExecError]
       # @return [String] stdout
       def exec!(cmd, **options)
@@ -92,7 +100,8 @@ module Pharos
         synchronize { RemoteCommand.new(self, cmd, **options).run!.stdout }
       end
 
-      # @param script [String] name of script
+      # @param name [String] name of script
+      # @param env [Hash] environment variables hash
       # @param path [String] real path to file, defaults to script
       # @raise [Pharos::SSH::RemoteCommand::ExecError]
       # @return [String] stdout
@@ -107,11 +116,14 @@ module Pharos
       end
 
       # @param cmd [String] command to execute
+      # @param options [Hash]
       # @return [Boolean]
       def exec?(cmd, **options)
         exec(cmd, **options).success?
       end
 
+      # @param path [String]
+      # @return [Pharos::SSH::RemoteFile]
       def file(path)
         Pharos::SSH::RemoteFile.new(self, path)
       end

--- a/lib/pharos/ssh/interactive_session.rb
+++ b/lib/pharos/ssh/interactive_session.rb
@@ -8,6 +8,7 @@ module Pharos
     class InteractiveSession
       attr_reader :client
 
+      # @param client [Pharos::SSH::Client]
       def initialize(client)
         @client = client
       end

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -134,7 +134,7 @@ module Pharos
       # @param source [String, NilClass]
       # @return [Integer]
       def debug_cmd(cmd, source: nil)
-        $stdout.write("#{INDENT} #{pastel.cyan("#{@client.host}:")} #{pastel.cyan("$ #{cmd}" + (source ? " < #{source}" : ""))}\n")
+        $stdout.write("#{INDENT} #{pastel.cyan("#{@client.host}:")} #{pastel.cyan("$ #{cmd}" + (source ? " < #{source}" : ''))}\n")
       end
 
       # @param data [String]

--- a/lib/pharos/ssh/remote_command.rb
+++ b/lib/pharos/ssh/remote_command.rb
@@ -135,7 +135,6 @@ module Pharos
       # @return [Integer]
       def debug_cmd(cmd, source: nil)
         $stdout.write("#{INDENT} #{pastel.cyan("#{@client.host}:")} #{pastel.cyan("$ #{cmd}" + (source ? " < #{source}" : ""))}\n")
-
       end
 
       # @param data [String]

--- a/lib/pharos/ssh/remote_file.rb
+++ b/lib/pharos/ssh/remote_file.rb
@@ -19,19 +19,26 @@ module Pharos
       alias to_s path
 
       # Removes the remote file
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def unlink
         @client.exec!("sudo rm #{escaped_path}")
       end
       alias rm unlink
 
+      # @return [String]
       def basename
         File.basename(@path)
       end
 
+      # @return [String]
       def dirname
         File.dirname(@path)
       end
 
+      # @param content [String]
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def write(content)
         tmp = temp_file_path.shellescape
         @client.exec!(
@@ -40,18 +47,23 @@ module Pharos
         )
       end
 
+      # @param mode [String, Integer]
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def chmod(mode)
         @client.exec!("sudo chmod #{mode} #{escaped_path}")
       end
 
       # Returns remote jfile content
-      # @return [String]
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def read
         @client.exec!("sudo cat #{escaped_path}")
       end
 
       # True if the file exists. Assumes a bash-like shell.
       # @return [Boolean]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def exist?
         @client.exec!("sudo env -i bash --norc --noprofile -c -- 'test -e #{escaped_path} && echo true || echo false'").strip == "true"
       end
@@ -64,6 +76,8 @@ module Pharos
 
       # Moves the current file to target path
       # @param target [String]
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def move(target)
         @client.exec!("sudo mv #{@path} #{target.shellescape}")
       end
@@ -71,6 +85,8 @@ module Pharos
 
       # Copies the current file to target path
       # @param target [String]
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def copy(target)
         @client.exec!("sudo cp #{escaped_path} #{target.shellescape}")
       end
@@ -78,11 +94,14 @@ module Pharos
 
       # Creates a symlink at the target path that points to the current file
       # @param target [String]
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def link(target)
         @client.exec!("sudo ln -s #{escaped_path} #{target.shellescape}")
       end
 
       # @return [String, nil]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def readlink
         target = @client.exec!("readlink #{escaped_path} || echo").strip
 

--- a/lib/pharos/ssh/tempfile.rb
+++ b/lib/pharos/ssh/tempfile.rb
@@ -29,6 +29,9 @@ module Pharos
         run(&block) if block_given?
       end
 
+      # @param content [String]
+      # @return [Pharos::SSH::RemoteCommand::Result]
+      # @raises [Pharos::SSH::RemoteCommand::ExecError]
       def write(content)
         @client.exec!(
           "cat > #{escaped_path}",


### PR DESCRIPTION
It's very difficult to follow debug output because most phases are executed in parallel and output does not have any hints which host produced the line. This PR improves output by prefixing each debug output with ssh hostname.