### PR TITLE
Release v2.2.0-alpha.1

### DIFF
--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -8,7 +8,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra5/rubyc-0.5.0+extra5-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${DRONE_TAG#"v"}

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -7,7 +7,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra5/rubyc-0.5.0+extra5-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -9,7 +9,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra5/rubyc-0.5.0+extra5-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${TRAVIS_TAG#"v"}

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -7,7 +7,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra5/rubyc-0.5.0+extra5-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.0-alpha.0"
+  VERSION = "2.2.0-alpha.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.1.3

- Kubernetes v1.13.1 (#941)
- Kontena Network LB addon implementation (#557)
- Create cluster issuer with kube CA (#931)
- Update Helm to 2.12.1 (#937)
- Remove exponential backoff from retries (#854)
- Prefix debug output with ssh hostname (#928)
- Improve SSH password / passphrase prompting (#911)
- K8s-client v0.7.0 (#943)
- Drop "pharos build" alias for "pharos up" (#895)
- Fix travis bundler error (#942)