### PR TITLE
Log phase completed message

### DIFF
--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -70,7 +70,7 @@ module Pharos
 
         phase.call
 
-        logger.debug { "Completed #{phase} in #{'%.3fs' % [Time.now - start]}" }
+        logger.info { "[#{phase.host}] Completed phase in #{'%.2fs' % [Time.now - start]}" }
       end
     end
   end

--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -70,7 +70,7 @@ module Pharos
 
         phase.call
 
-        logger.info { "[#{phase.host}] Completed phase in #{'%.2fs' % [Time.now - start]}" }
+        phase.logger.info 'Completed phase in %<duration>.2fs' % { duration: Time.now - start }
       end
     end
   end


### PR DESCRIPTION
IMO gives better feedback to users.

Example:
```
    [pharos-worker-0] Configuring package repositories ...
    [pharos-master-2] Configuring package repositories ...
    [pharos-master-1] Configuring netfilter ...
    [pharos-master-0] Configuring netfilter ...
    [pharos-worker-1] Configuring package repositories ...
    [pharos-master-2] Configuring netfilter ...
    [pharos-worker-0] Configuring netfilter ...
    [pharos-master-1] Configuring container runtime (cri-o) packages ...
    [pharos-master-0] Configuring container runtime (cri-o) packages ...
    [pharos-master-2] Configuring container runtime (cri-o) packages ...
    [pharos-worker-0] Configuring container runtime (cri-o) packages ...
    [pharos-worker-1] Configuring netfilter ...
    [pharos-worker-1] Configuring container runtime (cri-o) packages ...
    [pharos-worker-2] Configuring package repositories ...
    [pharos-worker-2] Configuring netfilter ...
    [pharos-master-1] Completed phase in 22.30s
    [pharos-master-2] Completed phase in 24.68s
    [pharos-worker-2] Configuring container runtime (cri-o) packages ...
    [pharos-worker-1] Completed phase in 25.38s
    [pharos-worker-0] Completed phase in 25.38s
    [pharos-master-0] Completed phase in 25.44s
    [pharos-worker-2] Completed phase in 34.95s
```