### PR TITLE
Set or generate names for clusters

### DIFF
--- a/e2e/digitalocean/main.tf
+++ b/e2e/digitalocean/main.tf
@@ -92,6 +92,12 @@ resource "digitalocean_volume_attachment" "pharos_storage" {
   volume_id               = "${element(digitalocean_volume.pharos_storage.*.id, count.index)}"
 }
 
+output "pharos_cluster" {
+  value = {
+    name = "${var.cluster_name}"
+  }
+}
+
 output "pharos_hosts" {
   value = {
     masters = {

--- a/e2e/digitalocean/terraform.tfvars
+++ b/e2e/digitalocean/terraform.tfvars
@@ -12,3 +12,5 @@ worker_size = "8gb"
 image = "ubuntu-18-04-x64"
 
 region = "fra1"
+
+cluster_name = "e2e"

--- a/e2e/digitalocean/terraform.tfvars
+++ b/e2e/digitalocean/terraform.tfvars
@@ -13,4 +13,3 @@ image = "ubuntu-18-04-x64"
 
 region = "fra1"
 
-cluster_name = "e2e"

--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -60,6 +60,7 @@ module Pharos
       apply_phase(Phases::GatherFacts, config.hosts, parallel: true)
       apply_phase(Phases::ConfigureClient, [config.master_host], parallel: false, optional: true)
       apply_phase(Phases::LoadClusterConfiguration, [config.master_host]) if config.master_host.master_sort_score.zero?
+      apply_phase(Phases::ConfigureClusterName, %w(localhost))
     end
 
     def validate

--- a/lib/pharos/command_options/tf_json.rb
+++ b/lib/pharos/command_options/tf_json.rb
@@ -37,6 +37,7 @@ module Pharos
           config['addons'] ||= {}
           config['hosts'].concat(tf_parser.hosts)
           config['api'].merge!(tf_parser.api) if tf_parser.api
+          config['name'] ||= tf_parser.cluster_name if tf_parser.cluster_name
           config['addons'].each do |name, conf|
             if addon_config = tf_parser.addons[name]
               conf.merge!(addon_config)

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -59,6 +59,7 @@ module Pharos
     attribute :addons, Pharos::Types::Hash.default(proc { {} })
     attribute :admission_plugins, Types::Coercible::Array.of(Pharos::Configuration::AdmissionPlugin)
     attribute :container_runtime, Pharos::Configuration::ContainerRuntime
+    attribute :name, Pharos::Types::String
 
     attr_accessor :data
 

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -91,6 +91,7 @@ module Pharos
             end
           end
         end
+        optional(:name).filled(:str?)
         optional(:api).schema do
           optional(:endpoint).filled(:str?)
         end

--- a/lib/pharos/kube/config.rb
+++ b/lib/pharos/kube/config.rb
@@ -85,6 +85,7 @@ module Pharos
         # Rename cluster in context
         context = config['contexts'].first
         context['context']['cluster'] = new_name
+        rename_context(context['name'].split('@').first + '@' + new_name)
 
         self
       end

--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -29,6 +29,7 @@ module Pharos
           'apiVersion' => 'kubeadm.k8s.io/v1alpha3',
           'kind' => 'ClusterConfiguration',
           'kubernetesVersion' => Pharos::KUBE_VERSION,
+          'clusterName' => @config.name,
           'imageRepository' => @config.image_repository,
           'apiServerCertSANs' => build_extra_sans,
           'networking' => {

--- a/lib/pharos/kubeadm/config_generator.rb
+++ b/lib/pharos/kubeadm/config_generator.rb
@@ -58,7 +58,7 @@ module Pharos
           "preferences" => {},
           "clusters" => [
             {
-              "name" => webhook_config[:cluster][:name].to_s,
+              "name" => webhook_config.dig(:cluster, :name) || @config.name,
               "cluster" => {
                 "server" => webhook_config[:cluster][:server].to_s
               }
@@ -74,7 +74,7 @@ module Pharos
             {
               "name" => "webhook",
               "context" => {
-                "cluster" => webhook_config[:cluster][:name].to_s,
+                "cluster" => webhook_config.dig(:cluster, :name) || @config.name,
                 "user" => webhook_config[:user][:name].to_s
               }
             }

--- a/lib/pharos/phases/configure_cluster_name.rb
+++ b/lib/pharos/phases/configure_cluster_name.rb
@@ -41,7 +41,12 @@ module Pharos
 
         logger.info "Cluster name is #{existing_name.magenta}"
         if @config.name && @config.name != existing_name
-          raise Pharos::Error, "Cluster name mismatch, cluster: #{existing_name} configuration: #{@config.name}" unless cluster_context['force']
+          unless cluster_context['force']
+            logger.error "Current cluster name is #{existing_name.cyan} but the configuration defines #{@config.name.cyan}."
+            logger.info "  To keep the current name, change #{"name:".cyan} in the configuration, or use #{"--name #{existing_name}".cyan}."
+            logger.info "  To rename the cluster use the #{'--force'.cyan} option."
+            raise Pharos::ConfigError, { 'name' => "can't change from #{existing_name} to #{@config.name}" }
+          end
 
           logger.info "Cluster will be renamed to #{@config.name.magenta}"
           @config.name

--- a/lib/pharos/phases/configure_cluster_name.rb
+++ b/lib/pharos/phases/configure_cluster_name.rb
@@ -53,9 +53,9 @@ module Pharos
       end
 
       def use_config_name
-        if @config.name
-          logger.info "Using cluster name #{@config.name.magenta} from configuration"
-        end
+        return false unless @config.name
+
+        logger.info "Using cluster name #{@config.name.magenta} from configuration"
       end
 
       # @return [K8s::Resource, nil]
@@ -66,7 +66,7 @@ module Pharos
       def generate_new_name
         return if @config.name
 
-        new_name = "#{ADJECTIVES.sample}-#{NOUNS.sample}-#{"%04d" % rand(9999)}"
+        new_name = "#{ADJECTIVES.sample}-#{NOUNS.sample}-#{'%04d' % rand(9999)}"
         @config.set(:name, new_name)
         logger.info "Using generated random name #{new_name.magenta} as cluster name"
       end

--- a/lib/pharos/phases/configure_cluster_name.rb
+++ b/lib/pharos/phases/configure_cluster_name.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Phases
+    class ConfigureClusterName < Pharos::Phase
+      using Pharos::CoreExt::Colorize
+
+      title "Configure cluster name"
+
+      ADJECTIVES = %w(
+        autumn hidden bitter misty silent empty dry dark
+        summer icy delicate quiet white cool spring winter
+        patient twilight dawn crimson wispy weathered blue
+        billowing broken cold damp falling frosty green
+        long late bold little morning muddy
+        red rough still small sparkling shy
+        wandering withered wild black young holy solitary
+        fragrant aged snowy proud floral restless
+        polished purple lively nameless
+      ).freeze
+
+      NOUNS = %w(
+        waterfall river breeze moon rain wind sea morning
+        snow lake sunset pine shadow leaf dawn glitter
+        forest hill cloud meadow sun glade bird brook
+        butterfly bush dew dust field fire flower firefly
+        feather grass haze mountain night pond darkness
+        snowflake silence sound sky shape surf thunder
+        violet water wildflower wave water resonance sun
+        wood dream cherry tree fog frost voice paper
+        frog smoke star
+      ).freeze
+
+      def call
+        use_existing_name || use_config_name || generate_new_name
+      end
+
+      def use_existing_name
+        existing_name = config_map&.dig('data', 'pharos-cluster-name')
+        return false unless existing_name
+
+        logger.info "Cluster name is #{existing_name.magenta}"
+        if @config.name && @config.name != existing_name
+          raise Pharos::Error, "Cluster name mismatch, cluster: #{existing_name} configuration: #{@config.name}"
+        elsif !@config.name
+          @config.set(:name, existing_name)
+        end
+
+        true
+      end
+
+      def use_config_name
+        if @config.name
+          logger.info "Using cluster name #{@config.name.magenta} from configuration"
+        end
+      end
+
+      # @return [K8s::Resource, nil]
+      def config_map
+        cluster_context['previous-config-map']
+      end
+
+      def generate_new_name
+        return if @config.name
+
+        new_name = "#{ADJECTIVES.sample}-#{NOUNS.sample}-#{"%04d" % rand(9999)}"
+        @config.set(:name, new_name)
+        logger.info "Using generated random name #{new_name.magenta} as cluster name"
+      end
+    end
+  end
+end

--- a/lib/pharos/phases/configure_cluster_name.rb
+++ b/lib/pharos/phases/configure_cluster_name.rb
@@ -41,7 +41,10 @@ module Pharos
 
         logger.info "Cluster name is #{existing_name.magenta}"
         if @config.name && @config.name != existing_name
-          raise Pharos::Error, "Cluster name mismatch, cluster: #{existing_name} configuration: #{@config.name}"
+          raise Pharos::Error, "Cluster name mismatch, cluster: #{existing_name} configuration: #{@config.name}" unless cluster_context['force']
+
+          logger.info "Cluster will be renamed to #{@config.name.magenta}"
+          @config.attributes[:name] = @config.name
         elsif !@config.name
           @config.set(:name, existing_name)
         end

--- a/lib/pharos/phases/configure_cluster_name.rb
+++ b/lib/pharos/phases/configure_cluster_name.rb
@@ -43,9 +43,9 @@ module Pharos
         if @config.name && @config.name != existing_name
           unless cluster_context['force']
             logger.error "Current cluster name is #{existing_name.cyan} but the configuration defines #{@config.name.cyan}."
-            logger.info "  To keep the current name, change #{"name:".cyan} in the configuration, or use #{"--name #{existing_name}".cyan}."
+            logger.info "  To keep the current name, change #{'name:'.cyan} in the configuration, or use #{"--name #{existing_name}".cyan}."
             logger.info "  To rename the cluster use the #{'--force'.cyan} option."
-            raise Pharos::ConfigError, { 'name' => "can't change from #{existing_name} to #{@config.name}" }
+            raise Pharos::ConfigError, 'name' => "can't change from #{existing_name} to #{@config.name}"
           end
 
           logger.info "Cluster will be renamed to #{@config.name.magenta}"

--- a/lib/pharos/phases/store_cluster_configuration.rb
+++ b/lib/pharos/phases/store_cluster_configuration.rb
@@ -27,6 +27,7 @@ module Pharos
             'cluster.yml' => data.to_yaml,
             'pharos-version' => Pharos.version,
             'pharos-components.yml' => components.to_yaml,
+            'pharos-cluster-name' => @config.name,
             'pharos-addons.yml' => addons.to_yaml
           }
         )

--- a/lib/pharos/phases/validate_configuration_changes.rb
+++ b/lib/pharos/phases/validate_configuration_changes.rb
@@ -11,13 +11,12 @@ module Pharos
         changed?('network', 'provider', &DEFAULT_PROC)
         changed?('network', 'service_cidr', &DEFAULT_PROC)
         changed?('network', 'pod_network_cidr', &DEFAULT_PROC)
-        changed?('name', allow_set: true, &DEFAULT_PROC)
       end
 
-      def changed?(*config_keys, allow_set: false)
+      def changed?(*config_keys)
         old_value = previous_config&.dig(*config_keys)
         new_value = @config&.dig(*config_keys)
-        return false if old_value == new_value || (allow_set && old_value.nil?)
+        return false if old_value == new_value
         return true unless block_given?
 
         yield config_keys.map(&:to_s).join('.'), old_value, new_value

--- a/lib/pharos/phases/validate_configuration_changes.rb
+++ b/lib/pharos/phases/validate_configuration_changes.rb
@@ -11,12 +11,13 @@ module Pharos
         changed?('network', 'provider', &DEFAULT_PROC)
         changed?('network', 'service_cidr', &DEFAULT_PROC)
         changed?('network', 'pod_network_cidr', &DEFAULT_PROC)
+        changed?('name', allow_set: true, &DEFAULT_PROC)
       end
 
-      def changed?(*config_keys)
+      def changed?(*config_keys, allow_set: false)
         old_value = previous_config&.dig(*config_keys)
         new_value = @config&.dig(*config_keys)
-        return false if old_value == new_value
+        return false if old_value == new_value || (allow_set && old_value.nil?)
         return true unless block_given?
 
         yield config_keys.map(&:to_s).join('.'), old_value, new_value

--- a/lib/pharos/terraform/json_parser.rb
+++ b/lib/pharos/terraform/json_parser.rb
@@ -47,6 +47,11 @@ module Pharos
         @api ||= data.dig('pharos_api', 'value')
       end
 
+      # @return [String,NilClass]
+      def cluster_name
+        @cluster_name ||= data.dig('pharos_cluster', 'value', 'name')
+      end
+
       # @param bundle [Hash]
       # @param host [Hash]
       # @param index [Integer]

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -6,6 +6,7 @@ module Pharos
 
     options :load_config, :tf_json, :yes?
 
+    option ['-n', '--name'], 'NAME', 'use as cluster name', attribute_name: :new_name
     option ['-f', '--force'], :flag, "force upgrade"
 
     def execute
@@ -14,6 +15,7 @@ module Pharos
       Pharos::Kube.init_logging!
 
       config = load_config
+      config.attributes[:name] = new_name
 
       # set workdir to the same dir where config was loaded from
       # so that the certs etc. can be referenced more easily
@@ -55,7 +57,7 @@ module Pharos
         end
       end
       puts "    To configure kubectl for connecting to the cluster, use:"
-      puts "      #{File.basename($PROGRAM_NAME)} kubeconfig #{"#{@config_options.join(' ')} " if @config_options}> kubeconfig"
+      puts "      #{File.basename($PROGRAM_NAME)} kubeconfig #{"#{@config_options.join(' ')} " if @config_options} -n #{config.name} > kubeconfig"
       puts "      export KUBECONFIG=./kubeconfig"
       manager.disconnect
     end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -15,7 +15,7 @@ module Pharos
       Pharos::Kube.init_logging!
 
       config = load_config
-      config.attributes[:name] = new_name
+      config.attributes[:name] = new_name if new_name
 
       # set workdir to the same dir where config was loaded from
       # so that the certs etc. can be referenced more easily

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -54,7 +54,7 @@ Pharos.addon 'kontena-lens' do
 
     host = config.ingress&.host || config.host || "lens.#{gateway_node_ip}.nip.io"
     tls_email = config.ingress&.tls&.email || config.tls&.email
-    name = config.name || 'pharos-cluster'
+    name = config.name || cluster_config.name || 'pharos-cluster'
     charts_enabled = config.charts&.enabled != false
     helm_repositories = config.charts&.repositories || [stable_helm_repo]
     tiller_version = '2.12.2'


### PR DESCRIPTION
Fixes #1080 

Allows to set cluster name in config:

```yaml
hosts:
  - address: 10.0.0.1
name: pharos-cluster-123
```

Or through parameters:
```
pharos up -c cluster.yml --name pharos-cluster-123
```

If one is not given, a random name will be generated.

If the cluster already has a name and the config defines a different name, an error will be reported unless `--force` is used (or the same name is set by using `--name`)

The name can be displayed in [kontena-lens](https://pharos.sh/docs/2-0/addons/kontena-lens.html) for example.
