### PR TITLE
Update Kontena Lens to version 1.4.0-beta.1

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -46,7 +46,7 @@ Pharos.addon 'kontena-lens' do
 
     host = config.host || "lens.#{gateway_node_ip}.nip.io"
     name = config.name || 'pharos-cluster'
-    helm_repositories = config.charts&.repositories || [ stable_helm_repo ]
+    helm_repositories = config.charts&.repositories || [stable_helm_repo]
     tiller_version = '2.12.2'
 
     apply_resources(
@@ -55,7 +55,7 @@ Pharos.addon 'kontena-lens' do
       tls_enabled: tls_enabled?,
       user_management: user_management_enabled?,
       tiller_version: tiller_version,
-      helm_repositories: helm_repositories.map{|repo| "#{repo[:name]}=#{repo[:url]}"}.join('=')
+      helm_repositories: helm_repositories.map{ |repo| "#{repo[:name]}=#{repo[:url]}" }.join('=')
     )
     protocol = tls_enabled? ? 'https' : 'http'
     message = "Kontena Lens is configured to respond at: " + pastel.cyan("#{protocol}://#{host}")
@@ -80,6 +80,7 @@ Pharos.addon 'kontena-lens' do
     user_mgmt_deployment = kube_client.api('apps/v1').resource('deployments', namespace: 'kontena-lens').get('user-management')
     last_applied_string = user_mgmt_deployment.dig('metadata', 'annotations', last_config_annotation)
     return false unless last_applied_string
+
     last_applied = JSON.parse(last_applied_string)
     nested_replicas = last_applied.dig('spec', 'template', 'spec', 'replicas')
     if nested_replicas

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-deployment.yml.erb
@@ -15,18 +15,36 @@ spec:
         app: helm-api
     spec:
       restartPolicy: Always
+      securityContext:
+        fsGroup: 1000
       containers:
         - image: <%= image_repository %>/helm-api:<%= version %>
           name: api
+          env:
+          - name: TILLER_NAMESPACE
+            value: kontena-lens-tiller
+          - name: REPOSITORIES
+            value: <%= helm_repositories %>
           resources:
             requests:
-              memory: "256Mi"
+              memory: "128Mi"
               cpu: "0.1"
             limits:
-              memory: "512Mi"
+              memory: "192Mi"
           readinessProbe:
             httpGet:
-              path: /
+              path: /ping
               port: 9292
               scheme: HTTP
             timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /app/.helm
+              name: helm-home
+      volumes:
+      - name: helm-home
+        <%- if config.persistence&.enabled -%>
+        persistentVolumeClaim:
+          claimName: lens-helm-pvc
+        <%- else -%>
+        emptyDir: {}
+        <%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-pvc.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-pvc.yml.erb
@@ -9,5 +9,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 1Gi
 <% end %>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-pvc.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-pvc.yml.erb
@@ -1,0 +1,13 @@
+<% if config.persistence&.enabled %>
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: lens-helm-pvc
+  namespace: kontena-lens
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+<% end %>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-namespace.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kontena-lens-tiller

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-sa.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-sa.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kontena-lens-tiller

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/18-helm-lens-tiller-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/18-helm-lens-tiller-deployment.yml.erb
@@ -1,0 +1,43 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: kontena-lens-tiller
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helm
+        name: tiller
+    spec:
+      containers:
+      - env:
+        - name: TILLER_NAMESPACE
+          value: kontena-lens-tiller
+        - name: TILLER_HISTORY_MAX
+          value: "10"
+        image: <%= image_repository %>/tiller:v<%= tiller_version %>
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        name: tiller
+        command: ["/tiller"]
+        args: ["--listen=localhost:44134"]
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            memory: 32Mi
+      serviceAccountName: tiller

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-tiller-binding.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-tiller-binding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lens-tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kontena-lens-tiller

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-user-role.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-user-role.yml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lens-helm-user
+  namespace: kontena-lens-tiller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list


### PR DESCRIPTION
Kontena Lens 1.4.0 requires dedicated tiller so add-on will configure tiller in `kontena-lens-tiller` namespace. `lens-helm-user` role will be also pre-configured to allow to give access to cluster users to Application library.

For `helm-api` persistent volume (1GB) is added.

`charts` is new top level configuration option. It contains `repositories` array where user can configure helm repositories in the format of:
```
charts:
  repositories:
  - name: <repository_name>
    url: <repository_url>
```
If nothing is given stable helm repository will be used.

Depends on: 
- https://github.com/kontena/pharos-kube-zipper/pull/76
- https://github.com/kontena/pharos-kube-zipper/pull/77