### PR TITLE
Add bin/pharos to later replace bin/pharos-cluster

### DIFF
--- a/bin/pharos
+++ b/bin/pharos
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# add lib to libpath (only needed when running from the sources)
+require 'pathname'
+lib_path = File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
+$LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
+
+STDOUT.sync = true
+
+require 'pharos_cluster'
+Pharos::RootCommand.run

--- a/bin/pharos
+++ b/bin/pharos
@@ -1,4 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-load File.join(__dir__, 'pharos-cluster')
+# add lib to libpath (only needed when running from the sources)
+require 'pathname'
+lib_path = File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
+$LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
+
+STDOUT.sync = true
+
+require 'pharos_cluster'
+Pharos::RootCommand.run

--- a/bin/pharos
+++ b/bin/pharos
@@ -1,12 +1,4 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# add lib to libpath (only needed when running from the sources)
-require 'pathname'
-lib_path = File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
-$LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
-
-STDOUT.sync = true
-
-require 'pharos_cluster'
-Pharos::RootCommand.run
+load File.join(__dir__, 'pharos-cluster')

--- a/bin/pharos-cluster
+++ b/bin/pharos-cluster
@@ -1,12 +1,4 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# add lib to libpath (only needed when running from the sources)
-require 'pathname'
-lib_path = File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
-$LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
-
-STDOUT.sync = true
-
-require 'pharos_cluster'
-Pharos::RootCommand.run
+load File.join(__dir__, 'pharos')

--- a/build/drone/ubuntu.sh
+++ b/build/drone/ubuntu.sh
@@ -14,6 +14,6 @@ chmod +x /usr/local/bin/rubyc
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}"
 mkdir -p /root/.pharos/build
-rubyc --openssl-dir=/etc/ssl -o "$package" -d /root/.pharos/build --make-args=--silent pharos-cluster
+rubyc --openssl-dir=/etc/ssl -o "$package" -d /root/.pharos/build --make-args=--silent pharos
 rm -rf /root/.pharos/build
 ./"$package" version

--- a/build/drone/ubuntu_oss.sh
+++ b/build/drone/ubuntu_oss.sh
@@ -15,6 +15,6 @@ rm -rf non-oss/
 version=${DRONE_TAG#"v"}
 package="pharos-cluster-linux-amd64-${version}+oss"
 mkdir -p /root/.pharos/build
-rubyc --openssl-dir=/etc/ssl -o "$package" -d /root/.pharos/build --make-args=--silent pharos-cluster
+rubyc --openssl-dir=/etc/ssl -o "$package" -d /root/.pharos/build --make-args=--silent pharos
 rm -rf /root/.pharos/build
 ./"$package" version

--- a/build/travis/macos.sh
+++ b/build/travis/macos.sh
@@ -15,7 +15,7 @@ chmod +x /usr/local/bin/rubyc
 
 version=${TRAVIS_TAG#"v"}
 package="pharos-cluster-darwin-amd64-${version}"
-rubyc --openssl-dir=/usr/local/etc/openssl -o "$package" --make-args=--silent pharos-cluster
+rubyc --openssl-dir=/usr/local/etc/openssl -o "$package" --make-args=--silent pharos
 ./"$package" version
 
 rm -rf upload/

--- a/build/travis/macos_oss.sh
+++ b/build/travis/macos_oss.sh
@@ -16,7 +16,7 @@ rm -rf non-oss/
 
 version=${TRAVIS_TAG#"v"}
 package="pharos-cluster-darwin-amd64-${version}+oss"
-rubyc --openssl-dir=/usr/local/etc/openssl -o "$package" --make-args=--silent pharos-cluster
+rubyc --openssl-dir=/usr/local/etc/openssl -o "$package" --make-args=--silent pharos
 ./"$package" version
 
 rm -rf upload/


### PR DESCRIPTION
Minimal version of #1033

Maybe we could add some `[DEPRECATED]` notice to the old `bin/pharos-cluster`?
