### PR TITLE
PoC Clamp-completion gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
+gem 'clamp-completer', path: 'completer_gem'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.2.0.alpha.0)
+    pharos-cluster (2.2.0.alpha.1)
       bcrypt
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
@@ -17,6 +17,12 @@ PATH
       pastel
       rouge (~> 3.1)
       tty-prompt (~> 0.16)
+
+PATH
+  remote: completer_gem
+  specs:
+    clamp-completer (0.1.0)
+      clamp
 
 GEM
   remote: https://rubygems.org/
@@ -150,6 +156,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.15)
+  clamp-completer!
   fakefs (~> 0.13)
   pharos-cluster!
   rake (~> 10.0)
@@ -157,4 +164,4 @@ DEPENDENCIES
   rubocop (~> 0.57)
 
 BUNDLED WITH
-   1.16.3
+   1.17.2

--- a/completer_gem/Gemfile
+++ b/completer_gem/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in clamp-completer.gemspec
+gemspec

--- a/completer_gem/Gemfile.lock
+++ b/completer_gem/Gemfile.lock
@@ -1,0 +1,37 @@
+PATH
+  remote: .
+  specs:
+    clamp-completer (0.1.0)
+      clamp
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    clamp (1.2.1)
+    diff-lcs (1.3)
+    rake (10.5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.17)
+  clamp-completer!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   1.17.1

--- a/completer_gem/README.md
+++ b/completer_gem/README.md
@@ -1,0 +1,35 @@
+# Clamp::Completer
+
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/clamp/completer`. To experiment with that code, run `bin/console` for an interactive prompt.
+
+TODO: Delete this and the text above, and describe your gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'clamp-completer'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install clamp-completer
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/clamp-completer.

--- a/completer_gem/Rakefile
+++ b/completer_gem/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/completer_gem/bin/console
+++ b/completer_gem/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "clamp/completer"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/completer_gem/bin/setup
+++ b/completer_gem/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/completer_gem/clamp-completer.gemspec
+++ b/completer_gem/clamp-completer.gemspec
@@ -1,0 +1,40 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "clamp/completer/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "clamp-completer"
+  spec.version       = Clamp::Completer::VERSION
+  spec.authors       = ["Kimmo Lehto"]
+  spec.email         = ["kimmo.lehto@kontena.io"]
+
+  spec.summary       = %q{clamp complete}
+  spec.description   = %q{clomplete}
+  spec.homepage      = "http://example.com"
+
+  # # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # # to allow pushing to a single host or delete this section to allow pushing to any host.
+  # if spec.respond_to?(:metadata)
+  #   spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+
+  #   spec.metadata["homepage_uri"] = spec.homepage
+  #   spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
+  #   spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  # else
+  #   raise "RubyGems 2.0 or newer is required to protect against " \
+  #     "public gem pushes."
+  # end
+
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "clamp"
+
+  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end

--- a/completer_gem/examples/simple
+++ b/completer_gem/examples/simple
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+
+require 'clamp'
+require 'clamp/completer'
+
+Clamp do
+  option %w(-d --debug), :flag, "set debug on"
+  option '--[no-]yesno', :flag, "test option 3"
+
+  subcommand "foo", "do foo stuff" do
+    subcommand "bar", "do foo stuff" do
+      option '--test', :flag, "test flag"
+      option '--opt', 'OPT', "test option", attribute_name: :some_attr
+      option '--cmd', 'cmd', "test option 2"
+      option '--[no-]yesno', :flag, "test option 3"
+
+      def complete_cmd
+        { command: 'echo foo bar buz' }
+      end
+
+      def complete_some_attr
+        { glob: '*.y*ml' }
+      end
+
+      def execute
+        puts "--test given? : #{test?}"
+      end
+    end
+  end
+
+  subcommand "complete", "shell autocompletions", Clamp::Completer.new(self)
+end

--- a/completer_gem/lib/clamp/completer.rb
+++ b/completer_gem/lib/clamp/completer.rb
@@ -1,0 +1,73 @@
+require "clamp/completer/version"
+require 'shellwords'
+
+module Clamp
+  module Completer
+    module Builder
+      autoload :ERB, 'erb'
+      autoload :OpenStruct, 'ostruct'
+
+      class Iterator
+        def initialize(root)
+          @root = root
+        end
+
+        def recurse(base = [], &block)
+          if @root.has_subcommands?
+            @root.recognised_subcommands.each do |sc|
+              sc.names.each do |name|
+                Iterator.new(sc.subcommand_class).recurse(base + [name], &block)
+              end
+            end
+          end
+          yield(base, @root) unless base.empty?
+        end
+      end
+
+      def root
+        self.class.root_command
+      end
+
+      def template_path(shell_name)
+        File.join(__dir__, 'completer', 'templates', "#{shell_name}.sh.erb")
+      end
+
+      def wrapper
+        klass = Class.new(self.class)
+        klass.subcommand(File.basename($PROGRAM_NAME), root.description || "main", root)
+        klass
+      end
+
+      def execute
+        template_file = template_path(shell)
+        unless File.exist?(template_file)
+          warn "Completion generation is not supported for #{shell}, defaulting to bash"
+          template_file = template_path("bash")
+        end
+
+        puts ERB.new(File.read(template_file), nil, '%-').tap { |e| e.location = [template_file, nil] }.result(
+                         OpenStruct.new(progname: File.basename($PROGRAM_NAME), iterator: Iterator.new(wrapper)).instance_eval { binding }
+        )
+      end
+    end
+
+    def self.new(root_command, inherit_from: Clamp::Command)
+      @klass = Class.new(inherit_from) do
+        include Builder
+
+        class << self
+          attr_accessor :root_command
+        end
+      end
+
+      @klass.parameter('[SHELL]', 'shell', environment_variable: 'SHELL', default: 'bash') do |shell|
+        File.basename(shell)
+      end
+
+      @klass.root_command = root_command
+
+      @klass.banner("To load, use: source <(#{File.basename($PROGRAM_NAME)} complete #{@klass.usage_descriptions.join(' ')})")
+      @klass
+    end
+  end
+end

--- a/completer_gem/lib/clamp/completer/templates/bash.sh.erb
+++ b/completer_gem/lib/clamp/completer/templates/bash.sh.erb
@@ -1,0 +1,92 @@
+_clamp_completer_<%= progname %>_current_subcommand() {
+  local ret="_${COMP_WORDS[0]}"
+  for ((i=1; i<$COMP_CWORD; i++)); do
+    if [[ ! $COMP_WORDS[$i] == -* ]]; then
+      declare -fF -- "${ret}_${COMP_WORDS[$i]}" >/dev/null && ret="${ret}_${COMP_WORDS[$i]}"
+    fi
+  done
+
+  if [ -n "$ret" ]; then
+    RET="${ret}"
+    return 0
+  else
+    return 1
+  fi
+}
+
+_clamp_completer_<%= progname %>_nospace() {
+  command -v compopt &> /dev/null && compopt -o nospace
+}
+
+<%- iterator.recurse do |invocation_path, command_class| -%>
+_<%= invocation_path.join('_') %>() {
+  local cur prev subcmd
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  _clamp_completer_<%= progname %>_current_subcommand && subcmd="$RET"
+
+  if [ "$subcmd" = "${FUNCNAME[0]}${funcstack[1]}" ]; then
+    <%- visible_opts = command_class.recognised_options.reject(&:hidden?) -%>
+    if [[ ${cur} == -* ]] ; then
+      COMPREPLY=( $(compgen -W "<%= visible_opts.map(&:long_switch).join(' ') %>" -- ${cur}) )
+      return 0
+    fi
+
+    <%- visible_non_flag_opts = visible_opts.reject { |o| o.type == :flag } -%>
+    <%- unless visible_non_flag_opts.empty? -%>
+    <%- instance = command_class.new(invocation_path) -%>
+    case "$prev" in
+      <%- visible_non_flag_opts.each do |option| -%>
+      <%= option.switches.join('|') %>)
+       COMPREPLY=()
+        <%- if instance.respond_to?("complete_#{option.attribute_name}")
+              reply = instance.send("complete_#{option.attribute_name}")
+            else
+              cleaned_type = "complete_#{option.type.downcase.delete_prefix('[').split(' ').first}"
+              if instance.respond_to?(cleaned_type)
+                reply = instance.send(cleaned_type)
+              end
+            end -%>
+       <%- [reply].compact.each do |reply| -%>
+       <%= case reply
+          when String
+            "COMPREPLY+=( $(compgen -W \"#{reply}\" -- \"${cur}\") );"
+          when Symbol
+            case reply
+            when :dirs
+              "COMPREPLY+=( $(compgen -o nospace -d -S \"/\"  -- \"${cur}\") ); _clamp_completer_#{ progname }_nospace;"
+            when :hosts
+              "COMPREPLY+=( $(compgen -A hostname -- \"${cur}\") );"
+            when :files
+              "COMPREPLY+=( $(compgen -o filenames -f -- \"${cur}\") );"
+            end
+          when Hash
+            case reply.first.first
+            when :glob
+              "COMPREPLY+=( $(compgen -o filenames -f -G \"#{reply.first.last}\" -- \"${cur}\") );"
+            when :command
+              "COMPREPLY+=( $(compgen -C \"#{reply.first.last}\" -- \"${cur}\") );"
+            end
+          else
+            "COMPREPLY+=( $(compgen -o bashdefault -- \"${cur}\") );"
+          end %>
+        <%- end -%>
+        return 0
+        ;;
+      <%- end -%>
+    esac
+    <%- end -%>
+
+    <%- if command_class.has_subcommands? -%>
+    COMPREPLY=( $(compgen -W "<%= command_class.recognised_subcommands.flat_map(&:names).join(' ') %>" -- ${cur}) )
+    <%- else -%>
+    COMPREPLY=()
+    <%- end -%>
+  elif [ -n "$subcmd" ]; then
+    eval "$subcmd"
+  fi
+}
+
+<%- end -%>
+complete -F _<%= progname %> <%= progname %>

--- a/completer_gem/lib/clamp/completer/templates/zsh.sh.erb
+++ b/completer_gem/lib/clamp/completer/templates/zsh.sh.erb
@@ -1,0 +1,94 @@
+#compdef <%= progname %>
+
+<%- iterator.recurse do |invocation_path, command_class| -%>
+<%- if command_class.has_subcommands? -%>
+_<%= invocation_path.join('_') %>_subcommands() {
+  local subcommands=( <%= command_class.recognised_subcommands.map { |sc| "'#{sc.names.first}:#{sc.description.gsub(/'\$\\/, '\\\1') }'" }.join(' ') %> )
+  _describe 'subcommands' subcommands && return 0
+  return 1
+}
+
+<%- else -%>
+_<%= invocation_path.join('_') %>_subcommands() {
+  return 1
+}
+
+<%- end -%>
+
+_<%= invocation_path.join('_') %>() {
+  local curcontext="$curcontext" state state_descr line expl
+  local ret=1
+
+  _arguments -C : \
+    '1:subcommands:_<%= invocation_path.join('_') %>_subcommands' \
+    <%- command_class.recognised_options.each do |opt| -%>
+      <%- if opt.type == :flag -%>
+        <%- if opt.long_switch.include?('[no-]') -%>
+          '<%= opt.long_switch.gsub('[no-]', 'no-') %>[(disable) <%= opt.description.gsub(/\[|\]|:/, '\\\1') %>]' \
+          '<%= opt.long_switch.gsub('[no-]', '') %>[(enable) <%= opt.description.gsub(/\[|\]|:/, '\\\1') %>]' \
+        <%- else -%>
+          '<%= opt.long_switch %>[<%= opt.description.gsub(/\[|\]|:/, '\\\1') %>]' \
+        <%- end -%>
+      <%- else
+            instance = command_class.new(invocation_path)
+            if instance.respond_to?("complete_#{opt.attribute_name}")
+              reply = instance.send("complete_#{opt.attribute_name}")
+            else
+              cleaned_type = "complete_#{opt.type.downcase.delete_prefix('[').split(' ').first}"
+              if instance.respond_to?(cleaned_type)
+                reply = instance.send(cleaned_type)
+              end
+            end
+            result=[]
+            [reply].compact.each do |reply|
+            case reply
+            when String
+              result << "(#{reply})"
+            when Symbol
+              case reply
+              when :dirs
+                result << "_path_files -/"
+              when :hosts
+              when :files
+                result << "_path_files -f"
+              end
+            when Hash
+              case reply.first.first
+              when :glob
+                result << "_path_files -f -g \"#{reply.first.last}\""
+              when :command
+                result << "(${(k)commands})"
+              end
+            else
+            end
+        -%>
+        <%- if opt.long_switch.include?('[no-]') -%>
+          '<%= opt.long_switch.gsub('[no-]', 'no-') %>:(disable) <%= opt.description.gsub(/\[|\]|:/, '\\\1') %>:<%= result.first %>' \
+          '<%= opt.long_switch.gsub('[no-]', '') %>:(enable) <%= opt.description.gsub(/\[|\]|:/, '\\\1') %>:<%= result.first %>' \
+        <%- else -%>
+          '<%= opt.long_switch %>:<%= opt.description.gsub(/\[|\]|:/, '\\\1') %>:<%= result.first %>' \
+        <%- end -%>
+        <%- end -%>
+        <%- end -%>
+        <%- end -%>
+    '*::options:->options' && return 0
+
+  case "$state" in
+    command) _<%= invocation_path.join('_') %>_subcommands && return 0 ;;
+    options)
+      local command="${line[1]}"
+      curcontext="${curcontext%:*:*}:<%= invocation_path.join('-') %>-${command}"
+
+      line=(${line:1})
+      local completion_func="_<%= invocation_path.join('_') %>_${command//-/_}"
+      _call_function ret "${completion_func}" && return ret
+
+      _message "a completion function is not defined for ${command}"
+      return 1
+    ;;
+  esac
+}
+
+<%- end -%>
+
+compdef _<%= progname %> <%= progname %>

--- a/completer_gem/lib/clamp/completer/version.rb
+++ b/completer_gem/lib/clamp/completer/version.rb
@@ -1,0 +1,5 @@
+module Clamp
+  module Completer
+    VERSION = "0.1.0"
+  end
+end

--- a/completer_gem/spec/clamp/completer_spec.rb
+++ b/completer_gem/spec/clamp/completer_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Clamp::Completer do
+  it "has a version number" do
+    expect(Clamp::Completer::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/completer_gem/spec/spec_helper.rb
+++ b/completer_gem/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "clamp/completer"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/lib/pharos/command_options/filtered_hosts.rb
+++ b/lib/pharos/command_options/filtered_hosts.rb
@@ -18,6 +18,10 @@ module Pharos
       end
 
       module InstanceMethods
+        def complete_role
+          "master worker"
+        end
+
         private
 
         def filtered_hosts

--- a/lib/pharos/command_options/load_config.rb
+++ b/lib/pharos/command_options/load_config.rb
@@ -19,6 +19,14 @@ module Pharos
       end
 
       module InstanceMethods
+        def complete_config_yaml
+          { glob: "*.y*ml" }
+        end
+
+        def complete_tf_json
+          { glob: "*.json" }
+        end
+
         private
 
         # @return [Pharos::YamlFile]

--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -6,6 +6,8 @@ require_relative 'version_command'
 require_relative 'kubeconfig_command'
 require_relative 'ssh_command'
 
+require 'clamp/completer'
+
 module Pharos
   class RootCommand < Pharos::Command
     banner "#{File.basename($PROGRAM_NAME)} - Kontena Pharos cluster manager"
@@ -15,5 +17,6 @@ module Pharos
     subcommand "reset", "reset cluster", ResetCommand
     subcommand "ssh", "start an ssh session to a server in a pharos cluster", SSHCommand
     subcommand "version", "show version information", VersionCommand
+    subcommand "complete", "generate shell auto-completions", Clamp::Completer.new(self, inherit_from: Pharos::Command)
   end
 end


### PR DESCRIPTION
Automatic completion generation gem for clamp.

Basically just by adding `subcommand "complete", "generate shell auto-completions", Clamp::Completer.new(self)`, it will make something like this work:

```console
$ source <(pharos complete bash)
# mac bash version requires trickery:
$ source /dev/stdin <<<"$(pharos complete bash)"
```

Subcommand completions work out of the box with no changes and so do flag-type option completions. For other option completions, it's possible to do something like:

```ruby
option %w(-c --config), 'PATH', "Path to config"

def complete_path # method name derived from the PATH opt value description
  { glob: "*.yml" }
end
```

or

```ruby
option %w(-r --role), 'ROLE', "Role name", attribute_name: :role_name

def complete_role_name # method name derived from the attribute_name
  "master worker" # simple word list
end
```

Generates separate completion configs for bash and zsh, including fancy description things for zsh's fancier completion system.

(specs fail due to rubocopping the "packaged" completer_gem)
