### PR TITLE
Place kontena-lens redis to a master node

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/10-redis-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/10-redis-deployment.yml.erb
@@ -15,6 +15,11 @@ spec:
         app: redis
     spec:
       restartPolicy: Always
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       containers:
       - name: redis
         image: <%= image_repository %>/redis:4-alpine


### PR DESCRIPTION
In a full-autoscaled environment only static host role is the master.