### PR TITLE
Raise ingress-nginx default backend limits

### DIFF
--- a/addons/ingress-nginx/resources/default-backend.yml.erb
+++ b/addons/ingress-nginx/resources/default-backend.yml.erb
@@ -45,8 +45,8 @@ spec:
         - containerPort: 8080
         resources:
           limits:
-            cpu: 10m
-            memory: 20Mi
+            cpu: 100m
+            memory: 40Mi
           requests:
             cpu: 10m
             memory: 20Mi


### PR DESCRIPTION
It seems that new cri-o/runc might consume more memory on start.. and sometimes default-backend ends up in "cannot allocate memory" error.