### PR TITLE
Fix Ubuntu Bionic cri-o cgroup driver fallback logic

### DIFF
--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -164,14 +164,20 @@ module Pharos
         end
       end
 
-      # @return [Boolean]
-      def fresh_crio_install?
-        @fresh_crio_install ||= !ssh.file('/etc/crio/crio.conf').exist?
+      # @return [String, NilClass]
+      def current_crio_cgroup_manager
+        file = ssh.file('/etc/crio/crio.conf')
+        return unless file.exist?
+
+        match = file.read.match(/^cgroup_manager = "(.+)"/)
+        return unless match
+
+        match[1]
       end
 
       # @return [Boolean]
       def can_pull?
-        return true if fresh_crio_install?
+        return true if current_crio_cgroup_manager.nil?
 
         ssh.exec("sudo crictl pull #{config.image_repository}/pause:3.1").success?
       end

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -196,6 +196,13 @@ hooks_dir_path = "/usr/share/containers/oci/hooks.d"
       expect(subject.current_crio_cgroup_manager).to be_nil
     end
 
+    it 'returns nil if config exists but cgroup_manager is not set' do
+      expect(file).to receive(:exist?).and_return(true)
+      expect(file).to receive(:read).and_return(config.gsub('cgroup_manager', '#cgroup_manager'))
+
+      expect(subject.current_crio_cgroup_manager).to be_nil
+    end
+
     it 'returns configured cgroup managed if config exists' do
       expect(file).to receive(:exist?).and_return(true)
       expect(file).to receive(:read).and_return(config)

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -170,4 +170,37 @@ describe Pharos::Host::Configurer do
       end
     end
   end
+
+  describe '#current_crio_cgroup_manager' do
+    let(:ssh) { double(:ssh) }
+    let(:file) { double(:file) }
+    let(:config) {
+      %{
+# cgroup_manager is the cgroup management implementation to be used
+# for the runtime.
+cgroup_manager = "foobar"
+
+# hooks_dir_path is the oci hooks directory for automatically executed hooks
+hooks_dir_path = "/usr/share/containers/oci/hooks.d"
+      }
+    }
+
+    before(:each) do
+      allow(host).to receive(:ssh).and_return(ssh)
+      allow(ssh).to receive(:file).and_return(file)
+    end
+
+    it 'returns nil by default' do
+      expect(file).to receive(:exist?).and_return(false)
+
+      expect(subject.current_crio_cgroup_manager).to be_nil
+    end
+
+    it 'returns configured cgroup managed if config exists' do
+      expect(file).to receive(:exist?).and_return(true)
+      expect(file).to receive(:read).and_return(config)
+
+      expect(subject.current_crio_cgroup_manager).to eq('foobar')
+    end
+  end
 end

--- a/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
+++ b/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
@@ -33,8 +33,6 @@ describe Pharos::Host::UbuntuXenial do
 
     context 'cri-o' do
       it 'configures cri-o' do
-        #allow(ssh).to receive(:exec).and_return(double(:result, success?: true))
-        allow(subject).to receive(:fresh_crio_install?).and_return(true)
         allow(subject).to receive(:config).and_return(cluster_config)
         allow(subject).to receive(:insecure_registries)
         allow(subject).to receive(:docker?).and_return(false)

--- a/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
+++ b/spec/pharos/host/ubuntu/ubuntu_xenial_spec.rb
@@ -33,6 +33,7 @@ describe Pharos::Host::UbuntuXenial do
 
     context 'cri-o' do
       it 'configures cri-o' do
+        allow(subject).to receive(:can_pull?).and_return(true)
         allow(subject).to receive(:config).and_return(cluster_config)
         allow(subject).to receive(:insecure_registries)
         allow(subject).to receive(:docker?).and_return(false)


### PR DESCRIPTION
Current logic is completely busted because it will fallback to `cgroupfs` always after first install.

