### PR TITLE
 Add pharos-console for development

### DIFF
--- a/bin/pharos-console
+++ b/bin/pharos-console
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# add lib to libpath (only needed when running from the sources)
+require 'pathname'
+lib_path = File.expand_path('../../lib', Pathname.new(__FILE__).realpath)
+$LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
+
+STDOUT.sync = true
+
+require 'pharos_cluster'
+require 'pry'
+
+Class.new(Pharos::Command) do
+  options :load_config, :tf_json, :filtered_hosts
+
+  def config
+    @config ||= load_config
+  end
+
+  def execute
+    binding.pry
+  end
+end.run

--- a/bin/pharos-console
+++ b/bin/pharos-console
@@ -18,6 +18,14 @@ Class.new(Pharos::Command) do
     @config ||= load_config
   end
 
+  def cluster_manager
+    @cluster_manager ||= Pharos::ClusterManager.new(config).tap(&:load)
+  end
+
+  def addon_manager
+    cluster_manager.addon_manager
+  end
+
   def execute
     binding.pry
   end

--- a/bin/pharos-console
+++ b/bin/pharos-console
@@ -27,6 +27,8 @@ Class.new(Pharos::Command) do
   end
 
   def execute
+    # rubocop:disable Lint/Debugger
     binding.pry
+    # rubocop:enable Lint/Debugger
   end
 end.run

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -39,7 +39,7 @@ module Pharos
     end
 
     option ['-d', '--debug'], :flag, "enable debug output", environment_variable: "DEBUG" do
-      ENV["DEBUG"] = "true"
+      Pharos.debug!
     end
 
     def prompt

--- a/lib/pharos/configuration/bastion.rb
+++ b/lib/pharos/configuration/bastion.rb
@@ -7,6 +7,8 @@ module Pharos
       attribute :user, Pharos::Types::Strict::String
       attribute :ssh_key_path, Pharos::Types::Strict::String
 
+      alias to_s address
+
       def host
         Host.new(address: address, user: user, ssh_key_path: ssh_key_path)
       end

--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -28,6 +28,10 @@ module Pharos
         short_hostname || address
       end
 
+      def inspect
+        "#<Pharos::Configuration::Host:#{self} user:#{user} role:#{role} bastion:#{!!bastion}>"
+      end
+
       def short_hostname
         return nil unless hostname
 

--- a/lib/pharos/kube.rb
+++ b/lib/pharos/kube.rb
@@ -6,7 +6,7 @@ module Pharos
   module Kube
     def self.init_logging!
       # rubocop:disable Style/GuardClause
-      if ENV['DEBUG']
+      if Pharos.debug?
         K8s::Logging.debug!
         K8s::Transport.verbose!
       end

--- a/lib/pharos/logging.rb
+++ b/lib/pharos/logging.rb
@@ -7,7 +7,7 @@ module Pharos
     def self.initialize_logger(log_target = $stdout, log_level = Logger::INFO)
       @logger = Logger.new(log_target)
       @logger.progname = 'API'
-      @logger.level = ENV["DEBUG"] ? Logger::DEBUG : log_level
+      @logger.level = Pharos.debug? ? Logger::DEBUG : log_level
       logger.formatter = proc do |_severity, _datetime, _progname, msg|
         "    %<msg>s\n" % { msg: msg }
       end

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -37,7 +37,7 @@ module Pharos
     def logger
       @logger ||= Logger.new($stdout).tap do |logger|
         logger.progname = @host.to_s
-        logger.level = ENV["DEBUG"] ? Logger::DEBUG : Logger::INFO
+        logger.level = Pharos.debug? ? Logger::DEBUG : Logger::INFO
         logger.formatter = proc do |_severity, _datetime, progname, msg|
           "    [%<progname>s] %<msg>s\n" % { progname: progname, msg: msg }
         end

--- a/lib/pharos/transport/command/result.rb
+++ b/lib/pharos/transport/command/result.rb
@@ -24,7 +24,7 @@ module Pharos
         end
 
         def inspect
-          streams = {stdin: stdin, stdout: stdout, stderr: stderr}.map do |name, stream|
+          streams = { stdin: stdin, stdout: stdout, stderr: stderr }.map do |name, stream|
             stream.empty? ? nil : "#{name}:#{stream[0..20].inspect}#{'...' if stream.length > 20}"
           end.compact.join(' ')
 

--- a/lib/pharos/transport/command/ssh.rb
+++ b/lib/pharos/transport/command/ssh.rb
@@ -12,7 +12,7 @@ module Pharos
 
         # @return [Pharos::Transport::CommandResult]
         def run
-          raise Pharos::ExecError, "Connection not established" unless @client.connected?
+          raise Pharos::ExecError.new(@source || @cmd, -127, "Connection not established") unless @client.connected?
 
           result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
           response = @client.session.open_channel do |channel|

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -21,11 +21,21 @@ module Pharos
         @user = @opts.delete(:user)
       end
 
+      def to_s
+        "#{"#{bastion.user}@#{bastion.address}->" if bastion}#{@user}:#{host}"
+      end
+
+      def inspect
+        "#<Pharos::Transport::SSH:#{self} connected:#{connected?}>"
+      end
+
       # @return [Hash,NilClass]
       def bastion
         @bastion ||= @opts.delete(:bastion)
       end
 
+      # @return [true] raises or returns true
+      # @raise [*]
       # @param options [Hash] see Net::SSH#start
       def connect(**options)
         synchronize do
@@ -59,6 +69,8 @@ module Pharos
             end
           end
         end
+
+        true
       end
 
       # @param host [String]

--- a/lib/pharos/transport/transport_file.rb
+++ b/lib/pharos/transport/transport_file.rb
@@ -18,6 +18,10 @@ module Pharos
 
       alias to_s path
 
+      def inspect
+        "#<Pharos::Transport::TransportFile:#{self}>"
+      end
+
       # Removes the remote file
       # @return [Pharos::Transport::Command::Result]
       # @raise [Pharos::ExecError]

--- a/lib/pharos_cluster.rb
+++ b/lib/pharos_cluster.rb
@@ -15,6 +15,17 @@ module Pharos
   KUBELET_PROXY_VERSION = '0.3.7'
   COREDNS_VERSION = '1.2.2'
   TELEMETRY_VERSION = '0.2.0'
+
+  # @return [Boolean]
+  def self.debug?
+    @debug ||= !ENV['DEBUG'].to_s.empty?
+  end
+
+  # Set debug true
+  # @return [true]
+  def self.debug!
+    @debug = true
+  end
 end
 
 require "pharos_non_oss" if $LOAD_PATH.any? { |path| path.end_with?('non-oss') }

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = files
   spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^bin/}).reject { |f| f.end_with?('console') }.map { |f| File.basename(f) }
   spec.require_paths = require_paths
   spec.required_ruby_version = '~> 2.5'
 


### PR DESCRIPTION
Adds `bin/pharos-console` that takes similar options as `pharos up` or `pharos reset` but just spawns a pry instance that has methods that are available in command classes, such as `load_config`. It does not get added to the gem, so it won't be available after `gem install` or in the pharos binary.

Instead of always having to go this route:

```
$ bundle exec irb -r pharos_cluster
bundler: command not found: irb
Install missing gem executables with `bundle install`
# argh, muscle memory!
$ DEBUG=true bundle exec pry -r pharos_cluster
[1] pry(main)> c = Pharos::Config.load(YAML.load(File.read('cluster.yml')))
[2] pry(main)> ssh = c.hosts.first.transport
```

With this PR you can now do this:

```
$ bundle exec bin/pharos-console -c buster.yml -r master --d
[1] pry(#<#<Class:0x00007fb3390d8330>>)> filtered_hosts.first
==> Reading instructions ...
=> #<Pharos::Configuration::Host:192.168.100.100 user:vagrant role:master bastion:true>
```

Or:

```
[1] pry(#<#<Class:0x00007fc9cf1f02e8>>)> cluster_manager.gather_facts
==> Reading instructions ...
==> Open SSH connection @ 192.168.100.100 192.168.100.101 192.168.100.102
    [192.168.100.100] Completed phase in 0.31s
    [192.168.100.101] Completed phase in 0.27s
    [192.168.100.102] Completed phase in 0.26s
==> Gather host facts @ 192.168.100.100 192.168.100.101 192.168.100.102
    [192.168.100.100] Checking sudo access ...
    [192.168.100.102] Checking sudo access ...
    [192.168.100.101] Checking sudo access ...
    [192.168.100.100] Gathering host facts ...
    [192.168.100.101] Gathering host facts ...
    [192.168.100.102] Gathering host facts ...
    [192.168.100.101] Completed phase in 1.34s
    [192.168.100.102] Completed phase in 1.40s
    [192.168.100.100] Completed phase in 1.73s
==> Configure kube client @ host-00
    [host-00] Fetching kubectl config ...
    [host-00] Completed phase in 0.13s
==> Load cluster configuration @ host-00
    [host-00] Loading previous cluster configuration from configmap ...
    [host-00] Completed phase in 0.45s
=> [true]
```

Or how about:

```
[3] pry(#<#<Class:0x00007fc9cf1f02e8>>)> cluster_manager.apply_phase(Pharos::Phases::ValidateHost, filtered_hosts)
==> Validate hosts @ host-00
    [host-00] Validating current role matches ...
    [host-00] Validating distro and version ...
    [host-00] Validating host configuration ...
    [host-00] Validating hostname uniqueness ...
    [host-00] Validating host routes ...
    [host-00] Validating localhost dns resolve ...
    [host-00] Validating peer address ...
    [host-00] Completed phase in 0.12s
=> [true]
```

Sweet.
