### PR TITLE
Deprecate Pharos.addon DSL in favor of regular subclassing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,8 @@ Naming/UncommunicativeMethodParamName:
 
 Metrics/BlockLength:
   Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: true
+  Exclude:
+    - "**/addon.rb"

--- a/addons/cert-manager/addon.rb
+++ b/addons/cert-manager/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'cert-manager' do
+class Pharos::Addons::CertManager < Pharos::Addon
   version '0.5.2'
   license 'Apache License 2.0'
 

--- a/addons/helm/addon.rb
+++ b/addons/helm/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'helm' do
+class Pharos::Addons::Helm < Pharos::Addon
   version '2.12.1'
   license 'Apache License 2.0'
 end

--- a/addons/host-upgrades/addon.rb
+++ b/addons/host-upgrades/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'host-upgrades' do
+class Pharos::Addons::HostUpgrades < Pharos::Addon
   version '0.3.1'
   license 'Apache License 2.0'
 

--- a/addons/ingress-nginx/addon.rb
+++ b/addons/ingress-nginx/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'ingress-nginx' do
+class Pharos::Addons::IngressNginx < Pharos::Addon
   version '0.21.0'
   license 'Apache License 2.0'
 

--- a/addons/openebs/addon.rb
+++ b/addons/openebs/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'openebs' do
+class Pharos::Addons::Openebs < Pharos::Addon
   version '0.5.3'
   license 'Apache License 2.0'
 

--- a/examples/terraform-do/pharos-addons/do-csi/addon.rb
+++ b/examples/terraform-do/pharos-addons/do-csi/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon('do-csi') do
+class Pharos::Addons::DoCsi < Pharos::Addon
   version '1.0.0'
   license 'Apache 2.0'
 

--- a/examples/terraform-packet/pharos-addons/packet-ccm/addon.rb
+++ b/examples/terraform-packet/pharos-addons/packet-ccm/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'packet-ccm' do
+class Pharos::Addons::PacketCcm < Pharos::Addon
   version '0.0.4'
   license 'Apache License 2.0'
 

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -15,9 +15,9 @@ module Pharos
   # @return [Pharos::Addon]
   def self.addon(name, &block)
     warn '[DEPRECATED] The "Pharos.addon ..." DSL will be removed in the near future.'
-    warn "             To upgrade, change #{block.source_location.first}:"
-    warn "               before: Pharos.addon '#{name}' do".red
-    warn "               after: class Pharos::Addons::#{name.capitalize} < Pharos::Addon".green
+    warn "             To upgrade, change #{block.source_location.first.cyan}:"
+    warn '             before: ' + "Pharos.addon '#{name}' do".red
+    warn '             after:  ' + "class Pharos::Addons::#{name.to_s.dup.camelcase} < Pharos::Addon".green
 
     klass = Class.new(Pharos::Addon, &block).tap do |addon|
       addon.addon_location = File.dirname(block.source_location.first)

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -33,7 +33,11 @@ module Pharos
     def self.inherited(klass)
       super
       klass.addon_location ||= File.dirname(caller(1..1).first.split(':').first)
-      klass.addon_name = klass.name.to_s.split('::').last.underscore.tr('_', '-') if klass.name
+      klass.addon_name = if klass.name
+                           klass.name.to_s.split('::').last.underscore.tr('_', '-')
+                         else
+                           File.split(File.dirname(klass.addon_location)).last
+                         end
       Pharos::AddonManager.addons << klass
     end
 

--- a/lib/pharos/core-ext/colorize.rb
+++ b/lib/pharos/core-ext/colorize.rb
@@ -15,6 +15,7 @@ module Pharos
 
       refine String do
         Pastel::ANSI::ATTRIBUTES.each_key do |meth|
+          next if meth == :underscore
           define_method(meth) do
             Pharos::CoreExt::Colorize.pastel.send(meth, self)
           end

--- a/lib/pharos/version_command.rb
+++ b/lib/pharos/version_command.rb
@@ -32,7 +32,7 @@ module Pharos
 
     # @return [Array<Pharos::Addon>]
     def addons
-      Pharos::AddonManager.addons.sort_by(&:name)
+      Pharos::AddonManager.addons.sort_by(&:addon_name)
     end
   end
 end

--- a/non-oss/pharos_pro/addons/kontena-backup/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-backup/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'kontena-backup' do
+class Pharos::Addons::KontenaBackup < Pharos::Addon
   using Pharos::CoreExt::DeepTransformKeys
 
   ark_version = '0.9.6'

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -4,7 +4,7 @@ require 'bcrypt'
 require 'json'
 
 class Pharos::Addons::KontenaLens < Pharos::Addon
-#  using Pharos::CoreExt::Colorize
+  using Pharos::CoreExt::Colorize
 
   version '1.4.1'
   license 'Kontena License'

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -3,8 +3,8 @@
 require 'bcrypt'
 require 'json'
 
-Pharos.addon 'kontena-lens' do
-  using Pharos::CoreExt::Colorize
+class Pharos::Addons::KontenaLens < Pharos::Addon
+#  using Pharos::CoreExt::Colorize
 
   version '1.4.1'
   license 'Kontena License'

--- a/non-oss/pharos_pro/addons/kontena-network-lb/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-network-lb/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'kontena-network-lb' do
+class Pharos::Addons::KontenaNetworkLb < Pharos::Addon
   version '0.7.3'
   license 'Kontena License'
 

--- a/non-oss/pharos_pro/addons/kontena-storage/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-storage/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'kontena-storage' do
+class Pharos::Addons::KontenaStorage < Pharos::Addon
   using Pharos::CoreExt::DeepTransformKeys
   version '0.8.3+kontena.1'
   license 'Kontena License'

--- a/non-oss/pharos_pro/addons/pharos-license-enforcer/addon.rb
+++ b/non-oss/pharos_pro/addons/pharos-license-enforcer/addon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Pharos.addon 'pharos-license-enforcer' do
+class Pharos::Addons::PharosLicenseEnforcer < Pharos::Addon
   using Pharos::CoreExt::Colorize
 
   version '0.1.0'


### PR DESCRIPTION
Fixes #562 
New take on #563 
Closes #1102 

Changes all addon definitions from:

```ruby
Pharos.addon "foofoo" do
```

to:

```
class Pharos::Addons::Foofoo < Pharos::Addon
end
```

The old syntax still works, but adds a deprecation message with instructions on how to fix the old syntax addon:

![image](https://user-images.githubusercontent.com/224971/53249507-e7ace800-36c0-11e9-9876-2859eb62ef58.png)

