### PR TITLE
Add option to disable outgoing NAT with calico

### DIFF
--- a/lib/pharos/phases/configure_calico.rb
+++ b/lib/pharos/phases/configure_calico.rb
@@ -52,7 +52,8 @@ module Pharos
           ipip_mode: @config.network.calico&.ipip_mode || 'Always',
           ipip_enabled: @config.network.calico&.ipip_mode != 'Never',
           master_ip: @config.master_host.peer_address,
-          version: CALICO_VERSION
+          version: CALICO_VERSION,
+          nat_outgoing: @config.network.calico&.nat_outgoing || 'true'
         )
       end
     end

--- a/lib/pharos/resources/calico/daemonset.yml.erb
+++ b/lib/pharos/resources/calico/daemonset.yml.erb
@@ -84,6 +84,8 @@ spec:
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "<%= ipip_mode %>"
+            - name: CALICO_IPV4POOL_NAT_OUTGOING
+              value: "<%= nat_outgoing ? 'true' : 'false' %>"
             # Enable IP-in-IP within Felix.
             - name: FELIX_IPINIPENABLED
               value: "<%= ipip_enabled ? 'true' : 'false' %>"


### PR DESCRIPTION
Simple option to disable outgoing NAT in calico. [calico configuration docs](https://docs.projectcalico.org/v3.4/reference/node/configuration)

Fixes #964 

Will document seperately.