### PR TITLE
Support for oidc configuration

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -134,6 +134,15 @@ module Pharos
             end
             optional(:cache_ttl).filled
           end
+          optional(:oidc).schema do
+            required(:issuer_url).filled(:str?)
+            required(:client_id).filled(:str?)
+            optional(:username_claim).filled(:str?)
+            optional(:username_prefix).filled(:str?)
+            optional(:groups_claim).filled(:str?)
+            optional(:groups_prefix).filled(:str?)
+            optional(:ca_file).filled(:str?)
+          end
         end
         optional(:cloud).schema do
           required(:provider).filled(:str?)

--- a/lib/pharos/configuration/authentication.rb
+++ b/lib/pharos/configuration/authentication.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'token_webhook'
+require_relative 'oidc'
 
 module Pharos
   module Configuration
     class Authentication < Pharos::Configuration::Struct
       attribute :token_webhook, Pharos::Configuration::TokenWebhook
+      attribute :oidc, Pharos::Configuration::OIDC
     end
   end
 end

--- a/lib/pharos/configuration/oidc.rb
+++ b/lib/pharos/configuration/oidc.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Configuration
+    class OIDC < Pharos::Configuration::Struct
+      attribute :issuer_url, Pharos::Types::String
+      attribute :client_id, Pharos::Types::String
+      attribute :username_claim, Pharos::Types::String
+      attribute :username_prefix, Pharos::Types::String
+      attribute :groups_prefix, Pharos::Types::String
+      attribute :groups_claim, Pharos::Types::String
+      attribute :ca_file, Pharos::Types::String
+    end
+  end
+end

--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -149,7 +149,7 @@ module Pharos
       def configure_oidc(config)
         config['apiServerExtraArgs'].merge!(
           'oidc-issuer-url' => @config.authentication.oidc.issuer_url,
-          'oidc-client-id' => @config.authentication.oidc.client_id,
+          'oidc-client-id' => @config.authentication.oidc.client_id
         )
         # These are optional in config, so set conditionally
         config['apiServerExtraArgs']['oidc-username-claim'] = @config.authentication.oidc.username_claim if @config.authentication.oidc.username_claim

--- a/lib/pharos/phases/setup_master.rb
+++ b/lib/pharos/phases/setup_master.rb
@@ -14,6 +14,7 @@ module Pharos
         push_audit_policy if @config.audit
         push_audit_config if @config.audit&.webhook&.server
         push_authentication_token_webhook_config if @config.authentication&.token_webhook
+        push_oidc_certs if @config.authentication&.oidc&.ca_file
         push_cloud_config if @config.cloud&.config
       end
 
@@ -66,6 +67,12 @@ module Pharos
         logger.info { "Pushing cloud-config to master ..." }
         ssh.exec!('sudo mkdir -p /etc/pharos/cloud')
         ssh.file('/etc/pharos/cloud/cloud-config').write(File.open(File.expand_path(@config.cloud.config)))
+      end
+
+      def push_oidc_certs
+        logger.info { "Pushing OIDC certificates to master ..." }
+        ssh.exec!('sudo mkdir -p /etc/kubernetes/authentication')
+        ssh.file('/etc/kubernetes/authentication/oidc_ca.crt').write(File.open(File.expand_path(@config.authentication.oidc.ca_file)))
       end
     end
   end

--- a/spec/pharos/kubeadm/cluster_config_spec.rb
+++ b/spec/pharos/kubeadm/cluster_config_spec.rb
@@ -245,6 +245,46 @@ describe Pharos::Kubeadm::ClusterConfig do
       end
     end
 
+    context 'with authentication oidc configuration' do
+      let(:config) { Pharos::Config.new(
+        hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
+        network: {},
+        addons: {},
+        authentication: {
+          oidc: {
+            issuer_url: "https://accounts.google.com",
+            client_id: "foobar",
+            username_claim: 'email',
+            ca_file: '/path/to/oidc.ca.crt'
+          }
+        }
+      ) }
+
+      it 'comes with proper oidc flags for api-server' do
+        config = subject.generate
+        expect(config['apiServerExtraArgs']['oidc-issuer-url'])
+          .to eq('https://accounts.google.com')
+          expect(config['apiServerExtraArgs']['oidc-client-id'])
+          .to eq('foobar')
+          expect(config['apiServerExtraArgs']['oidc-username-claim'])
+          .to eq('email')
+      end
+
+      it 'comes with proper volume mounts' do
+        valid_volume_mounts =  [
+          {
+            'name' => 'k8s-auth-oidc',
+            'hostPath' => '/etc/kubernetes/authentication',
+            'mountPath' => '/etc/kubernetes/authentication'
+          }
+        ]
+        config = subject.generate
+        expect(config['apiServerExtraVolumes']).to include(valid_volume_mounts[0])
+        expect(config['apiServerExtraArgs']['oidc-ca-file'])
+          .to eq('/etc/kubernetes/authentication/oidc_ca.crt')
+      end
+    end
+
     context 'with admission plugins' do
       context 'with proper config' do
         let(:config) { Pharos::Config.new(


### PR DESCRIPTION
Initial support for configuring oidc on api-server.

Can be configured e.g. with:
```
authentication:
  oidc:
    issuer_url: https://accounts.google.com
    client_id: <REDACTED>.apps.googleusercontent.com
    username_claim: email
```

Needs docs still.

And we need to figure out how/if this affects Lens deployment somehow.


fixes #978 