### PR TITLE
Release v2.2.0-rc.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.2.0.rc.1)
+    pharos-cluster (2.2.0.rc.3)
       bcrypt
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.0-rc.2"
+  VERSION = "2.2.0-rc.3"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.2.0-rc.2

- Bump Kontena Lens to version 1.4.0-rc.2 (#1038) [Pro, EE]
- Enable kubelet server tls bootstrap (#1016, #1039)
- Fix kube-bench nitpickings (#1032, #1035, #1036)
- Add configuration change validations (#1004)
- Add priority classes to pro addons (#1021) [Pro, EE]
- Add pharos-cluster-critical priority class (#1025)
- Drop phase master: parameter (#1028)
- Allow to set no_masq_local for weave (#1027)
- Docs for vagrant/centos example (#1037)
- Add bin/pharos to later replace bin/pharos-cluster (#1034)
- Log phase completed message (#1008)