### PR TITLE
Release v2.2.1-rc.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.2.0)
-      bcrypt
-      bcrypt_pbkdf (>= 1.0, < 2.0)
+    pharos-cluster (2.2.1.rc.1)
+      bcrypt (~> 3.1)
+      bcrypt_pbkdf (~> 1.0)
       clamp (= 1.2.1)
       dry-logic (= 0.4.2)
       dry-struct (= 0.5.0)
       dry-types (= 0.13.2)
       dry-validation (= 0.12.1)
-      ed25519 (= 1.2.4)
+      ed25519 (~> 1.2)
       excon (~> 0.62.0)
       fugit (~> 1.1.2)
       k8s-client (~> 0.8.1)
       net-ssh (= 5.1.0)
       net-ssh-gateway (= 2.0.0)
-      pastel
+      pastel (~> 0.7)
       rouge (~> 3.1)
       tty-prompt (~> 0.16)
       yaml-safe_load_stream (~> 0.1)
@@ -29,7 +29,7 @@ GEM
     clamp (1.2.1)
     concurrent-ruby (1.1.4)
     diff-lcs (1.3)
-    dry-configurable (0.8.0)
+    dry-configurable (0.8.1)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
     dry-container (0.7.0)
@@ -150,7 +150,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler
+  bundler (>= 1.17.2, <= 3.0)
   fakefs (~> 0.13)
   pharos-cluster!
   rake (~> 10.0)

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.0"
+  VERSION = "2.2.1-rc.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.2.0

- Update Kontena Lens to 1.4.1 (#1066)
- Use docker 18.06.2 on debian (#1064, #1065)
- KubeletConfig readOnlyPort should be an integer (#1060)
- Allow to install latest release/revision for given version on debian/ubuntu (#1067)
- Update gemspec to avoid warnings (#1063)
- Change the defaults of configuration arrays and hashes to procs (#936)
- Retry cluster version validation without ssl verify if it fails (#884)
- Don't reinitialize phase manager for every phase (#1059)
- Add network LB to vagrant/centos example (#1061)