### PR TITLE
Update net-ssh to v5.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       excon (~> 0.62.0)
       fugit (~> 1.1.2)
       k8s-client (~> 0.6.3)
-      net-ssh (= 5.0.2)
+      net-ssh (= 5.1.0)
       net-ssh-gateway (= 2.0.0)
       pastel
       rouge (~> 3.1)
@@ -85,7 +85,7 @@ GEM
       yajl-ruby (~> 1.4.0)
     multi_json (1.13.1)
     necromancer (0.4.0)
-    net-ssh (5.0.2)
+    net-ssh (5.1.0)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     parallel (1.12.1)

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "clamp", "1.2.1"
   spec.add_runtime_dependency "pastel"
-  spec.add_runtime_dependency "net-ssh", "5.0.2"
+  spec.add_runtime_dependency "net-ssh", "5.1.0"
   spec.add_runtime_dependency "net-ssh-gateway", "2.0.0"
   spec.add_runtime_dependency "ed25519", "1.2.4"
   spec.add_runtime_dependency "bcrypt"


### PR DESCRIPTION
Should support new OpenSSH private key format for RSA.