### PR TITLE
Add ipalloc_default_subnet config option to Weave

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -116,6 +116,7 @@ module Pharos
             optional(:trusted_subnets).each(type?: String)
             optional(:known_peers).each(type?: String)
             optional(:password).filled(:str?)
+            optional(:ipalloc_cidr).filled(:str?)
             optional(:no_masq_local).filled(:bool?)
           end
           optional(:calico).schema do

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -116,7 +116,7 @@ module Pharos
             optional(:trusted_subnets).each(type?: String)
             optional(:known_peers).each(type?: String)
             optional(:password).filled(:str?)
-            optional(:ipalloc_cidr).filled(:str?)
+            optional(:ipalloc_default_subnet).filled(:str?)
             optional(:no_masq_local).filled(:bool?)
           end
           optional(:calico).schema do

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -10,6 +10,7 @@ module Pharos
         attribute :no_masq_local, Pharos::Types::Strict::Bool.default(false)
         attribute :known_peers, Pharos::Types::Array.of(Pharos::Types::String)
         attribute :password, Pharos::Types::Strict::String.optional
+        attribute :ipalloc_cidr, Pharos::Types::Strict::String.optional
 
         # @param routes [Array<Pharos::Configuration::Route>]
         # @return [Array<Pharos::Configuration::Route>]

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -10,7 +10,7 @@ module Pharos
         attribute :no_masq_local, Pharos::Types::Strict::Bool.default(false)
         attribute :known_peers, Pharos::Types::Array.of(Pharos::Types::String)
         attribute :password, Pharos::Types::Strict::String.optional
-        attribute :ipalloc_cidr, Pharos::Types::Strict::String.optional
+        attribute :ipalloc_default_subnet, Pharos::Types::Strict::String.optional
 
         # @param routes [Array<Pharos::Configuration::Route>]
         # @return [Array<Pharos::Configuration::Route>]

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -73,6 +73,7 @@ module Pharos
       # @return [Array<String>]
       def extra_args
         args = []
+        args << "--ipalloc-default-subnet=#{@config.network&.weave&.ipalloc_cidr}" if @config.network&.weave&.ipalloc_cidr
         args << "--trusted-subnets=#{trusted_subnets.join(',')}" unless trusted_subnets.empty?
         args << "--no-discovery" if flying_shuttle?
 

--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -73,7 +73,7 @@ module Pharos
       # @return [Array<String>]
       def extra_args
         args = []
-        args << "--ipalloc-default-subnet=#{@config.network&.weave&.ipalloc_cidr}" if @config.network&.weave&.ipalloc_cidr
+        args << "--ipalloc-default-subnet=#{@config.network&.weave&.ipalloc_default_subnet}" if @config.network&.weave&.ipalloc_default_subnet
         args << "--trusted-subnets=#{trusted_subnets.join(',')}" unless trusted_subnets.empty?
         args << "--no-discovery" if flying_shuttle?
 


### PR DESCRIPTION
Makes it possible to have unique ipam cidr per cluster on multi-cluster setups. For example Istio requires this.