### PR TITLE
Fix failing addon manager spec

### DIFF
--- a/spec/pharos/addon_manager_spec.rb
+++ b/spec/pharos/addon_manager_spec.rb
@@ -38,7 +38,7 @@ describe Pharos::AddonManager do
     end
 
     before do
-      allow(subject).to receive(:addon_classes).and_return([enabled_addon])
+      allow(described_class).to receive(:addons).and_return([enabled_addon])
     end
 
     subject { described_class.new(config, {}) }


### PR DESCRIPTION
Fixes #1116 (assumedly, don't know why)

The specs fail if you run this in master branch:

```
PHAROS_NON_OSS=true bundle exec rspec --order defined \
  non-oss/spec/pharos_pro/commands/version_command_spec.rb:8 \
  spec/pharos/addon_manager_spec.rb
```

And do not on this branch.

Possibly something to do with the class level memoizations.
