### PR TITLE
Drop IPAddr Loopback backport usage

### DIFF
--- a/lib/pharos/phases/gather_facts.rb
+++ b/lib/pharos/phases/gather_facts.rb
@@ -5,8 +5,6 @@ require 'ipaddr'
 module Pharos
   module Phases
     class GatherFacts < Pharos::Phase
-      using Pharos::CoreExt::IPAddrLoopback if RUBY_VERSION < '2.5.0'
-
       title "Gather host facts"
 
       FULL_HOSTNAME_CLOUD_PROVIDERS = %w(aws vsphere).freeze


### PR DESCRIPTION
The refinement isn't there anymore and is only required on Ruby < 2.5, but the gemspec requires 2.5+.

So the line was doing nothing.
