### PR TITLE
Allow to set `NO_MASQ_LOCAL` for weave

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -113,6 +113,7 @@ module Pharos
           end
           optional(:weave).schema do
             optional(:trusted_subnets).each(type?: String)
+            optional(:no_masq_local).filled(:bool?)
           end
           optional(:calico).schema do
             optional(:ipip_mode).filled(included_in?: %(Always, CrossSubnet, Never))

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -7,6 +7,7 @@ module Pharos
     class Network < Pharos::Configuration::Struct
       class Weave < Pharos::Configuration::Struct
         attribute :trusted_subnets, Pharos::Types::Array.of(Pharos::Types::String)
+        attribute :no_masq_local, Pharos::Types::Strict::Bool.default(false)
 
         # @param routes [Array<Pharos::Configuration::Host::Routes>]
         # @return [Array<Pharos::Configuration::Host::Routes>]

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -54,7 +54,8 @@ module Pharos
           version: WEAVE_VERSION,
           firewalld_enabled: !!@config.network&.firewalld&.enabled,
           flying_shuttle_enabled: @config.regions.size > 1,
-          flying_shuttle_version: WEAVE_FLYING_SHUTTLE_VERSION
+          flying_shuttle_version: WEAVE_FLYING_SHUTTLE_VERSION,
+          no_masq_local: @config.network.weave&.no_masq_local || false
         )
       end
 

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -33,6 +33,10 @@ spec:
             - name: EXTRA_ARGS
               value: "--trusted-subnets <%= trusted_subnets.join(',') %><% if flying_shuttle_enabled %> --no-discovery<% end %>"
             <% end %>
+            <% if no_masq_local %>
+            - name: NO_MASQ_LOCAL
+              value: '1'
+            <% end %>
             - name: IPALLOC_RANGE
               value: "<%= ipalloc_range %>"
             - name: WEAVE_PASSWORD


### PR DESCRIPTION
Setting this up in the config:
```
network:
  weave:
    no_masq_local: true
```

```
$ for node in $NODES; do curl -s $node:$NODEPORT | grep -i client_address; done
client_address=10.38.0.0
client_address=10.32.0.1
client_address=10.44.0.0

$ kubectl patch svc nodeport -p '{"spec":{"externalTrafficPolicy":"Local"}}'
service/nodeport patched

$ for node in $NODES; do curl --connect-timeout 1 -s $node:$NODEPORT | grep -i client_address; done
client_address=91.153.x.y
```
^ the reported address is my actual address :)


Docs PR: https://github.com/kontena/pharos-docs/pull/147

fixes #1010 