### PR TITLE
Fix DeepTransformKeys and spec

### DIFF
--- a/e2e/drone.sh
+++ b/e2e/drone.sh
@@ -4,8 +4,6 @@ set -ue
 
 export PHAROS_NON_OSS=true
 
-export DEBUG=true
-
 bundle install
 gem build pharos-cluster.gemspec
 gem install pharos-cluster*.gem
@@ -14,5 +12,5 @@ pharos-cluster -v
 pharos-cluster version
 pharos-cluster up -y -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json
 pharos-cluster kubeconfig -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json > kubeconfig.e2e && ls -al kubeconfig.e2e && rm -f kubeconfig.e2e
-pharos-cluster ssh --role master -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json -- kubectl get nodes -o wide
+pharos-cluster exec --role master -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json -- kubectl get nodes -o wide
 pharos-cluster up -y -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json

--- a/e2e/drone.sh
+++ b/e2e/drone.sh
@@ -4,6 +4,8 @@ set -ue
 
 export PHAROS_NON_OSS=true
 
+export DEBUG=true
+
 bundle install
 gem build pharos-cluster.gemspec
 gem install pharos-cluster*.gem
@@ -11,6 +13,6 @@ pharos-cluster
 pharos-cluster -v
 pharos-cluster version
 pharos-cluster up -y -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json
-pharos-cluster kubeconfig --role master -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json > kubeconfig.e2e && ls -al kubeconfig.e2e && rm -f kubeconfig.e2e
+pharos-cluster kubeconfig -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json > kubeconfig.e2e && ls -al kubeconfig.e2e && rm -f kubeconfig.e2e
 pharos-cluster ssh --role master -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json -- kubectl get nodes -o wide
 pharos-cluster up -y -c e2e/digitalocean/cluster.yml --tf-json e2e/digitalocean/tf.json

--- a/lib/pharos/core-ext/deep_transform_keys.rb
+++ b/lib/pharos/core-ext/deep_transform_keys.rb
@@ -16,8 +16,8 @@ module Pharos
             else
               key
             end
-          end.transform_values do |value|
-            deep_transform_keys(value, &block)
+          end.transform_values do |inner_value|
+            deep_transform_keys(inner_value, &block)
           end
         else
           value

--- a/lib/pharos/core-ext/deep_transform_keys.rb
+++ b/lib/pharos/core-ext/deep_transform_keys.rb
@@ -10,7 +10,15 @@ module Pharos
         when Array
           value.map { |v| deep_transform_keys(v, &block) }
         when Hash
-          Hash[value.map { |k, v| [yield(k.dup), deep_transform_keys(v, &block)] }]
+          value.transform_keys do |key|
+            if key.is_a?(String) || key.is_a?(Symbol)
+              block.call(key.to_s.dup.extend(StringCasing))
+            else
+              key
+            end
+          end.transform_values do |value|
+            deep_transform_keys(value, &block)
+          end
         else
           value
         end
@@ -30,6 +38,14 @@ module Pharos
 
       def deep_stringify_keys!
         replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_s))
+      end
+
+      def deep_symbolize_keys
+        ::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_sym)
+      end
+
+      def deep_symbolize_keys!
+        replace(::Pharos::CoreExt::DeepTransformKeys.deep_transform_keys(self, &:to_sym))
       end
 
       refine Hash do

--- a/spec/pharos/core_ext/deep_transform_keys_spec.rb
+++ b/spec/pharos/core_ext/deep_transform_keys_spec.rb
@@ -50,4 +50,27 @@ describe Pharos::CoreExt::DeepTransformKeys do
       end
     end
   end
+
+  describe '#deep_symbolize_keys' do
+    context 'as a module' do
+      subject { { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } } }
+      it 'deep symbolizes keys' do
+        subject.extend(described_class)
+        expect(subject.deep_symbolize_keys).to eq(
+          { foo: { bar: [ { baz: 1 } ] } }
+        )
+      end
+    end
+
+    context 'as a refinement' do
+      using Pharos::CoreExt::DeepTransformKeys
+      subject { { 'foo' => { 'bar' => [ { 'baz' => 1 } ] } } }
+
+      it 'deep symbolizes keys' do
+        expect(subject.deep_symbolize_keys).to eq(
+          { foo: { bar: [ { baz: 1 } ] } }
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1054 

The spec was failing on ruby 2.6, probably for a reason.

The transform now leaves non-string/symbol keys as-is, so this can't be used for something weird like:

```ruby
{ ['abc', 'def'] => 1 }.deep_transform_keys(&:first)
```
