### PR TITLE
Don't reinitialize phase manager for every phase

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -33,7 +33,7 @@ module Pharos
 
     # @return [Pharos::AddonManager]
     def phase_manager
-      @phase_manager = Pharos::PhaseManager.new(
+      @phase_manager ||= Pharos::PhaseManager.new(
         config: @config,
         cluster_context: @context
       )


### PR DESCRIPTION
ClusterManager's `phase_manager` accessor was creating a new instance of `PhaseManager` for every call because the memoization was broken.

This should not have caused any problems since the object references pointed to the same cluster manager instance variables.

PhaseManager is mostly unnecessary and is doing what the Phase class should do by itself (`run_parallel`, `run_serial`) or maybe it should be `PhaseRunner`, it's not managing anything.

