### PR TITLE
Fix firewalld config schema

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -94,7 +94,7 @@ module Pharos
           optional(:endpoint).filled(:str?)
         end
         optional(:network).schema do
-          optional(:provider).filled(included_in?: %(weave calico custom))
+          optional(:provider).filled(included_in?: %w(weave calico custom))
           optional(:dns_replicas).filled(:int?, gt?: 0)
           optional(:service_cidr).filled(:str?)
           optional(:pod_network_cidr).filled(:str?)
@@ -104,8 +104,8 @@ module Pharos
               each do
                 schema do
                   required(:port).filled(:str?)
-                  required(:protocol).filled(included_in?: %(tcp udp))
-                  required(:roles).filled(included_in?: %(master worker *))
+                  required(:protocol).filled(included_in?: %w(tcp udp))
+                  required(:roles).each(type?: String, included_in?: %w(master worker *))
                 end
               end
             end
@@ -116,7 +116,7 @@ module Pharos
             optional(:no_masq_local).filled(:bool?)
           end
           optional(:calico).schema do
-            optional(:ipip_mode).filled(included_in?: %(Always, CrossSubnet, Never))
+            optional(:ipip_mode).filled(included_in?: %w(Always CrossSubnet Never))
             optional(:nat_outgoing).filled(:bool?)
           end
           optional(:custom).schema do


### PR DESCRIPTION
Fixes #1076 

The schema definition for `firewalld.ports` was expecting a string instead of an array of strings. I'm not sure if the array makes sense since there's only two options and "both" (*)

Also fixes a couple of accidentally working(?) schema definition errors (string in place of array)
