### PR TITLE
Also run OSS specs during NON-OSS spec run

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ pipeline:
       - bundle install --path bundler
       - bundle exec rubocop --fail-level A -S --format c --parallel
       - bundle exec rspec spec/
-      - PHAROS_NON_OSS=true bundle exec rspec non-oss/spec/
+      - PHAROS_NON_OSS=true bundle exec rspec spec/ non-oss/spec/
   test-shellcheck:
     image: koalaman/shellcheck-alpine:latest
     commands:

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -6,4 +6,8 @@ module Pharos
   def self.version
     VERSION + "+oss"
   end
+
+  def self.oss?
+    true
+  end
 end

--- a/non-oss/pharos_pro/version.rb
+++ b/non-oss/pharos_pro/version.rb
@@ -4,4 +4,8 @@ module Pharos
   def self.version
     VERSION
   end
+
+  def self.oss?
+    false
+  end
 end

--- a/non-oss/spec/pharos_pro/commands/version_command_spec.rb
+++ b/non-oss/spec/pharos_pro/commands/version_command_spec.rb
@@ -1,4 +1,4 @@
-describe Pharos::VersionCommand do
+describe Pharos::VersionCommand, unless: Pharos.oss? do
   subject { described_class.new('') }
 
   it 'outputs pharos version' do

--- a/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
+++ b/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
@@ -1,7 +1,8 @@
-require 'pharos/phases/validate_version'
-require 'pharos_pro/phases/validate_version'
+describe Pharos::Phases::ValidateVersion, unless: Pharos.oss? do
+  before :all do
+    require 'pharos_pro/phases/validate_version'
+  end
 
-describe Pharos::Phases::ValidateVersion do
   let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.1', role: 'master') }
   let(:network_config) { {} }
   let(:config) { Pharos::Config.new(hosts: [host]) }

--- a/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
+++ b/non-oss/spec/pharos_pro/phases/validate_version_spec.rb
@@ -1,12 +1,14 @@
-describe Pharos::Phases::ValidateVersion, unless: Pharos.oss? do
+describe "Pharos::Phases::ValidateVersion", unless: Pharos.oss? do
   before :all do
-    require 'pharos_pro/phases/validate_version'
+    Pharos::Phases.send(:remove_const, :ValidateVersion) if Pharos::Phases.const_defined?(:ValidateVersion)
+    load File.expand_path(File.join(__dir__, '../../../../lib/pharos/phases/validate_version.rb'))
+    load File.expand_path(File.join(__dir__, '../../../pharos_pro/phases/validate_version.rb'))
   end
 
   let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.1', role: 'master') }
   let(:network_config) { {} }
   let(:config) { Pharos::Config.new(hosts: [host]) }
-  subject { described_class.new(host, config: config) }
+  subject { Pharos::Phases::ValidateVersion.new(host, config: config) }
 
   describe '#validate_version' do
     it 'allows re-up for stable releases' do

--- a/spec/pharos/phases/validate_version_spec.rb
+++ b/spec/pharos/phases/validate_version_spec.rb
@@ -1,6 +1,6 @@
 require 'pharos/phases/validate_version'
 
-describe Pharos::Phases::ValidateVersion do
+describe Pharos::Phases::ValidateVersion, if: Pharos.oss? do
   let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.1', role: 'master') }
   let(:network_config) { {} }
   let(:config) { Pharos::Config.new(hosts: [host]) }

--- a/spec/pharos/phases/validate_version_spec.rb
+++ b/spec/pharos/phases/validate_version_spec.rb
@@ -1,12 +1,15 @@
-require 'pharos/phases/validate_version'
+describe "Pharos::Phases::ValidateVersion", if: Pharos.oss? do
+  before :all do
+    Pharos::Phases.send(:remove_const, :ValidateVersion) if Pharos::Phases.const_defined?(:ValidateVersion)
+    load File.expand_path(File.join(__dir__, '../../../lib/pharos/phases/validate_version.rb'))
+  end
 
-describe Pharos::Phases::ValidateVersion, if: Pharos.oss? do
   let(:host) { Pharos::Configuration::Host.new(address: '192.0.2.1', role: 'master') }
   let(:network_config) { {} }
   let(:config) { Pharos::Config.new(hosts: [host]) }
   let(:ssh) { instance_double(Pharos::SSH::Client) }
   let(:cluster_context) { Hash.new }
-  subject { described_class.new(host, config: config, cluster_context: cluster_context) }
+  subject { Pharos::Phases::ValidateVersion.new(host, config: config, cluster_context: cluster_context) }
 
   before do
     allow(host).to receive(:ssh).and_return(ssh)

--- a/spec/pharos/version_command_spec.rb
+++ b/spec/pharos/version_command_spec.rb
@@ -1,4 +1,4 @@
-describe Pharos::VersionCommand do
+describe Pharos::VersionCommand, if: Pharos.oss? do
   subject { described_class.new('') }
 
   it 'outputs version with +oss' do


### PR DESCRIPTION
Runs the specs from the main oss directory for non-oss.

Previously only the non-oss specs were run when `PHAROS_NON_OSS=true`.

Only two specs had to be made conditional. I'm not sure if this is a good or a bad sign.