### PR TITLE
The string colorization refactoring broke string.underscore

### DIFF
--- a/lib/pharos/core-ext/colorize.rb
+++ b/lib/pharos/core-ext/colorize.rb
@@ -15,6 +15,7 @@ module Pharos
 
       refine String do
         Pastel::ANSI::ATTRIBUTES.each_key do |meth|
+          next if meth == :underscore
           define_method(meth) do
             Pharos::CoreExt::Colorize.pastel.send(meth, self)
           end

--- a/lib/pharos/core-ext/colorize.rb
+++ b/lib/pharos/core-ext/colorize.rb
@@ -16,6 +16,7 @@ module Pharos
       refine String do
         Pastel::ANSI::ATTRIBUTES.each_key do |meth|
           next if meth == :underscore
+
           define_method(meth) do
             Pharos::CoreExt::Colorize.pastel.send(meth, self)
           end


### PR DESCRIPTION
Pastel has `pastel.underscore("hello")` which is aliased as `pastel.underline`.

The colorization PR #802 copies all instance methods from pastel to String, and thus breaks `String#underscore` provided by `Pharos::CoreExt::StringCasing`.
