### PR TITLE
Support multi-document YAMLs when applying kube resources

### DIFF
--- a/lib/pharos/autoload.rb
+++ b/lib/pharos/autoload.rb
@@ -33,6 +33,11 @@ module Pharos
   autoload :Logging, 'pharos/logging'
   autoload :ClusterManager, 'pharos/cluster_manager'
 
+  module Kube
+    autoload :Stack, 'pharos/kube/stack'
+    autoload :Config, 'pharos/kube/config'
+  end
+
   module CommandOptions
     autoload :FilteredHosts, 'pharos/command_options/filtered_hosts'
     autoload :LoadConfig, 'pharos/command_options/load_config'

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'k8s-client'
-require_relative 'kube/config'
 
 module Pharos
   module Kube
@@ -12,30 +11,6 @@ module Pharos
         K8s::Transport.verbose!
       end
       # rubocop:enable Style/GuardClause
-    end
-
-    class Stack < K8s::Stack
-      # custom labels
-      LABEL = 'pharos.kontena.io/stack'
-      CHECKSUM_ANNOTATION = 'pharos.kontena.io/stack-checksum'
-
-      # Load stack with resources from path containing erb-templated YAML files
-      #
-      # @param path [String]
-      # @param name [String]
-      # @param vars [Hash]
-      def self.load(name, path, **vars)
-        path = Pathname.new(path).freeze
-        files = Pathname.glob(path.join('*.{yml,yaml,yml.erb,yaml.erb}')).sort_by(&:to_s)
-        resources = files.map do |file|
-          K8s::Resource.new(Pharos::YamlFile.new(file).load(name: name, **vars))
-        end.select do |r|
-          # Take in only resources that are valid kube resources
-          r.kind && r.apiVersion
-        end
-
-        new(name, resources)
-      end
     end
 
     # @param host [String]

--- a/lib/pharos/kube/stack.rb
+++ b/lib/pharos/kube/stack.rb
@@ -31,4 +31,3 @@ module Pharos
     end
   end
 end
-

--- a/lib/pharos/kube/stack.rb
+++ b/lib/pharos/kube/stack.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'k8s-client'
+
+module Pharos
+  module Kube
+    class Stack < K8s::Stack
+      # custom labels
+      LABEL = 'pharos.kontena.io/stack'
+      CHECKSUM_ANNOTATION = 'pharos.kontena.io/stack-checksum'
+
+      # Load stack with resources from path containing erb-templated YAML files
+      #
+      # @param path [String]
+      # @param name [String]
+      # @param vars [Hash]
+      def self.load(name, path, **vars)
+        path = Pathname.new(path).freeze
+        files = Pathname.glob(path.join('*.{yml,yaml,yml.erb,yaml.erb}')).sort_by(&:to_s)
+        resources = files.flat_map do |file|
+          Pharos::YamlFile.new(file).load_stream(name: name, **vars) do |doc|
+            K8s::Resource.new(doc)
+          end
+        end.select do |r|
+          # Take in only resources that are valid kube resources
+          r.kind && r.apiVersion
+        end
+
+        new(name, resources)
+      end
+    end
+  end
+end
+

--- a/lib/pharos/yaml_file.rb
+++ b/lib/pharos/yaml_file.rb
@@ -3,10 +3,13 @@
 require 'yaml'
 require 'erb'
 require_relative 'yaml_file/namespace'
+require 'yaml/safe_load_stream'
 
 module Pharos
   # Reads YAML files and optionally performs ERB evaluation
   class YamlFile
+    using YAMLSafeLoadStream
+
     ParseError = Class.new(StandardError)
 
     attr_reader :content, :filename
@@ -32,6 +35,16 @@ module Pharos
         raise ParseError, "File #{"#{@filename} " if @filename}does not appear to be in YAML format"
       end
       result
+    rescue Psych::SyntaxError => ex
+      raise ParseError, ex.message
+    end
+
+    def load_stream(variables = {}, &block)
+      if block_given?
+        YAML.safe_load_stream(read(variables), @filename, &block)
+      else
+        YAML.safe_load_stream(read(variables), @filename)
+      end
     rescue Psych::SyntaxError => ex
       raise ParseError, ex.message
     end

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"
   spec.add_runtime_dependency "k8s-client", "~> 0.8.1"
+  spec.add_runtime_dependency "yaml-safe_load_stream", "~> 0.1"
   spec.add_runtime_dependency "excon", "~> 0.62.0"
 
   spec.add_development_dependency "bundler"

--- a/spec/fixtures/stacks/multidoc/resources/multidoc.yml
+++ b/spec/fixtures/stacks/multidoc/resources/multidoc.yml
@@ -1,0 +1,15 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multidoctest
+  namespace: default
+data:
+  doc: 1
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multidoctest2
+  namespace: default
+data:
+  doc: 2

--- a/spec/pharos/addon_spec.rb
+++ b/spec/pharos/addon_spec.rb
@@ -2,7 +2,10 @@ require "pharos/addon"
 
 describe Pharos::Addon do
   let(:test_addon) do
-    Pharos.addon 'test-addon' do
+    Class.new(Pharos::Addon) do
+      self.addon_name = 'test-addon'
+      self.addon_location = File.expand_path(File.join(__dir__, '..', 'fixtures', 'stacks', 'multidoc'))
+
       version "0.2.2"
       license "MIT"
 
@@ -57,7 +60,9 @@ describe Pharos::Addon do
 
   describe ".install" do
     subject do
-      Pharos.addon 'test-addon-install' do
+      Class.new(Pharos::Addon) do
+        self.addon_name = 'test-addon-install'
+
         version "0.2.2"
         license "MIT"
 
@@ -89,6 +94,12 @@ describe Pharos::Addon do
     it "returns kube stack" do
       stack = subject.kube_stack
       expect(stack).to be_instance_of(Pharos::Kube::Stack)
+    end
+
+    it 'loads multiple documents from a single yaml' do
+      stack = subject.kube_stack
+      expect(stack.resources.first.data.doc).to eq 1
+      expect(stack.resources.last.data.doc).to eq 2
     end
   end
 


### PR DESCRIPTION
Fixes #1014 

Allows multiple documents in resource YAML-files, separated with the YAML document separator `---`.
