### PR TITLE
host upgrades addon v0.3.1

### DIFF
--- a/addons/host-upgrades/addon.rb
+++ b/addons/host-upgrades/addon.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Pharos.addon 'host-upgrades' do
-  version '0.3.0'
+  version '0.3.1'
   license 'Apache License 2.0'
 
   config {


### PR DESCRIPTION
0.3.1 reports the version correctly:
```
$ kubectl -n kube-system logs host-upgrades-n5lrm
2019/01/15 10:59:57 pharos-host-upgrades version 0.3.1 (Go go1.10.2)

```