### PR TITLE
Add charts.enabled configuration option for Kontena Lens

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -26,6 +26,7 @@ Pharos.addon 'kontena-lens' do
       optional(:skip_refresh).filled(:bool?)
     end
     optional(:charts).schema do
+      optional(:enabled).filled(:bool?)
       optional(:repositories).each do
         schema do
           required(:name).filled(:str?)
@@ -46,13 +47,14 @@ Pharos.addon 'kontena-lens' do
 
     host = config.host || "lens.#{gateway_node_ip}.nip.io"
     name = config.name || 'pharos-cluster'
+    charts_enabled = config.charts&.enabled != false
     helm_repositories = config.charts&.repositories || [stable_helm_repo]
     tiller_version = '2.12.2'
-
     apply_resources(
       host: host,
       email: config.tls&.email,
       tls_enabled: tls_enabled?,
+      charts_enabled: charts_enabled,
       user_management: user_management_enabled?,
       tiller_version: tiller_version,
       helm_repositories: helm_repositories.map{ |repo| "#{repo[:name]}=#{repo[:url]}" }.join(',')

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
@@ -28,7 +28,9 @@ spec:
             - name: REDIS_CLIENT_HOST
               value: redis
             - name: USER_MANAGEMENT_ENABLED
-              value: "<%=  user_management ? "true" : "false" %>"
+              value: "<%=  user_management %>"
+            - name: CHARTS_ENABLED
+              value: "<%=  charts_enabled %>"
           resources:
             requests:
               memory: "256Mi"

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-pvc.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-pvc.yml.erb
@@ -1,4 +1,4 @@
-<% if config.persistence&.enabled %>
+<%- if charts_enabled && config.persistence&.enabled -%>
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -10,4 +10,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
-<% end %>
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-service.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-service.yml.erb
@@ -1,3 +1,4 @@
+<%- if charts_enabled -%>
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,3 +12,4 @@ spec:
   selector:
     app: helm-api
   type: ClusterIP
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
@@ -1,3 +1,4 @@
+<%- if charts_enabled -%>
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -48,3 +49,4 @@ spec:
         <%- else -%>
         emptyDir: {}
         <%- end -%>
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-namespace.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-namespace.yml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kontena-lens-tiller

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-namespace.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-namespace.yml.erb
@@ -1,0 +1,6 @@
+<%- if charts_enabled -%>
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kontena-lens-tiller
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-sa.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-sa.yml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tiller
-  namespace: kontena-lens-tiller

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-sa.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/17-lens-helm-tiller-sa.yml.erb
@@ -1,0 +1,7 @@
+<%- if charts_enabled -%>
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kontena-lens-tiller
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/18-helm-lens-tiller-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/18-helm-lens-tiller-deployment.yml.erb
@@ -1,3 +1,4 @@
+<%- if charts_enabled -%>
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -41,3 +42,4 @@ spec:
           requests:
             memory: 32Mi
       serviceAccountName: tiller
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-tiller-binding.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-tiller-binding.yml.erb
@@ -1,3 +1,4 @@
+<%- if charts_enabled -%>
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
   - kind: ServiceAccount
     name: tiller
     namespace: kontena-lens-tiller
+<%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-user-role.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/18-lens-helm-user-role.yml.erb
@@ -1,3 +1,4 @@
+<%- if charts_enabled -%>
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -16,3 +17,4 @@ rules:
   - pods
   verbs:
   - list
+<%- end -%>


### PR DESCRIPTION
Add option to enable/disable Kontena Lens charts. If disabled, `helm-api` and `tiller` and related resources won't be deployed. Also dashboard pod will have `CHARTS_ENABLED` environment variable.