### PR TITLE
Change helm-api to StatefulSet

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: helm-api
   namespace: kontena-lens


### PR DESCRIPTION
StatefulSet handles volumes better on pod re-create. Another option would have been to specify `spec.strategy.type=Recreate` to Deployment.