### PR TITLE
Remove bundler version restriction

### DIFF
--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "k8s-client", "~> 0.7.0"
   spec.add_runtime_dependency "excon", "~> 0.62.0"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "fakefs", "~> 0.13"


### PR DESCRIPTION
```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.15)

  Current Bundler version:
    bundler (2.0.0)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.15)' in any of the relevant sources:
  the local ruby installation
```

The current version constraint does not allow 2.x
