### PR TITLE
Release v2.2.0-alpha.2

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.0-alpha.1"
+  VERSION = "2.2.0-alpha.2"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.2.0-alpha.1

- Kontena Lens v1.4.0-alpha.1 (#968)
- BYO networking (#963)
- Calico v3.2.4 (#948, #959)
- Add option to disable outgoing NAT with calico (#965)
- Fix erb trim mode warning (#947)
- Remove bundler version restriction (#952)
- Fix k8s api connection via bastion host (#951)
- Silence phase thread exception reporting (#954)
- k8s-client v0.8.1 (#955, #972)
- Abort configure host on all nodes if one raises an exception (#960)
- Disable travis homebrew update (#970)