### PR TITLE
Release v2.2.0-beta.1

### DIFF
--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -8,7 +8,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${DRONE_TAG#"v"}

--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -8,7 +8,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/2.6.0-0.6.0/rubyc-2.6.0-0.6.0-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${DRONE_TAG#"v"}

--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -4,7 +4,7 @@ set -ue
 
 # build binary
 apt-get update -y
-apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-core texinfo curl openssl
+apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-core texinfo curl openssl tzdata
 
 update-ca-certificates
 

--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -8,7 +8,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${DRONE_TAG#"v"}

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -7,7 +7,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -7,7 +7,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/2.6.0-0.6.0/rubyc-2.6.0-0.6.0-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -7,7 +7,7 @@ apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-cor
 
 update-ca-certificates
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-linux-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -3,7 +3,7 @@
 set -ue
 
 apt-get update -y
-apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-core texinfo curl openssl
+apt-get install -y -q squashfs-tools build-essential ruby bison ruby-dev git-core texinfo curl openssl tzdata
 
 update-ca-certificates
 

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -10,7 +10,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/2.6.0-0.6.0/rubyc-2.6.0-0.6.0-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${TRAVIS_TAG#"v"}

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -10,7 +10,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${TRAVIS_TAG#"v"}

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -10,7 +10,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 version=${TRAVIS_TAG#"v"}

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -9,7 +9,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/2.6.0-0.6.0/rubyc-2.6.0-0.6.0-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -9,7 +9,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -9,7 +9,7 @@ brew install openssl || brew upgrade openssl || true
 
 curl -sL https://curl.haxx.se/ca/cacert.pem > /usr/local/etc/openssl/cacert.pem
 
-curl -sL https://dl.bintray.com/kontena/ruby-packer/0.5.0-dev/rubyc-0.5.0-extra2-darwin-amd64.gz | gunzip > /usr/local/bin/rubyc
+curl -sL https://github.com/kontena/ruby-packer/releases/download/0.5.0%2Bextra7/rubyc-0.5.0+extra7-osx-amd64.gz | gunzip > /usr/local/bin/rubyc
 chmod +x /usr/local/bin/rubyc
 
 rm -rf non-oss/

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.0-alpha.2"
+  VERSION = "2.2.0-beta.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.2.0-alpha.2

- Kubernetes v1.13.2 (#980)
- Update Kontena Lens to version 1.4.0-beta.1 (#994) [Pro, EE]
- Kontena-storage: add agent NoSchedule toleration (#993) [Pro, EE]
- Place kontena-lens redis to a master node (#990) [Pro, EE]
- Fix loading of addons from symlinked directories under pharos-addons/ (#989)
- Fix Ubuntu Bionic cri-o cgroup driver fallback logic (#985)
- Add config option to pass skip_refresh option to shell image (#828) [Pro, EE]
- Fix kontena-lens resource applier cpu request (#981) [Pro, EE]
- Host upgrades addon v0.3.1 (#979)
- Fix calico nat_outgoing config. (#974)
- Fix to reset of openebs plugin (#973)
- Remove unix:// prefix from container-runtime-endpoint (#976)
- Move kubelet flags to kubelet config yaml (#956)