### PR TITLE
Improve kontena-lens addon installation flow

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -59,16 +59,14 @@ Pharos.addon 'kontena-lens' do
     )
     protocol = tls_enabled? ? 'https' : 'http'
     message = "Kontena Lens is configured to respond at: " + pastel.cyan("#{protocol}://#{host}")
-    if lens_configured?
+    message << "\nStarting up Kontena Lens the first time might take couple of minutes, until that you'll see 503 with the address given above."
+    if configmap_exists?
       update_lens_name(name) if configmap.data.clusterName != name
     else
-      unless admin_exists?
-        create_admin_user(admin_password)
-      end
-      unless config_exists?
-        create_config(name, "https://#{master_host_ip}:6443")
-      end
-      message << "\nStarting up Kontena Lens the first time might take couple of minutes, until that you'll see 503 with the address given above."
+      create_config(name, "https://#{master_host_ip}:6443")
+    end
+    if user_management_enabled? && !admin_exists?
+      create_admin_user(admin_password)
       message << "\nYou can sign in with the following admin credentials (you won't see these again): " + pastel.cyan("admin / #{admin_password}")
     end
     post_install_message(message)
@@ -118,14 +116,6 @@ Pharos.addon 'kontena-lens' do
       }
     )
     kube_client.api('beta.kontena.io/v1').resource('users').create_resource(admin)
-  end
-
-  # @return [Boolean]
-  def config_exists?
-    kube_client.api('v1').resource('configmaps').get('config', namespace: 'kontena-lens')
-    true
-  rescue K8s::Error::NotFound
-    false
   end
 
   # @param name [String]
@@ -194,7 +184,7 @@ Pharos.addon 'kontena-lens' do
     @admin_password ||= SecureRandom.hex(8)
   end
 
-  def lens_configured?
+  def configmap_exists?
     !configmap.nil?
   end
 

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -60,7 +60,7 @@ Pharos.addon 'kontena-lens' do
     protocol = tls_enabled? ? 'https' : 'http'
     message = "Kontena Lens is configured to respond at: " + pastel.cyan("#{protocol}://#{host}")
     message << "\nStarting up Kontena Lens the first time might take couple of minutes, until that you'll see 503 with the address given above."
-    if configmap_exists?
+    if config_exists?
       update_lens_name(name) if configmap.data.clusterName != name
     else
       create_config(name, "https://#{master_host_ip}:6443")
@@ -184,7 +184,7 @@ Pharos.addon 'kontena-lens' do
     @admin_password ||= SecureRandom.hex(8)
   end
 
-  def configmap_exists?
+  def config_exists?
     !configmap.nil?
   end
 

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/04-user-management-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/04-user-management-deployment.yml.erb
@@ -1,3 +1,4 @@
+<%- if user_management -%>
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,3 +40,4 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 180
             timeoutSeconds: 5
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/05-user-management-service.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/05-user-management-service.yml.erb
@@ -1,3 +1,4 @@
+<%- if user_management -%>
 kind: Service
 apiVersion: v1
 metadata:
@@ -9,3 +10,4 @@ spec:
   ports:
   - port: 9999
     targetPort: 9999
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/06-authenticator-daemonset.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/06-authenticator-daemonset.yml.erb
@@ -1,3 +1,4 @@
+<%- if user_management -%>
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -45,3 +46,4 @@ spec:
               memory: "256Mi"
               cpu: "50m"
       hostNetwork: true
+  <%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/06-authenticator-daemonset.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/06-authenticator-daemonset.yml.erb
@@ -46,4 +46,4 @@ spec:
               memory: "256Mi"
               cpu: "50m"
       hostNetwork: true
-  <%- end -%>
+<%- end -%>


### PR DESCRIPTION
This PR improves `kontena-lens` add-on installation when user management is disabled. Now user management Deployment and authenticator DaemonSet won't be deployed if user management is disabled. Also admin user won't be created and, thus, no credentials are displayed on post installation messages.

However, if user management is first enabled and then disabled we don't remove users or groups and this is on purpose.