### PR TITLE
Update gemspec to avoid warnings

### DIFF
--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "yaml-safe_load_stream", "~> 0.1"
   spec.add_runtime_dependency "excon", "~> 0.62.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", ">= 1.17.2", "<= 3.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "fakefs", "~> 0.13"

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.email         = ["info@kontena.io"]
 
   spec.summary       = "Kontena Pharos cluster manager"
-  spec.description   = "Kontena Pharos cluster manager"
   spec.homepage      = "https://github.com/kontena/pharos-cluster"
+  spec.license       = ENV['PHAROS_NON_OSS'] == 'true' ? "Nonstandard" : "Apache-2.0"
 
   spec.files         = files
   spec.bindir        = "bin"
@@ -27,12 +27,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.5'
 
   spec.add_runtime_dependency "clamp", "1.2.1"
-  spec.add_runtime_dependency "pastel"
+  spec.add_runtime_dependency "pastel", "~> 0.7"
   spec.add_runtime_dependency "net-ssh", "5.1.0"
   spec.add_runtime_dependency "net-ssh-gateway", "2.0.0"
-  spec.add_runtime_dependency "ed25519", "1.2.4"
-  spec.add_runtime_dependency "bcrypt"
-  spec.add_runtime_dependency "bcrypt_pbkdf", ">= 1.0", "< 2.0"
+  spec.add_runtime_dependency "ed25519", "~> 1.2"
+  spec.add_runtime_dependency "bcrypt", "~> 3.1"
+  spec.add_runtime_dependency "bcrypt_pbkdf", "~> 1.0"
   spec.add_runtime_dependency "dry-types", "0.13.2"
   spec.add_runtime_dependency "dry-validation", "0.12.1"
   spec.add_runtime_dependency "dry-struct", "0.5.0"
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "yaml-safe_load_stream", "~> 0.1"
   spec.add_runtime_dependency "excon", "~> 0.62.0"
 
-  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "fakefs", "~> 0.13"


### PR DESCRIPTION
`gem build pharos-cluster.gemspec` gives warnings:

```
WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  description and summary are identical
WARNING:  open-ended dependency on pastel (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on bcrypt (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on bundler (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

This PR fixes that.
