### PR TITLE
Fix non-oss cluster version validation malformed version string error

### DIFF
--- a/non-oss/pharos_pro/phases/validate_version.rb
+++ b/non-oss/pharos_pro/phases/validate_version.rb
@@ -5,7 +5,7 @@ module Pharos
     class ValidateVersion < Pharos::Phase
       # @param cluster_version [String]
       def validate_version(cluster_version)
-        raise "Downgrade not supported" if Gem::Version.new(cluster_version) > pharos_version
+        raise "Downgrade not supported" if Gem::Version.new(cluster_version.gsub(/\+.*/, '')) > pharos_version
 
         logger.info { "Valid cluster version detected: #{cluster_version}" }
       end

--- a/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
+++ b/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
@@ -28,6 +28,11 @@ describe Pharos::Phases::ValidateVersion do
       expect{subject.validate_version('2.0.0')}.not_to raise_error
     end
 
+    it 'allows upgrade from oss to non-oss' do
+      stub_const('Pharos::VERSION', '2.0.1-alpha.1')
+      expect{subject.validate_version('2.0.1-alpha.1+oss')}.not_to raise_error
+    end
+
     it 'does not allow downgrade on development releases' do
       stub_const('Pharos::VERSION', '2.0.0-alpha.1')
       expect{subject.validate_version('2.0.0-alpha.2')}.to raise_error(RuntimeError, "Downgrade not supported")


### PR DESCRIPTION
The non-oss `ValidateVersion` phase does not cut the `+oss` from the version string and reports "malformed version string" when trying to go from oss to non-oss.

This PR fixes that.
