### PR TITLE
Release v2.2.3-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.1"
+  VERSION = "2.2.3-rc.1"
 
   def self.version
     VERSION + "+oss"

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -8,7 +8,7 @@ require_relative "pharos/error"
 require_relative "pharos/root_command"
 
 module Pharos
-  CRIO_VERSION = '1.13.0'
+  CRIO_VERSION = '1.13.1'
   KUBE_VERSION = ENV.fetch('KUBE_VERSION') { '1.13.3' }
   KUBEADM_VERSION = ENV.fetch('KUBEADM_VERSION') { KUBE_VERSION }
   ETCD_VERSION = ENV.fetch('ETCD_VERSION') { '3.2.24' }

--- a/non-oss/pharos_pro/addons/kontena-backup/resources/30-restic-daemonset.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-backup/resources/30-restic-daemonset.yml.erb
@@ -60,8 +60,8 @@ spec:
               memory: "64Mi"
               cpu: "20m"
             limits:
-              memory: "128Mi"
-              cpu: "50m"
+              memory: "512Mi"
+              cpu: "500m"
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
## Changes since v2.2.2

- Cri-o v1.13.1 (#1120)
- Increase kontena-backup restic daemonset limits (#1119)