### PR TITLE
Allow to override ARGV when executing commands internally

### DIFF
--- a/lib/pharos/terraform/apply_command.rb
+++ b/lib/pharos/terraform/apply_command.rb
@@ -36,7 +36,9 @@ module Pharos
         cmd << '-y' if yes?
         cmd << '--force' if force?
 
-        Pharos::UpCommand.new('pharos').run(cmd)
+        up = Pharos::UpCommand.new('pharos')
+        up.argv = ['up'] + cmd
+        up.run(cmd)
       end
     end
   end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -46,7 +46,7 @@ module Pharos
       manager.save_config
 
       craft_time = Time.now - start_time
-      defined_opts = (ARGV[1..-1] - STRIP_OPTIONS).join(" ")
+      defined_opts = (argv[1..-1] - STRIP_OPTIONS).join(" ")
       defined_opts += " " unless defined_opts.empty?
       puts pastel.green("==> Cluster has been crafted! (took #{humanize_duration(craft_time.to_i)})")
       manager.post_install_messages.each do |component, message|
@@ -59,6 +59,14 @@ module Pharos
       puts "      #{File.basename($PROGRAM_NAME)} kubeconfig #{defined_opts}> kubeconfig"
       puts "      export KUBECONFIG=./kubeconfig"
       manager.disconnect
+    end
+
+    def argv=(argv)
+      @argv = argv
+    end
+
+    def argv
+      @argv ||= ARGV
     end
 
     # @param config [Pharos::Config]


### PR DESCRIPTION
Otherwise help output contains unnecessary arguments.