### PR TITLE
k8s-client v0.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.1.0)
+    pharos-cluster (2.2.0.alpha.0)
       bcrypt
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
@@ -11,7 +11,7 @@ PATH
       ed25519 (= 1.2.4)
       excon (~> 0.62.0)
       fugit (~> 1.1.2)
-      k8s-client (~> 0.6.3)
+      k8s-client (~> 0.7.0)
       net-ssh (= 5.1.0)
       net-ssh-gateway (= 2.0.0)
       pastel
@@ -25,7 +25,7 @@ GEM
     bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.0)
     clamp (1.2.1)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     deep_merge (1.2.1)
     diff-lcs (1.3)
     dry-configurable (0.7.0)
@@ -69,13 +69,13 @@ GEM
     fugit (1.1.6)
       et-orbi (~> 1.1, >= 1.1.6)
       raabro (~> 1.1)
-    hashdiff (0.3.7)
+    hashdiff (0.3.8)
     ice_nine (0.11.2)
     jaro_winkler (1.5.1)
-    jsonpath (0.9.6)
+    jsonpath (0.9.8)
       multi_json
       to_regexp (~> 0.2.1)
-    k8s-client (0.6.3)
+    k8s-client (0.7.0)
       deep_merge (~> 1.2.1)
       dry-struct (~> 0.5.0)
       excon (~> 0.62.0)
@@ -83,6 +83,7 @@ GEM
       jsonpath (~> 0.9.5)
       recursive-open-struct (~> 1.1.0)
       yajl-ruby (~> 1.4.0)
+      yaml-safe_load_stream (~> 0.1)
     multi_json (1.13.1)
     necromancer (0.4.0)
     net-ssh (5.1.0)
@@ -122,12 +123,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
-    thread_safe (0.3.6)
     timers (4.2.0)
     to_regexp (0.2.1)
     tty-color (0.4.3)
     tty-cursor (0.6.0)
-    tty-prompt (0.18.0)
+    tty-prompt (0.18.1)
       necromancer (~> 0.4.0)
       pastel (~> 0.7.0)
       timers (~> 4.0)
@@ -138,11 +138,12 @@ GEM
       tty-screen (~> 0.6.4)
       wisper (~> 2.0.0)
     tty-screen (0.6.5)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.0)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.4.0)
     wisper (2.0.0)
     yajl-ruby (1.4.1)
+    yaml-safe_load_stream (0.1.0)
 
 PLATFORMS
   ruby

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
-  spec.add_runtime_dependency "k8s-client", "~> 0.6.3"
+  spec.add_runtime_dependency "k8s-client", "~> 0.7.0"
   spec.add_runtime_dependency "excon", "~> 0.62.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
Should fix infinite `got error (K8s::Error::UndefinedResource)` error.