### PR TITLE
Fix loading of addons from symlinked directories under pharos-addons/

### DIFF
--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -26,7 +26,7 @@ module Pharos
     # @return [Array<Class<Pharos::Addon>>]
     def self.load_addons(*dirs)
       dirs.each do |dir|
-        Dir.glob(File.join(dir, '**', 'addon.rb')).each { |f| require(f) }
+        Dir.glob(File.join(dir, '*/**', 'addon.rb')).each { |f| require(f) }
       end
 
       addons

--- a/spec/pharos/addon_manager_spec.rb
+++ b/spec/pharos/addon_manager_spec.rb
@@ -1,0 +1,24 @@
+require 'tmpdir'
+require 'fileutils'
+
+describe Pharos::AddonManager do
+  describe 'load addons' do
+    let(:tmpdir_1) { Dir.mktmpdir }
+    let(:tmpdir_2) { Dir.mktmpdir }
+
+    before do
+      FileUtils.touch(File.join(tmpdir_2, 'addon.rb'))
+      FileUtils.ln_s(tmpdir_2, File.join(tmpdir_1, 'linked-addon'))
+    end
+
+    after do
+      FileUtils.rm_rf(tmpdir_1)
+      FileUtils.rm_rf(tmpdir_2)
+    end
+
+    it 'loads files from symlinked subdirectories' do
+      expect(described_class).to receive(:require).with(File.join(tmpdir_1, 'linked-addon', 'addon.rb'))
+      described_class.load_addons(tmpdir_1)
+    end
+  end
+end


### PR DESCRIPTION
Previously if you symlinked something under `$PWD/pharos-addon/`:

```
$ mkdir pharos-addons
$ ln -s /home/addons/todoapp-addon pharos-addons/
$ ls -al pharos-addons
total 0
drwx------    3 user  staff     96 Jan 17 14:58 .
drwxr-x---  421 user  staff  13472 Jan 17 15:00 ..
lrwxr-xr-x    1 user  staff     72 Jan 17 14:58 todoapp-addon -> /home/addons/todoapp-addon
```

the addon would not have been loaded.

This PR changes the glob pattern to allow recursing into symlinked directories also.
