### PR TITLE
Modify addon DSL loader to fix constant namespacing issues

### DIFF
--- a/spec/pharos/addon_manager_spec.rb
+++ b/spec/pharos/addon_manager_spec.rb
@@ -17,8 +17,11 @@ describe Pharos::AddonManager do
     end
 
     it 'loads files from symlinked subdirectories' do
-      expect(described_class).to receive(:require).with(File.join(tmpdir_1, 'linked-addon', 'addon.rb'))
-      described_class.load_addons(tmpdir_1)
+      old_feats = $LOADED_FEATURES.dup
+      file_path = File.join(tmpdir_1, 'linked-addon', 'addon.rb')
+      expect{described_class.load_addons(tmpdir_1)}.to change{$LOADED_FEATURES}
+      expect($LOADED_FEATURES.include?(file_path)).to be_truthy
+      $LOADED_FEATURES.replace(old_feats)
     end
   end
 


### PR DESCRIPTION
Fixes #562 
Replaces #563 (which would be a better choice)
Replaces #564 
Is #uglyhack 

Uses a dirty regex to replace `Pharos.addon` with `class Pharos::Addons::#{addon_name.camelcase}`

This fixes constant namespacing problems in addons:

```
Pharos.addon "foofoo" do
  FILENAME = "foo"
end

Pharos.addon "barbar" do
  FILENAME = "bar"
end
Warning: Already defined constant FILENAME

Object::FILENAME # => "foo"
Pharos::Addons::Barbar::FILENAME # NameError: uninitialized constant Pharos::Addons::Barbar::FILENAME
```


Does not remove the `Pharos.addon` method, it can be used as previously, just the `addon_manager.load_addons` has been modified.

This does not touch addons defined like:

```ruby
Pharos.addon "foofoo" {
 ...
}
```

because bracket-matching is difficult. Only ones with `do ... end`.

Even though it's using `eval`, securitywise it brings no change. The files could have contained `system("rm -rf /")` that would have been evaluated before as well.
