### PR TITLE
Fix nested addon configuration validation errors

### DIFF
--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -7,6 +7,7 @@ require_relative 'kube'
 module Pharos
   class AddonManager
     include Pharos::Logging
+    using Pharos::CoreExt::DeepTransformKeys
 
     class InvalidConfig < Pharos::Error; end
     class UnknownAddon < Pharos::Error; end
@@ -70,12 +71,12 @@ module Pharos
       self.class.addons
     end
 
+
     def validate
       with_enabled_addons do |addon_class, config|
         outcome = addon_class.validate(config)
         unless outcome.success?
-          error_msg = "#{addon_class.addon_name} => " + outcome.errors.map { |key, value| "#{key} #{value.join(',')}" }.flatten.join(', ')
-          raise InvalidConfig, error_msg
+          raise InvalidConfig, YAML.dump(addon_class.addon_name => outcome.errors.deep_stringify_keys).gsub(/^---$/, '')
         end
       end
     end

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -55,7 +55,7 @@ module Pharos
         addon_class = addon_classes.find { |a| a.addon_name == name }
         raise UnknownAddon, "unknown addon: #{name}" if addon_class.nil?
         addon_class.priority
-      }.to_h
+      }.to_h.deep_stringify_keys
     end
 
     def prev_configs
@@ -112,7 +112,7 @@ module Pharos
     def with_enabled_addons
       configs.each do |name, config|
         klass = addon_classes.find { |a| a.addon_name == name }
-        if klass && config["enabled"]
+        if klass && config['enabled']
           yield(klass, config)
         end
       end
@@ -122,7 +122,7 @@ module Pharos
       addon_classes.select { |addon_class|
         prev_config = prev_configs[addon_class.addon_name]
         config = configs[addon_class.addon_name]
-        prev_config && prev_config["enabled"] && (config.nil? || !config["enabled"])
+        prev_config && prev_config['enabled'] && (config.nil? || !config['enabled'])
       }.each do |addon_class|
         yield(addon_class)
       end

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -71,7 +71,6 @@ module Pharos
       self.class.addons
     end
 
-
     def validate
       with_enabled_addons do |addon_class, config|
         outcome = addon_class.validate(config)


### PR DESCRIPTION
Fixes #998 

From:
```
ERROR: NoMethodError : undefined method `join' for #<Hash:0x00007f90e1206560>
```

To:

![image](https://user-images.githubusercontent.com/224971/51730601-cd132f00-2080-11e9-8415-bd039756a8e6.png)
