### PR TITLE
Change the defaults of configuration arrays and hashes to procs

### DIFF
--- a/addons/openebs/addon.rb
+++ b/addons/openebs/addon.rb
@@ -16,8 +16,8 @@ Pharos.addon 'openebs' do
   }.freeze
 
   config {
-    attribute :default_storage_class, Pharos::Types::Hash.default(DEFAULT_CLASS_OPTS)
-    attribute :default_storage_pool, Pharos::Types::Hash.default(DEFAULT_POOL_OPTS)
+    attribute :default_storage_class, Pharos::Types::Hash.default(proc { DEFAULT_CLASS_OPTS.dup })
+    attribute :default_storage_pool, Pharos::Types::Hash.default(proc { DEFAULT_POOL_OPTS.dup })
   }
 
   config_schema {

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -55,8 +55,8 @@ module Pharos
     attribute :telemetry, Pharos::Configuration::Telemetry
     attribute :pod_security_policy, Pharos::Configuration::PodSecurityPolicy
     attribute :image_repository, Pharos::Types::String.default('registry.pharos.sh/kontenapharos')
-    attribute :addon_paths, Pharos::Types::Array.default(proc { Array.new })
-    attribute :addons, Pharos::Types::Hash.default(proc { Hash.new })
+    attribute :addon_paths, Pharos::Types::Array.default(proc { [] })
+    attribute :addons, Pharos::Types::Hash.default(proc { {} })
     attribute :admission_plugins, Types::Coercible::Array.of(Pharos::Configuration::AdmissionPlugin)
     attribute :container_runtime, Pharos::Configuration::ContainerRuntime
 
@@ -66,6 +66,7 @@ module Pharos
     def dns_replicas
       return network.dns_replicas if network.dns_replicas
       return 1 if hosts.length == 1
+
       1 + (hosts.length / HOSTS_PER_DNS_REPLICA.to_f).ceil
     end
 
@@ -133,6 +134,7 @@ module Pharos
     # @raise [Pharos::ConfigError]
     def set(key, value)
       raise Pharos::Error, "Cannot override #{key}." if data[key.to_s]
+
       attributes[key] = value
     end
 

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -55,8 +55,8 @@ module Pharos
     attribute :telemetry, Pharos::Configuration::Telemetry
     attribute :pod_security_policy, Pharos::Configuration::PodSecurityPolicy
     attribute :image_repository, Pharos::Types::String.default('registry.pharos.sh/kontenapharos')
-    attribute :addon_paths, Pharos::Types::Array.default([])
-    attribute :addons, Pharos::Types::Hash.default({})
+    attribute :addon_paths, Pharos::Types::Array.default(proc { Array.new })
+    attribute :addons, Pharos::Types::Hash.default(proc { Hash.new })
     attribute :admission_plugins, Types::Coercible::Array.of(Pharos::Configuration::AdmissionPlugin)
     attribute :container_runtime, Pharos::Configuration::ContainerRuntime
 

--- a/lib/pharos/configuration/container_runtime.rb
+++ b/lib/pharos/configuration/container_runtime.rb
@@ -3,7 +3,7 @@
 module Pharos
   module Configuration
     class ContainerRuntime < Pharos::Configuration::Struct
-      attribute :insecure_registries, Pharos::Types::Array.default([])
+      attribute :insecure_registries, Pharos::Types::Array.default(proc { Array.new })
     end
   end
 end

--- a/lib/pharos/configuration/container_runtime.rb
+++ b/lib/pharos/configuration/container_runtime.rb
@@ -3,7 +3,7 @@
 module Pharos
   module Configuration
     class ContainerRuntime < Pharos::Configuration::Struct
-      attribute :insecure_registries, Pharos::Types::Array.default(proc { Array.new })
+      attribute :insecure_registries, Pharos::Types::Array.default(proc { [] })
     end
   end
 end


### PR DESCRIPTION
The current way of defining defaults will share the same initial array / hash instance for the key across all instances of the configuration object and changing one of them will cause the change to appear in all of the instances that did not specify that configuration key themselves.

I don't think it causes any problems currently, but they're obviously wrong now:

```
rb(main):002:0> c = Pharos::Config.new
irb(main):003:0> c2 = Pharos::Config.new
irb(main):004:0> c.addon_paths << "hello"
=> ["hello"]
irb(main):005:0> c2.addon_paths
=> ["hello"]
```
