### PR TITLE
Release v2.2.0-rc.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.2.0.alpha.1)
+    pharos-cluster (2.2.0.rc.1)
       bcrypt
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
+      dry-logic (= 0.4.2)
       dry-struct (= 0.5.0)
       dry-types (= 0.13.2)
       dry-validation (= 0.12.1)
@@ -17,6 +18,7 @@ PATH
       pastel
       rouge (~> 3.1)
       tty-prompt (~> 0.16)
+      yaml-safe_load_stream (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -61,12 +63,12 @@ GEM
       dry-types (~> 0.13.1)
     ed25519 (1.2.4)
     equatable (0.5.0)
-    et-orbi (1.1.6)
+    et-orbi (1.1.7)
       tzinfo
     excon (0.62.0)
     fakefs (0.18.0)
-    fugit (1.1.6)
-      et-orbi (~> 1.1, >= 1.1.6)
+    fugit (1.1.8)
+      et-orbi (~> 1.1, >= 1.1.7)
       raabro (~> 1.1)
     hashdiff (0.3.8)
     ice_nine (0.11.2)
@@ -74,7 +76,7 @@ GEM
     jsonpath (0.9.9)
       multi_json
       to_regexp (~> 0.2.1)
-    k8s-client (0.8.1)
+    k8s-client (0.8.2)
       dry-struct (~> 0.5.0)
       excon (~> 0.62.0)
       hashdiff (~> 0.3.7)
@@ -121,7 +123,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
-    timers (4.2.0)
+    timers (4.3.0)
     to_regexp (0.2.1)
     tty-color (0.4.3)
     tty-cursor (0.6.0)

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.0-beta.1"
+  VERSION = "2.2.0-rc.1"
 
   def self.version
     VERSION + "+oss"

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-types", "0.13.2"
   spec.add_runtime_dependency "dry-validation", "0.12.1"
   spec.add_runtime_dependency "dry-struct", "0.5.0"
+  spec.add_runtime_dependency "dry-logic", "0.4.2"
   spec.add_runtime_dependency "fugit", "~> 1.1.2"
   spec.add_runtime_dependency "rouge", "~> 3.1"
   spec.add_runtime_dependency "tty-prompt", "~> 0.16"


### PR DESCRIPTION
## Changes since v2.2.0-beta.1

- Update Kontena Lens to version 1.4.0-rc.1 (#1009) [Pro, EE]
- Support for oidc configuration (#986)
- Protect (firewall) cluster using firewalld (#992)
- Pull control plane images parallel (#1000)
- Generate helm repository environment variable string properly (#1001) [Pro, EE]
- Change helm-api to StatefulSet (#1002) [Pro, EE]
- Improve kontena-lens addon installation flow (#1006) [Pro, EE]
- Increase Helm API memory limit (#1007) [Pro, EE]
- Fix nested addon configuration validation errors (#1005)
- Add charts.enabled configuration option for Kontena Lens (#1012) [Pro, EE]
- Support multi-document YAMLs when applying kube resources (#1017)
- Add ingress config option to kontena-lens addon (#995)
- Fix non-oss cluster version validation malformed version string error (#1018)
- Add priority classes to addons (#1020)