### PR TITLE
[wip] Validate configuration changes

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -135,6 +135,10 @@ module Pharos
         hooks[:modify_cluster_config] = block
       end
 
+      def validate_configuration_changes(&block)
+        hooks[:validate_configuration_changes] = block
+      end
+
       def validation
         Dry::Validation.Params(Schema) { yield }
       end

--- a/lib/pharos/phases/validate_configuration_changes.rb
+++ b/lib/pharos/phases/validate_configuration_changes.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Phases
+    class ValidateConfigurationChanges < Pharos::Phase
+      title "Validate configuration changes"
+
+      DEFAULT_PROC = proc { |key, old_val, new_val| raise Pharos::ConfigError, { key => "can't change #{key} from #{old_val} to #{new_val}"} }
+
+      def call
+        changed?('network.provider', &DEFAULT_PROC)
+      end
+
+      def changed?(config_key_path)
+        old_value = string_dig(config_key_path, previous_config)
+        new_value = string_dig(config_key_path, @config)
+        return false if old_value == new_value
+        return true unless block_given?
+        yield config_key_path, old_value, new_value
+      end
+
+      def string_dig(string, source)
+        string.to_s.split('.').inject(source) { |memo, item| memo.send(item.to_sym) if memo.respond_to?(item.to_sym) }
+      end
+
+      def previous_config
+        cluster_context['previous-config']
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Fixes #997 

Here's the mechanism

For addons added a hook:
```ruby
  validate_configuration_changes { |old_config, new_config|
    raise "can't uninstall!" if old_config.enabled && !new_config.enabled
  end
```

For phases / general config changes, made the cluster_manager load previous config earlier and run `ValidateConfigurationChanges` phase if a working master was found during `GatherFacts`.

It appears to work:

![image](https://user-images.githubusercontent.com/224971/51686375-f12b2d80-1ff8-11e9-9388-761a3ba60a18.png)

