### PR TITLE
Generic env handling for calico, including enabling metrics

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -118,6 +118,7 @@ module Pharos
           optional(:calico).schema do
             optional(:ipip_mode).filled(included_in?: %w(Always CrossSubnet Never))
             optional(:nat_outgoing).filled(:bool?)
+            optional(:environment).filled(:hash?)
           end
           optional(:custom).schema do
             required(:manifest_path).filled(:str?)

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -21,6 +21,7 @@ module Pharos
       class Calico < Pharos::Configuration::Struct
         attribute :ipip_mode, Pharos::Types::String.default('Always')
         attribute :nat_outgoing, Pharos::Types::Strict::Bool.default(true)
+        attribute :environment, Pharos::Types::Hash.default({})
 
         # @param routes [Array<Pharos::Configuration::Host::Routes>]
         # @return [Array<Pharos::Configuration::Host::Routes>]

--- a/lib/pharos/phases/configure_calico.rb
+++ b/lib/pharos/phases/configure_calico.rb
@@ -54,8 +54,19 @@ module Pharos
           master_ip: @config.master_host.peer_address,
           version: CALICO_VERSION,
           nat_outgoing: @config.network.calico&.nat_outgoing,
-          firewalld_enabled: !!@config.network&.firewalld&.enabled
+          firewalld_enabled: !!@config.network&.firewalld&.enabled,
+          envs: @config.network.calico&.environment || {},
+          metrics_enabled: metrics_enabled?,
+          metrics_port: metrics_port
         )
+      end
+
+      def metrics_enabled?
+        !!@config.network.calico&.environment&.dig('FELIX_PROMETHEUSMETRICSENABLED')
+      end
+
+      def metrics_port
+        @config.network.calico&.environment&.dig('FELIX_PROMETHEUSMETRICSPORT') || 9091
       end
     end
   end

--- a/lib/pharos/resources/calico/daemonset.yml.erb
+++ b/lib/pharos/resources/calico/daemonset.yml.erb
@@ -106,6 +106,10 @@ spec:
               value: "can-reach=<%= master_ip %>"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            <% envs.each do |k,v| %>
+            - name: <%= k %>
+              value: "<%= v %>"
+            <% end %>
           securityContext:
             privileged: true
           resources:
@@ -136,6 +140,11 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
+          <% if metrics_enabled %>
+          ports:
+            - containerPort: <%= metrics_port %>
+              name: metrics
+          <% end %>
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni

--- a/lib/pharos/resources/calico/metrics-service.yml.erb
+++ b/lib/pharos/resources/calico/metrics-service.yml.erb
@@ -1,0 +1,15 @@
+<% if metrics_enabled %>
+apiVersion: v1
+kind: Service
+metadata:
+  name: calico-metrics
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: <%= metrics_port %>
+    protocol: TCP
+    targetPort: <%= metrics_port %>
+  selector:
+    k8s-app: calico-node
+<% end %>


### PR DESCRIPTION
Calico has lot of config env vars which can be configured. This PR enables to set env vars for the calico daemonset. For example:
```yaml
network:
  provider: calico
  pod_network_cidr: 172.31.0.0/16
  service_cidr: 172.32.0.0/16
  calico:
    environment:
      FELIX_PROMETHEUSMETRICSENABLED: true
      FELIX_PROMETHEUSMETRICSPORT: 9999
```

Metrics is a bit special case, the calico phase figures out that metrics is enabled and goes also automatically and sets up the needed headless service.

Needs still:

- [x]  docs PR

fixes #1031 


docs PR at https://github.com/kontena/pharos-docs/pull/160