### PR TITLE
Release v2.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       ed25519 (= 1.2.4)
       excon (~> 0.62.0)
       fugit (~> 1.1.2)
-      k8s-client (~> 0.8.0)
+      k8s-client (~> 0.8.1)
       net-ssh (= 5.1.0)
       net-ssh-gateway (= 2.0.0)
       pastel
@@ -74,7 +74,7 @@ GEM
     jsonpath (0.9.9)
       multi_json
       to_regexp (~> 0.2.1)
-    k8s-client (0.8.0)
+    k8s-client (0.8.1)
       dry-struct (~> 0.5.0)
       excon (~> 0.62.0)
       hashdiff (~> 0.3.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.1.3)
+    pharos-cluster (2.1.4)
       bcrypt
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
@@ -11,7 +11,7 @@ PATH
       ed25519 (= 1.2.4)
       excon (~> 0.62.0)
       fugit (~> 1.1.2)
-      k8s-client (~> 0.6.3)
+      k8s-client (~> 0.8.0)
       net-ssh (= 5.1.0)
       net-ssh-gateway (= 2.0.0)
       pastel
@@ -26,7 +26,6 @@ GEM
     bcrypt_pbkdf (1.0.0)
     clamp (1.2.1)
     concurrent-ruby (1.1.4)
-    deep_merge (1.2.1)
     diff-lcs (1.3)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
@@ -72,17 +71,17 @@ GEM
     hashdiff (0.3.8)
     ice_nine (0.11.2)
     jaro_winkler (1.5.1)
-    jsonpath (0.9.8)
+    jsonpath (0.9.9)
       multi_json
       to_regexp (~> 0.2.1)
-    k8s-client (0.6.4)
-      deep_merge (~> 1.2.1)
+    k8s-client (0.8.0)
       dry-struct (~> 0.5.0)
       excon (~> 0.62.0)
       hashdiff (~> 0.3.7)
       jsonpath (~> 0.9.5)
       recursive-open-struct (~> 1.1.0)
       yajl-ruby (~> 1.4.0)
+      yaml-safe_load_stream (~> 0.1)
     multi_json (1.13.1)
     necromancer (0.4.0)
     net-ssh (5.1.0)
@@ -142,6 +141,7 @@ GEM
     unicode-display_width (1.4.0)
     wisper (2.0.0)
     yajl-ruby (1.4.1)
+    yaml-safe_load_stream (0.1.1)
 
 PLATFORMS
   ruby

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -3,6 +3,7 @@
 set -ue
 
 export PHAROS_NON_OSS=true
+export HOMEBREW_NO_AUTO_UPDATE=1
 
 brew install squashfs
 brew install openssl || brew upgrade openssl || true

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -2,6 +2,8 @@
 
 set -ue
 
+export HOMEBREW_NO_AUTO_UPDATE=1
+
 brew install squashfs
 brew install openssl || brew upgrade openssl || true
 

--- a/e2e/cluster.yml
+++ b/e2e/cluster.yml
@@ -8,6 +8,7 @@ hosts:
     taints: []
 network:
   provider: $NETWORK_PROVIDER
+image_repository: registry-tuusula.pharos.sh/kontenapharos
 addons:
   ingress-nginx:
     enabled: true

--- a/e2e/digitalocean/cluster.yml
+++ b/e2e/digitalocean/cluster.yml
@@ -5,6 +5,7 @@ network:
   weave:
     trusted_subnets:
       - "10.133.0.0/16"
+image_repository: registry-tuusula.pharos.sh/kontenapharos
 telemetry:
   enabled: false
 addons:

--- a/lib/pharos/host/ubuntu/scripts/configure-docker.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-docker.sh
@@ -35,5 +35,9 @@ EOF
 export DEBIAN_FRONTEND=noninteractive
 
 apt-mark unhold "$DOCKER_PACKAGE" || echo "Nothing to unhold"
-apt-get install -y "$DOCKER_PACKAGE=$DOCKER_VERSION"
+if dpkg -l docker.io ; then
+    apt-get install -y "$DOCKER_PACKAGE=$DOCKER_VERSION*" || echo "Cannot install specific version, keeping the current one"
+else
+    apt-get install -y "$DOCKER_PACKAGE=$DOCKER_VERSION*"
+fi
 apt-mark hold "$DOCKER_PACKAGE"

--- a/lib/pharos/host/ubuntu/ubuntu_bionic.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_bionic.rb
@@ -43,7 +43,7 @@ module Pharos
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1~18.04.1",
+            DOCKER_VERSION: DOCKER_VERSION,
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?

--- a/lib/pharos/host/ubuntu/ubuntu_xenial.rb
+++ b/lib/pharos/host/ubuntu/ubuntu_xenial.rb
@@ -35,7 +35,7 @@ module Pharos
           exec_script(
             'configure-docker.sh',
             DOCKER_PACKAGE: 'docker.io',
-            DOCKER_VERSION: "#{DOCKER_VERSION}-0ubuntu1~16.04.2",
+            DOCKER_VERSION: DOCKER_VERSION,
             INSECURE_REGISTRIES: insecure_registries
           )
         elsif custom_docker?

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.1.4"
+  VERSION = "2.1.5"
 
   def self.version
     VERSION + "+oss"

--- a/non-oss/pharos_pro/phases/configure_host.rb
+++ b/non-oss/pharos_pro/phases/configure_host.rb
@@ -6,6 +6,7 @@ module Pharos
       title "Configure hosts"
 
       def configure_container_runtime
+        Thread.current.abort_on_exception = true
         if @host.new? || host_configurer.configure_container_runtime_safe?
           logger.info { "Configuring container runtime (#{@host.container_runtime}) packages ..." }
           host_configurer.configure_container_runtime

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
-  spec.add_runtime_dependency "k8s-client", "~> 0.8.0"
+  spec.add_runtime_dependency "k8s-client", "~> 0.8.1"
   spec.add_runtime_dependency "excon", "~> 0.62.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
-  spec.add_runtime_dependency "k8s-client", "~> 0.6.3"
+  spec.add_runtime_dependency "k8s-client", "~> 0.8.0"
   spec.add_runtime_dependency "excon", "~> 0.62.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
## Changes since v2.1.4

- Improve ubuntu docker.io version pinning (#927)
- Update k8s-client to v0.8.1
- Abort configure host on all nodes if one raises an exception (#960)