### PR TITLE
Release v2.3.0-alpha.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.2.1"
+  VERSION = "2.3.0-alpha.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.2.3

- Weave multi-cluster pod network (#1058, #1100)
- Update Kontena Lens to 1.5.0-alpha.1 (#1130, #1129) [Pro, EE]
- Add dns-node-cache (#1114)
- Calico 3.5.1 (#1085)
- Kontena-backup v0.9.11+kontena.1 (#1107) [Pro, EE]
- Improved Terraform integration: pharos tf apply/destroy (#1087)
- License enforcement addon (#1101, #1094, #1115, #1128, #1127) [Pro, EE]
- Reconfigure kubelet on kubelet-config change (#1113)
- Generic env handling for calico, including enabling metrics (#1079)
- Localhost access without SSH (#1044, #1095, #1098)
- Extract Host::ResolvConf and Route into separate files (#1049)
- Use csi volume provider on digitalocean (#1093)
- Simplify the config option copying for kubeconfig hint (#1099)
- Fix DeepTransformKeys and spec (#1091)
- Refactor output colorization (#802, #1103)
- Export complete HTTP proxy environment (#1112)
- Also run OSS specs during NON-OSS spec run (#1078)
- Add dev gems to Gemfile, drop Gemfile.lock from VCS (#1045)
- Fix failing addon manager spec (#1117)
- Load addons using AddonContext instance_eval (#1108)