### PR TITLE
Increase Helm API memory limit

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
@@ -30,7 +30,7 @@ spec:
               memory: "128Mi"
               cpu: "0.1"
             limits:
-              memory: "192Mi"
+              memory: "256Mi"
           readinessProbe:
             httpGet:
               path: /ping


### PR DESCRIPTION
Seeing `OOMKilled` couple of times when installing a chart. So maybe we have too low memory limit for `helm-api`atm. This PR will increase it to `256Mi`.