### PR TITLE
Release v2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.2.0.rc.4)
+    pharos-cluster (2.2.0)
       bcrypt
       bcrypt_pbkdf (>= 1.0, < 2.0)
       clamp (= 1.2.1)
@@ -29,9 +29,10 @@ GEM
     clamp (1.2.1)
     concurrent-ruby (1.1.4)
     diff-lcs (1.3)
-    dry-configurable (0.7.0)
+    dry-configurable (0.8.0)
       concurrent-ruby (~> 1.0)
-    dry-container (0.6.0)
+      dry-core (~> 0.4, >= 0.4.7)
+    dry-container (0.7.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
     dry-core (0.4.7)

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.0-rc.4"
+  VERSION = "2.2.0"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.1.5

- Kubernetes v1.13.2 (#941, #980)
- Kontena Lens to version 1.4.0 (#1047, #968, #994, #1009, #1038) [Pro, EE]
- Kontena Network LB addon implementation (#557) [Pro, EE]
- Protect (firewall) cluster using firewalld (#992)
- BYO networking (#963)
- Calico v3.2.4 (#948, #959)
- Support for oidc configuration (#986)
- Create cluster issuer with kube CA (#931)
- Update Helm to 2.12.1 (#937)
- Enable kubelet server tls bootstrap (#1016, #1039)
- Fix kube-bench nitpickings (#1032, #1035, #1036)
- Support multi-document YAMLs when applying kube resources (#1017)
- Add option to disable outgoing NAT with calico (#965)
- Fix erb trim mode warning (#947)
- Remove bundler version restriction (#952)
- Fix k8s api connection via bastion host (#951)
- Silence phase thread exception reporting (#954)
- k8s-client v0.8.1 (#943, #955, #972)
- Abort configure host on all nodes if one raises an exception (#960)
- Disable travis homebrew update (#970)
- Remove exponential backoff from retries (#854)
- Prefix debug output with ssh hostname (#928)
- Improve SSH password / passphrase prompting (#911)
- Drop "pharos build" alias for "pharos up" (#895)
- Fix travis bundler error (#942)
- Kontena-storage: add agent NoSchedule toleration (#993) [Pro, EE]
- Place kontena-lens redis to a master node (#990) [Pro, EE]
- Fix loading of addons from symlinked directories under pharos-addons/ (#989)
- Fix Ubuntu Bionic cri-o cgroup driver fallback logic (#985)
- Add config option to pass skip_refresh option to shell image (#828) [Pro, EE]
- Fix kontena-lens resource applier cpu request (#981) [Pro, EE]
- Host upgrades addon v0.3.1 (#979)
- Fix calico nat_outgoing config. (#974)
- Fix to reset of openebs plugin (#973)
- Remove unix:// prefix from container-runtime-endpoint (#976)
- Move kubelet flags to kubelet config yaml (#956)
- Pull control plane images parallel (#1000)
- Generate helm repository environment variable string properly (#1001) [Pro, EE]
- Change helm-api to StatefulSet (#1002) [Pro, EE]
- Improve kontena-lens addon installation flow (#1006) [Pro, EE]
- Increase Helm API memory limit (#1007) [Pro, EE]
- Fix nested addon configuration validation errors (#1005)
- Add charts.enabled configuration option for Kontena Lens (#1012) [Pro, EE]
- Add ingress config option to kontena-lens addon (#995)
- Fix non-oss cluster version validation malformed version string error (#1018)
- Add priority classes to addons (#1020)
- Add configuration change validations (#1004)
- Add priority classes to pro addons (#1021)
- Add pharos-cluster-critical priority class (#1025)
- Drop phase master: parameter (#1028)
- Allow to set no_masq_local for weave (#1027)
- Docs for vagrant/centos example (#1037)
- Add bin/pharos to later replace bin/pharos-cluster (#1034)
- Log phase completed message (#1008)
- Retry connection-reset-by-peer errors (#1051)