### PR TITLE
Silence phase thread exception reporting

### DIFF
--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -30,6 +30,7 @@ module Pharos
     def run_parallel(phases, &block)
       threads = phases.map { |phase|
         Thread.new do
+          Thread.current.report_on_exception = false
           Retry.perform(yield_object: phase, logger: logger, exceptions: RETRY_ERRORS, &block)
         end
       }


### PR DESCRIPTION
Currently it always shows a backtrace... by silencing threads it will be shown only when `--debug` is on.