### PR TITLE
Abort configure host on all nodes if one raises an exception

### DIFF
--- a/non-oss/pharos_pro/phases/configure_host.rb
+++ b/non-oss/pharos_pro/phases/configure_host.rb
@@ -6,6 +6,7 @@ module Pharos
       title "Configure hosts"
 
       def configure_container_runtime
+        Thread.current.abort_on_exception = true
         if @host.new? || host_configurer.configure_container_runtime_safe?
           logger.info { "Configuring container runtime (#{@host.container_runtime}) packages ..." }
           host_configurer.configure_container_runtime


### PR DESCRIPTION
Makes the ConfigureHost phase on non_oss abort on all hosts if one host raises an exception

