### PR TITLE
Force kubelet serving cert rotation

### DIFF
--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -142,6 +142,8 @@ module Pharos
       def kubelet_args(local_only: false, cloud_provider: nil)
         args = []
 
+        args << "--rotate-server-certificates"
+
         if crio?
           args << '--container-runtime=remote'
           args << '--runtime-request-timeout=15m'

--- a/spec/pharos/phases/configure_kubelet_spec.rb
+++ b/spec/pharos/phases/configure_kubelet_spec.rb
@@ -54,7 +54,7 @@ describe Pharos::Phases::ConfigureKubelet do
       it "returns a systemd unit" do
         expect(subject.build_systemd_dropin).to eq <<~EOM
           [Service]
-          Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override= --pod-infra-container-image=registry.pharos.sh/kontenapharos/pause:3.1'
+          Environment='KUBELET_EXTRA_ARGS=--rotate-server-certificates --node-ip=192.168.42.1 --hostname-override= --pod-infra-container-image=registry.pharos.sh/kontenapharos/pause:3.1'
           ExecStartPre=-/sbin/swapoff -a
         EOM
       end
@@ -69,7 +69,7 @@ describe Pharos::Phases::ConfigureKubelet do
         it "returns a systemd unit" do
           expect(subject.build_systemd_dropin).to eq <<~EOM
             [Service]
-            Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override= --pod-infra-container-image=registry.pharos.sh/kontenapharos/pause:3.1'
+            Environment='KUBELET_EXTRA_ARGS=--rotate-server-certificates --node-ip=192.168.42.1 --hostname-override= --pod-infra-container-image=registry.pharos.sh/kontenapharos/pause:3.1'
             Environment='http_proxy=proxy.example.com'
             Environment='NO_PROXY=127.0.0.1'
             ExecStartPre=-/sbin/swapoff -a
@@ -81,7 +81,7 @@ describe Pharos::Phases::ConfigureKubelet do
         it "returns a systemd unit" do
           expect(subject.build_systemd_dropin).to eq <<~EOM
             [Service]
-            Environment='KUBELET_EXTRA_ARGS=--node-ip=192.168.42.1 --hostname-override= --pod-infra-container-image=registry.pharos.sh/kontenapharos/pause:3.1'
+            Environment='KUBELET_EXTRA_ARGS=--rotate-server-certificates --node-ip=192.168.42.1 --hostname-override= --pod-infra-container-image=registry.pharos.sh/kontenapharos/pause:3.1'
             ExecStartPre=-/sbin/swapoff -a
           EOM
         end


### PR DESCRIPTION
As the docs & K8S code is really unclear whether this is on by default or not, lets "force" it just-in-case.