### PR TITLE
Revert "Add priority classes to addons (#1020)"

### DIFF
--- a/addons/cert-manager/resources/20-deployment.yml.erb
+++ b/addons/cert-manager/resources/20-deployment.yml.erb
@@ -11,7 +11,6 @@ spec:
         app: cert-manager
     spec:
       serviceAccountName: cert-manager
-      priorityClassName: system-cluster-critical
       containers:
         - name: cert-manager
           image: "<%= image_repository %>/cert-manager-controller:v<%= version %>"

--- a/addons/helm/resources/deployment.yml.erb
+++ b/addons/helm/resources/deployment.yml.erb
@@ -41,4 +41,3 @@ spec:
           requests:
             memory: 32Mi
       serviceAccountName: tiller
-      priorityClassName: system-cluster-critical

--- a/addons/host-upgrades/resources/50-daemonset.yml.erb
+++ b/addons/host-upgrades/resources/50-daemonset.yml.erb
@@ -14,7 +14,6 @@ spec:
         app: host-upgrades
     spec:
       serviceAccountName: host-upgrades
-      priorityClassName: system-cluster-critical
       containers:
         - name: host-upgrades
           image: "<%= image_repository %>/pharos-host-upgrades:<%= version %>"

--- a/addons/ingress-nginx/resources/daemonset.yml.erb
+++ b/addons/ingress-nginx/resources/daemonset.yml.erb
@@ -24,7 +24,6 @@ spec:
       <%- end -%>
       <%- end -%>
       serviceAccountName: nginx-ingress-serviceaccount
-      priorityClassName: system-cluster-critical
       hostNetwork: true
       <%- unless config.tolerations.empty? -%>
       tolerations:


### PR DESCRIPTION
This was really bad idea, priorityClassName can be only used in `kube-system` namespace.