### PR TITLE
Enable felix prometheus metrics

### DIFF
--- a/lib/pharos/resources/calico/daemonset.yml.erb
+++ b/lib/pharos/resources/calico/daemonset.yml.erb
@@ -93,6 +93,9 @@ spec:
             # Typha support: controlled by the ConfigMap.
             - name: FELIX_TYPHAK8SSERVICENAME
               value: "none"
+            # Enable prometheus endpoint on port 9091
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "true"
             # Set based on the k8s node name.
             - name: NODENAME
               valueFrom:


### PR DESCRIPTION
This enables the prometheus endpoint on the calico node pods. It should be safe to enable without much impact. In order to scrape, users will need to add a service / service monitor, but this is a requirement for any of that.