### PR TITLE
Drop phase master: parameter

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -60,7 +60,7 @@ module Pharos
       apply_phase(Phases::ConnectSSH, config.hosts, parallel: true)
       apply_phase(Phases::AuthenticateSSH, config.hosts.reject(&:ssh?), parallel: false)
       apply_phase(Phases::GatherFacts, config.hosts, parallel: true)
-      apply_phase(Phases::ConfigureClient, [config.master_host], master: config.master_host, parallel: false, optional: true)
+      apply_phase(Phases::ConfigureClient, [config.master_host], parallel: false, optional: true)
     end
 
     def validate
@@ -68,15 +68,15 @@ module Pharos
       addon_manager.validate
       gather_facts
       apply_phase(Phases::ValidateHost, config.hosts, parallel: true)
-      apply_phase(Phases::ValidateVersion, [config.master_host], master: config.master_host, parallel: false)
+      apply_phase(Phases::ValidateVersion, [config.master_host], parallel: false)
     end
 
     def apply_phases
       master_hosts = config.master_hosts
       apply_phase(Phases::MigrateMaster, master_hosts, parallel: true)
-      apply_phase(Phases::ConfigureHost, config.hosts, master: master_hosts.first, parallel: true)
+      apply_phase(Phases::ConfigureHost, config.hosts, parallel: true)
       apply_phase(Phases::ConfigureFirewalld, config.hosts, parallel: true)
-      apply_phase(Phases::ConfigureClient, [master_hosts.first], master: master_hosts.first, parallel: false, optional: true)
+      apply_phase(Phases::ConfigureClient, [master_hosts.first], parallel: false, optional: true)
 
       unless @config.etcd&.endpoints
         etcd_hosts = config.etcd_hosts
@@ -88,32 +88,32 @@ module Pharos
 
       apply_phase(Phases::ConfigureSecretsEncryption, master_hosts, parallel: false)
       apply_phase(Phases::SetupMaster, master_hosts, parallel: true)
-      apply_phase(Phases::UpgradeMaster, master_hosts, master: master_hosts.first, parallel: false) # requires optional early ConfigureClient
+      apply_phase(Phases::UpgradeMaster, master_hosts, parallel: false) # requires optional early ConfigureClient
 
-      apply_phase(Phases::MigrateWorker, config.worker_hosts, parallel: true, master: master_hosts.first)
+      apply_phase(Phases::MigrateWorker, config.worker_hosts, parallel: true)
       apply_phase(Phases::ConfigureKubelet, config.hosts, parallel: true)
 
       apply_phase(Phases::PullMasterImages, master_hosts, parallel: true)
       apply_phase(Phases::ConfigureMaster, master_hosts, parallel: false)
-      apply_phase(Phases::ConfigureClient, [master_hosts.first], master: master_hosts.first, parallel: false)
+      apply_phase(Phases::ConfigureClient, [master_hosts.first], parallel: false)
 
       # master is now configured and can be used
-      apply_phase(Phases::LoadClusterConfiguration, [master_hosts.first], master: master_hosts.first)
+      apply_phase(Phases::LoadClusterConfiguration, [master_hosts.first])
       # configure essential services
-      apply_phase(Phases::ConfigurePSP, [master_hosts.first], master: master_hosts.first)
-      apply_phase(Phases::ConfigureDNS, [master_hosts.first], master: master_hosts.first)
-      apply_phase(Phases::ConfigureWeave, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'weave'
-      apply_phase(Phases::ConfigureCalico, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'calico'
-      apply_phase(Phases::ConfigureCustomNetwork, [master_hosts.first], master: master_hosts.first) if config.network.provider == 'custom'
+      apply_phase(Phases::ConfigurePSP, [master_hosts.first])
+      apply_phase(Phases::ConfigureDNS, [master_hosts.first])
+      apply_phase(Phases::ConfigureWeave, [master_hosts.first]) if config.network.provider == 'weave'
+      apply_phase(Phases::ConfigureCalico, [master_hosts.first]) if config.network.provider == 'calico'
+      apply_phase(Phases::ConfigureCustomNetwork, [master_hosts.first]) if config.network.provider == 'custom'
 
       apply_phase(Phases::ConfigureBootstrap, [master_hosts.first]) # using `kubeadm token`, not the kube API
 
       apply_phase(Phases::JoinNode, config.worker_hosts, parallel: true)
-      apply_phase(Phases::LabelNode, config.hosts, master: master_hosts.first, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
+      apply_phase(Phases::LabelNode, config.hosts, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
 
       # configure services that need workers
-      apply_phase(Phases::ConfigureMetrics, [master_hosts.first], master: master_hosts.first)
-      apply_phase(Phases::ConfigureTelemetry, [master_hosts.first], master: master_hosts.first)
+      apply_phase(Phases::ConfigureMetrics, [master_hosts.first])
+      apply_phase(Phases::ConfigureTelemetry, [master_hosts.first])
     end
 
     # @param hosts [Array<Pharos::Configuration::Host>]
@@ -121,7 +121,7 @@ module Pharos
       master_hosts = config.master_hosts
       if master_hosts.first.master_sort_score.zero?
         apply_phase(Phases::Drain, hosts, parallel: false)
-        apply_phase(Phases::DeleteHost, hosts, parallel: false, master: master_hosts.first)
+        apply_phase(Phases::DeleteHost, hosts, parallel: false)
       end
       addon_manager.each do |addon|
         next unless addon.enabled?
@@ -168,7 +168,7 @@ module Pharos
 
     def save_config
       master_host = config.master_host
-      apply_phase(Phases::StoreClusterConfiguration, [master_host], master: master_host)
+      apply_phase(Phases::StoreClusterConfiguration, [master_host])
     end
 
     def disconnect

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -73,10 +73,11 @@ module Pharos
 
     def apply_phases
       master_hosts = config.master_hosts
+      master_only = [config.master_host]
       apply_phase(Phases::MigrateMaster, master_hosts, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, parallel: true)
       apply_phase(Phases::ConfigureFirewalld, config.hosts, parallel: true)
-      apply_phase(Phases::ConfigureClient, [master_hosts.first], parallel: false, optional: true)
+      apply_phase(Phases::ConfigureClient, master_only, parallel: false, optional: true)
 
       unless @config.etcd&.endpoints
         etcd_hosts = config.etcd_hosts
@@ -95,25 +96,25 @@ module Pharos
 
       apply_phase(Phases::PullMasterImages, master_hosts, parallel: true)
       apply_phase(Phases::ConfigureMaster, master_hosts, parallel: false)
-      apply_phase(Phases::ConfigureClient, [master_hosts.first], parallel: false)
+      apply_phase(Phases::ConfigureClient, master_only, parallel: false)
 
       # master is now configured and can be used
-      apply_phase(Phases::LoadClusterConfiguration, [master_hosts.first])
+      apply_phase(Phases::LoadClusterConfiguration, master_only)
       # configure essential services
-      apply_phase(Phases::ConfigurePSP, [master_hosts.first])
-      apply_phase(Phases::ConfigureDNS, [master_hosts.first])
-      apply_phase(Phases::ConfigureWeave, [master_hosts.first]) if config.network.provider == 'weave'
-      apply_phase(Phases::ConfigureCalico, [master_hosts.first]) if config.network.provider == 'calico'
-      apply_phase(Phases::ConfigureCustomNetwork, [master_hosts.first]) if config.network.provider == 'custom'
+      apply_phase(Phases::ConfigurePSP, master_only)
+      apply_phase(Phases::ConfigureDNS, master_only)
+      apply_phase(Phases::ConfigureWeave, master_only) if config.network.provider == 'weave'
+      apply_phase(Phases::ConfigureCalico, master_only) if config.network.provider == 'calico'
+      apply_phase(Phases::ConfigureCustomNetwork, master_only) if config.network.provider == 'custom'
 
-      apply_phase(Phases::ConfigureBootstrap, [master_hosts.first]) # using `kubeadm token`, not the kube API
+      apply_phase(Phases::ConfigureBootstrap, master_only) # using `kubeadm token`, not the kube API
 
       apply_phase(Phases::JoinNode, config.worker_hosts, parallel: true)
       apply_phase(Phases::LabelNode, config.hosts, parallel: false) # NOTE: uses the @master kube API for each node, not threadsafe
 
       # configure services that need workers
-      apply_phase(Phases::ConfigureMetrics, [master_hosts.first])
-      apply_phase(Phases::ConfigureTelemetry, [master_hosts.first])
+      apply_phase(Phases::ConfigureMetrics, master_only)
+      apply_phase(Phases::ConfigureTelemetry, master_only)
     end
 
     # @param hosts [Array<Pharos::Configuration::Host>]

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -24,11 +24,9 @@ module Pharos
 
     # @param host [Pharos::Configuration::Host]
     # @param config [Pharos::Config]
-    # @param master [Pharos::Configuration::Host]
-    def initialize(host, config: nil, master: nil, cluster_context: nil)
+    def initialize(host, config: nil, cluster_context: nil)
       @host = host
       @config = config
-      @master = master
       @cluster_context = cluster_context
     end
 

--- a/non-oss/pharos_pro/phases/configure_host.rb
+++ b/non-oss/pharos_pro/phases/configure_host.rb
@@ -41,12 +41,8 @@ module Pharos
         master_ssh.exec!("kubectl drain --force --grace-period=0 --ignore-daemonsets --delete-local-data #{@host.hostname}")
       end
 
-      def master_ssh
-        @master.ssh
-      end
-
       def master_healthy?
-        @master.master_sort_score.zero?
+        @config.master_host.master_sort_score.zero?
       end
     end
   end

--- a/spec/pharos/phases/configure_calico_spec.rb
+++ b/spec/pharos/phases/configure_calico_spec.rb
@@ -11,7 +11,7 @@ describe Pharos::Phases::ConfigureCalico do
       kubelet: {read_only_port: false}
   ) }
 
-  subject { described_class.new(host, config: config, master: host) }
+  subject { described_class.new(host, config: config) }
 
   describe '#get_ippool' do
     let(:kube_client) { instance_double(K8s::Client) }

--- a/spec/pharos/phases/configure_dns_spec.rb
+++ b/spec/pharos/phases/configure_dns_spec.rb
@@ -19,7 +19,7 @@ describe Pharos::Phases::ConfigureDNS do
     allow(master).to receive(:cpu_arch).and_return(cpu_arch)
   end
 
-  subject { described_class.new(master, config: config, master: master) }
+  subject { described_class.new(master, config: config) }
 
   describe '#call' do
     context "with one host" do

--- a/spec/pharos/phases/label_node_spec.rb
+++ b/spec/pharos/phases/label_node_spec.rb
@@ -3,7 +3,7 @@ require 'pharos/phases/label_node'
 describe Pharos::Phases::LabelNode do
   let(:master) { Pharos::Configuration::Host.new(address: '192.0.2.1') }
   let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.2', labels: { foo: 'bar' } ) }
-  let(:subject) { described_class.new(host, master: master) }
+  let(:subject) { described_class.new(host) }
 
   let(:kube_client) { instance_double(K8s::Client) }
   let(:kube_api_v1) { instance_double(K8s::APIClient) }


### PR DESCRIPTION
None of the phases except configure_host on non-oss use `@master` and there's no `attr_reader` so it must be unused.

Changed the configure_host to use `master_ssh` and `@config.master_host` instead of `@master`.

Also replaced the `[master_hosts.first]` repetition with `master_only` preassigned array because this PR touches those lines anyway.
