### PR TITLE
Release v2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pharos-cluster (2.2.1.rc.1)
+    pharos-cluster (2.2.1)
       bcrypt (~> 3.1)
       bcrypt_pbkdf (~> 1.0)
       clamp (= 1.2.1)

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.1-rc.1"
+  VERSION = "2.2.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.2.0

- Update Kontena Lens to 1.4.1 (#1066)
- Use docker 18.06.2 on debian (#1064, #1065)
- KubeletConfig readOnlyPort should be an integer (#1060)
- Allow to install latest release/revision for given version on debian/ubuntu (#1067)
- Update gemspec to avoid warnings (#1063)
- Change the defaults of configuration arrays and hashes to procs (#936)
- Retry cluster version validation without ssl verify if it fails (#884)
- Don't reinitialize phase manager for every phase (#1059)
- Add network LB to vagrant/centos example (#1061)
- Raise ingress-nginx default backend limits (#1070)