### PR TITLE
Update kubeadm config schemas to v1beta1

### DIFF
--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -26,39 +26,46 @@ module Pharos
       # @return [Hash]
       def generate
         config = {
-          'apiVersion' => 'kubeadm.k8s.io/v1alpha3',
+          'apiVersion' => 'kubeadm.k8s.io/v1beta1',
           'kind' => 'ClusterConfiguration',
           'kubernetesVersion' => Pharos::KUBE_VERSION,
           'imageRepository' => @config.image_repository,
-          'apiServerCertSANs' => build_extra_sans,
           'networking' => {
             'serviceSubnet' => @config.network.service_cidr,
             'podSubnet' => @config.network.pod_network_cidr
           },
+          'apiServer' => {
+            'extraArgs' => {
+              'profiling' => 'false', # CIS 1.1.8
+              'kubelet-certificate-authority' => CA_FILE,
+              'repair-malformed-updates' => 'false', # CIS 1.1.9
+              'tls-cipher-suites' => TLS_CIPHERS, # CIS 1.1.30
+              'service-account-lookup' => 'true' # CIS 1.1.23
+            },
+            'certSANs' => build_extra_sans
+          },
           'controlPlaneEndpoint' => 'localhost:6443', # client-side loadbalanced kubelets
-          'apiServerExtraArgs' => {
-            'profiling' => 'false', # CIS 1.1.8
-            'kubelet-certificate-authority' => CA_FILE,
-            'repair-malformed-updates' => 'false', # CIS 1.1.9
-            'tls-cipher-suites' => TLS_CIPHERS, # CIS 1.1.30
-            'service-account-lookup' => 'true' # CIS 1.1.23
+          'controllerManager' => {
+            'extraArgs' => {
+              'horizontal-pod-autoscaler-use-rest-clients' => 'true',
+              'profiling' => 'false', # CIS 1.2.1
+              'terminated-pod-gc-threshold' => '1000' # CIS 1.3.1
+            },
+
           },
-          'controllerManagerExtraArgs' => {
-            'horizontal-pod-autoscaler-use-rest-clients' => 'true',
-            'profiling' => 'false', # CIS 1.2.1
-            'terminated-pod-gc-threshold' => '1000' # CIS 1.3.1
-          },
-          'schedulerExtraArgs' => {
-            'profiling' => 'false' # CIS 1.3.2
+          'scheduler' => {
+            'extraArgs' => {
+              'profiling' => 'false' # CIS 1.3.2
+            }
           }
         }
 
         if @config.cloud && @config.cloud.provider != 'external'
-          config['apiServerExtraArgs']['cloud-provider'] = @config.cloud.provider
-          config['controllerManagerExtraArgs']['cloud-provider'] = @config.cloud.provider
+          config['apiServer']['extraArgs']['cloud-provider'] = @config.cloud.provider
+          config['controllerManager']['extraArgs']['cloud-provider'] = @config.cloud.provider
           if @config.cloud.config
-            config['apiServerExtraArgs']['cloud-config'] = CLOUD_CFG_FILE
-            config['controllerManagerExtraArgs']['cloud-config'] = CLOUD_CFG_FILE
+            config['apiServer']['extraArgs']['cloud-config'] = CLOUD_CFG_FILE
+            config['controllerManager']['extraArgs']['cloud-config'] = CLOUD_CFG_FILE
           end
         end
 
@@ -68,7 +75,7 @@ module Pharos
         else
           configure_internal_etcd(config)
         end
-        config['apiServerExtraVolumes'] = [
+        config['apiServer']['extraVolumes'] = [
           {
             'name' => 'pharos',
             'hostPath' => PHAROS_DIR,
@@ -76,7 +83,7 @@ module Pharos
           }
         ]
 
-        config['controllerManagerExtraVolumes'] = [
+        config['controllerManager']['extraVolumes'] = [
           {
             'name' => 'pharos',
             'hostPath' => PHAROS_DIR,
@@ -96,8 +103,8 @@ module Pharos
         configure_admission_plugins(config)
 
         # Set secrets config location and mount it to api server
-        config['apiServerExtraArgs']['experimental-encryption-provider-config'] = SECRETS_CFG_FILE
-        config['apiServerExtraVolumes'] << {
+        config['apiServer']['extraArgs']['experimental-encryption-provider-config'] = SECRETS_CFG_FILE
+        config['apiServer']['extraVolumes'] << {
           'name' => 'k8s-secrets-config',
           'hostPath' => SECRETS_CFG_DIR,
           'mountPath' => SECRETS_CFG_DIR
@@ -146,33 +153,33 @@ module Pharos
 
       # @param config [Hash]
       def configure_token_webhook(config)
-        config['apiServerExtraArgs'].merge!(authentication_token_webhook_args(@config.authentication.token_webhook.cache_ttl))
-        config['apiServerExtraVolumes'] += volume_mounts_for_authentication_token_webhook
+        config['apiServer']['extraArgs'].merge!(authentication_token_webhook_args(@config.authentication.token_webhook.cache_ttl))
+        config['apiServer']['extraVolumes'] += volume_mounts_for_authentication_token_webhook
       end
 
       # @param config [Hash]
       def configure_audit_webhook(config)
-        config['apiServerExtraArgs'].merge!(
+        config['apiServer']['extraArgs'].merge!(
           "audit-webhook-config-file" => AUDIT_CFG_DIR + '/webhook.yml',
           "audit-policy-file" => AUDIT_CFG_DIR + '/policy.yml'
         )
-        config['apiServerExtraVolumes'] += volume_mounts_for_audit_config
+        config['apiServer']['extraVolumes'] += volume_mounts_for_audit_config
       end
 
       # @param config [Hash]
       def configure_oidc(config)
-        config['apiServerExtraArgs'].merge!(
+        config['apiServer']['extraArgs'].merge!(
           'oidc-issuer-url' => @config.authentication.oidc.issuer_url,
           'oidc-client-id' => @config.authentication.oidc.client_id
         )
         # These are optional in config, so set conditionally
-        config['apiServerExtraArgs']['oidc-username-claim'] = @config.authentication.oidc.username_claim if @config.authentication.oidc.username_claim
-        config['apiServerExtraArgs']['oidc-username-prefix'] = @config.authentication.oidc.username_prefix if @config.authentication.oidc.username_prefix
-        config['apiServerExtraArgs']['oidc-groups-claim'] = @config.authentication.oidc.groups_claim if @config.authentication.oidc.groups_claim
-        config['apiServerExtraArgs']['oidc-groups-prefix'] = @config.authentication.oidc.groups_prefix if @config.authentication.oidc.groups_prefix
-        config['apiServerExtraArgs']['oidc-ca-file'] = OIDC_CONFIG_DIR + '/oidc_ca.crt' if @config.authentication.oidc.ca_file
+        config['apiServer']['extraArgs']['oidc-username-claim'] = @config.authentication.oidc.username_claim if @config.authentication.oidc.username_claim
+        config['apiServer']['extraArgs']['oidc-username-prefix'] = @config.authentication.oidc.username_prefix if @config.authentication.oidc.username_prefix
+        config['apiServer']['extraArgs']['oidc-groups-claim'] = @config.authentication.oidc.groups_claim if @config.authentication.oidc.groups_claim
+        config['apiServer']['extraArgs']['oidc-groups-prefix'] = @config.authentication.oidc.groups_prefix if @config.authentication.oidc.groups_prefix
+        config['apiServer']['extraArgs']['oidc-ca-file'] = OIDC_CONFIG_DIR + '/oidc_ca.crt' if @config.authentication.oidc.ca_file
 
-        config['apiServerExtraVolumes'] += volume_mounts_for_authentication_oidc if @config.authentication.oidc.ca_file
+        config['apiServer']['extraVolumes'] += volume_mounts_for_authentication_oidc if @config.authentication.oidc.ca_file
       end
 
       # @return [Array<Hash>]
@@ -222,7 +229,7 @@ module Pharos
 
       # @param config [Hash]
       def configure_audit_file(config)
-        config['apiServerExtraArgs'].merge!(
+        config['apiServer']['extraArgs'].merge!(
           "audit-log-path" => @config.audit.file.path,
           "audit-log-maxage" => @config.audit.file.max_age.to_s,
           "audit-log-maxbackup" => @config.audit.file.max_backups.to_s,
@@ -230,13 +237,13 @@ module Pharos
           "audit-policy-file" => AUDIT_CFG_DIR + '/policy.yml'
         )
         base_dir = File.dirname(@config.audit.file.path)
-        config['apiServerExtraVolumes'] += [{
+        config['apiServer']['extraVolumes'] += [{
           'name' => 'k8s-audit-file',
           'hostPath' => base_dir,
           'mountPath' => base_dir,
-          'writable' => true
+          'readOnly' => false
         }]
-        config['apiServerExtraVolumes'] += volume_mounts_for_audit_config
+        config['apiServer']['extraVolumes'] += volume_mounts_for_audit_config
       end
 
       # @param config [Hash]
@@ -244,8 +251,8 @@ module Pharos
         disabled_plugins = @config.admission_plugins&.reject(&:enabled)&.map(&:name) || []
         enabled_plugins = DEFAULT_ADMISSION_PLUGINS.reject{ |p| disabled_plugins.include?(p) } + (@config.admission_plugins&.select(&:enabled)&.map(&:name) || [])
 
-        config['apiServerExtraArgs']['enable-admission-plugins'] = enabled_plugins.uniq.join(',') unless enabled_plugins.empty?
-        config['apiServerExtraArgs']['disable-admission-plugins'] = disabled_plugins.uniq.join(',') unless disabled_plugins.empty?
+        config['apiServer']['extraArgs']['enable-admission-plugins'] = enabled_plugins.uniq.join(',') unless enabled_plugins.empty?
+        config['apiServer']['extraArgs']['disable-admission-plugins'] = disabled_plugins.uniq.join(',') unless disabled_plugins.empty?
       end
     end
   end

--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -50,8 +50,7 @@ module Pharos
               'horizontal-pod-autoscaler-use-rest-clients' => 'true',
               'profiling' => 'false', # CIS 1.2.1
               'terminated-pod-gc-threshold' => '1000' # CIS 1.3.1
-            },
-
+            }
           },
           'scheduler' => {
             'extraArgs' => {

--- a/lib/pharos/kubeadm/init_config.rb
+++ b/lib/pharos/kubeadm/init_config.rb
@@ -13,9 +13,9 @@ module Pharos
       # @return [Hash]
       def generate
         config = {
-          'apiVersion' => 'kubeadm.k8s.io/v1alpha3',
+          'apiVersion' => 'kubeadm.k8s.io/v1beta1',
           'kind' => 'InitConfiguration',
-          'apiEndpoint' => {
+          'localApiEndpoint' => {
             'advertiseAddress' => advertise_address
           },
           'nodeRegistration' => {

--- a/spec/pharos/kubeadm/cluster_config_spec.rb
+++ b/spec/pharos/kubeadm/cluster_config_spec.rb
@@ -32,8 +32,8 @@ describe Pharos::Kubeadm::ClusterConfig do
 
       it 'comes with proper audit config' do
         config = subject.generate
-        expect(config.dig('apiServerExtraArgs', 'audit-webhook-config-file')).to eq('/etc/pharos/audit/webhook.yml')
-        expect(config.dig('apiServerExtraVolumes')).to include({
+        expect(config.dig('apiServer', 'extraArgs', 'audit-webhook-config-file')).to eq('/etc/pharos/audit/webhook.yml')
+        expect(config.dig('apiServer', 'extraVolumes')).to include({
           'name' => 'k8s-audit-webhook',
           'hostPath' => '/etc/pharos/audit',
           'mountPath' => '/etc/pharos/audit'
@@ -58,15 +58,15 @@ describe Pharos::Kubeadm::ClusterConfig do
 
       it 'comes with proper audit config' do
         config = subject.generate
-        expect(config.dig('apiServerExtraArgs', 'audit-log-path')).to eq('/var/log/kube_audit/audit.json')
-        expect(config.dig('apiServerExtraArgs', 'audit-log-maxage')).to eq('30')
-        expect(config.dig('apiServerExtraArgs', 'audit-log-maxbackup')).to eq('10')
-        expect(config.dig('apiServerExtraArgs', 'audit-log-maxsize')).to eq('200')
-        expect(config.dig('apiServerExtraVolumes')).to include({
+        expect(config.dig('apiServer', 'extraArgs', 'audit-log-path')).to eq('/var/log/kube_audit/audit.json')
+        expect(config.dig('apiServer', 'extraArgs', 'audit-log-maxage')).to eq('30')
+        expect(config.dig('apiServer', 'extraArgs', 'audit-log-maxbackup')).to eq('10')
+        expect(config.dig('apiServer', 'extraArgs', 'audit-log-maxsize')).to eq('200')
+        expect(config.dig('apiServer', 'extraVolumes')).to include({
           'name' => 'k8s-audit-file',
           'hostPath' => '/var/log/kube_audit',
           'mountPath' => '/var/log/kube_audit',
-          'writable' => true
+          'readOnly' => false
         })
       end
     end
@@ -93,7 +93,7 @@ describe Pharos::Kubeadm::ClusterConfig do
     it 'comes with correct master addresses' do
       config.hosts << master
       config = subject.generate
-      expect(config.dig('apiServerCertSANs')).to eq(['localhost', 'test', 'private'])
+      expect(config.dig('apiServer', 'certSANs')).to eq(['localhost', 'test', 'private'])
     end
 
     it 'comes with internal etcd config' do
@@ -105,8 +105,8 @@ describe Pharos::Kubeadm::ClusterConfig do
 
     it 'comes with secrets encryption config' do
       config = subject.generate
-      expect(config.dig('apiServerExtraArgs', 'experimental-encryption-provider-config')).to eq(described_class::SECRETS_CFG_FILE)
-      expect(config['apiServerExtraVolumes']).to include({'name' => 'k8s-secrets-config',
+      expect(config.dig('apiServer', 'extraArgs', 'experimental-encryption-provider-config')).to eq(described_class::SECRETS_CFG_FILE)
+      expect(config.dig('apiServer', 'extraVolumes')).to include({'name' => 'k8s-secrets-config',
         'hostPath' => described_class::SECRETS_CFG_DIR,
         'mountPath' => described_class::SECRETS_CFG_DIR
       })
@@ -156,8 +156,8 @@ describe Pharos::Kubeadm::ClusterConfig do
             'mountPath' => '/etc/pharos'
         }
         config = subject.generate
-        expect(config['apiServerExtraVolumes']).to include(pharos_volume_mount)
-        expect(config['controllerManagerExtraVolumes']).to include(pharos_volume_mount)
+        expect(config.dig('apiServer', 'extraVolumes')).to include(pharos_volume_mount)
+        expect(config.dig('controllerManager', 'extraVolumes')).to include(pharos_volume_mount)
       end
     end
 
@@ -173,13 +173,13 @@ describe Pharos::Kubeadm::ClusterConfig do
 
       it 'comes with proper cloud provider' do
         config = subject.generate
-        expect(config['apiServerExtraArgs']['cloud-provider']).to eq('aws')
+        expect(config.dig('apiServer', 'extraArgs', 'cloud-provider')).to eq('aws')
       end
 
       it 'comes with proper cloud config' do
         config = subject.generate
-        expect(config.dig('apiServerExtraArgs', 'cloud-config')).to be_nil
-        expect(config.dig('controllerManagerExtraArgs', 'cloud-config')).to be_nil
+        expect(config.dig('apiServer', 'extraArgs', 'cloud-config')).to be_nil
+        expect(config.dig('controllerManager', 'extraArgs', 'cloud-config')).to be_nil
       end
     end
 
@@ -196,13 +196,13 @@ describe Pharos::Kubeadm::ClusterConfig do
 
       it 'comes with proper cloud provider' do
         config = subject.generate
-        expect(config['apiServerExtraArgs']['cloud-provider']).to eq('aws')
+        expect(config.dig('apiServer', 'extraArgs', 'cloud-provider')).to eq('aws')
       end
 
       it 'comes with proper cloud config' do
         config = subject.generate
-        expect(config.dig('apiServerExtraArgs', 'cloud-config')).to eq('/etc/pharos/cloud/cloud-config')
-        expect(config.dig('controllerManagerExtraArgs', 'cloud-config')).to eq('/etc/pharos/cloud/cloud-config')
+        expect(config.dig('apiServer', 'extraArgs', 'cloud-config')).to eq('/etc/pharos/cloud/cloud-config')
+        expect(config.dig('controllerManager', 'extraArgs', 'cloud-config')).to eq('/etc/pharos/cloud/cloud-config')
       end
     end
 
@@ -228,7 +228,7 @@ describe Pharos::Kubeadm::ClusterConfig do
 
       it 'comes with proper authentication webhook token config' do
         config = subject.generate
-        expect(config['apiServerExtraArgs']['authentication-token-webhook-config-file'])
+        expect(config.dig('apiServer', 'extraArgs', 'authentication-token-webhook-config-file'))
           .to eq('/etc/kubernetes/authentication/token-webhook-config.yaml')
       end
 
@@ -241,7 +241,7 @@ describe Pharos::Kubeadm::ClusterConfig do
           }
         ]
         config = subject.generate
-        expect(config['apiServerExtraVolumes']).to include(valid_volume_mounts[0])
+        expect(config.dig('apiServer', 'extraVolumes')).to include(valid_volume_mounts[0])
       end
     end
 
@@ -262,11 +262,11 @@ describe Pharos::Kubeadm::ClusterConfig do
 
       it 'comes with proper oidc flags for api-server' do
         config = subject.generate
-        expect(config['apiServerExtraArgs']['oidc-issuer-url'])
+        expect(config.dig('apiServer', 'extraArgs', 'oidc-issuer-url'))
           .to eq('https://accounts.google.com')
-          expect(config['apiServerExtraArgs']['oidc-client-id'])
+          expect(config.dig('apiServer', 'extraArgs', 'oidc-client-id'))
           .to eq('foobar')
-          expect(config['apiServerExtraArgs']['oidc-username-claim'])
+          expect(config.dig('apiServer', 'extraArgs', 'oidc-username-claim'))
           .to eq('email')
       end
 
@@ -279,8 +279,8 @@ describe Pharos::Kubeadm::ClusterConfig do
           }
         ]
         config = subject.generate
-        expect(config['apiServerExtraVolumes']).to include(valid_volume_mounts[0])
-        expect(config['apiServerExtraArgs']['oidc-ca-file'])
+        expect(config.dig('apiServer', 'extraVolumes')).to include(valid_volume_mounts[0])
+        expect(config.dig('apiServer', 'extraArgs', 'oidc-ca-file'))
           .to eq('/etc/kubernetes/authentication/oidc_ca.crt')
       end
     end
@@ -298,7 +298,7 @@ describe Pharos::Kubeadm::ClusterConfig do
         ) }
 
         it 'configures enabled plugins to api server' do
-          extra_args = subject.generate['apiServerExtraArgs']
+          extra_args = subject.generate['apiServer']['extraArgs']
           expect(extra_args['enable-admission-plugins']).to eq('PodSecurityPolicy,NodeRestriction,AlwaysPullImages,NamespaceLifecycle,ServiceAccount')
           expect(extra_args['disable-admission-plugins']).to eq('Priority')
         end
@@ -311,7 +311,7 @@ describe Pharos::Kubeadm::ClusterConfig do
         ) }
 
         it 'configures default plugins to api server' do
-          extra_args = subject.generate['apiServerExtraArgs']
+          extra_args = subject.generate['apiServer']['extraArgs']
           expect(extra_args.has_key?('enable-admission-plugins')).to be_truthy
           plugins = extra_args['enable-admission-plugins'].split(',')
           expect(plugins).to include('PodSecurityPolicy')
@@ -328,7 +328,7 @@ describe Pharos::Kubeadm::ClusterConfig do
         ) }
 
         it 'configures default plugins to api server' do
-          extra_args = subject.generate['apiServerExtraArgs']
+          extra_args = subject.generate['apiServer']['extraArgs']
           expect(extra_args.has_key?('enable-admission-plugins')).to be_truthy
           plugins = extra_args['enable-admission-plugins'].split(',')
           expect(plugins).to include('PodSecurityPolicy')
@@ -348,7 +348,7 @@ describe Pharos::Kubeadm::ClusterConfig do
         ) }
 
         it 'configures enabled plugins to api server' do
-          extra_args = subject.generate['apiServerExtraArgs']
+          extra_args = subject.generate['apiServer']['extraArgs']
           expect(extra_args['enable-admission-plugins']).to eq('PodSecurityPolicy,NodeRestriction,AlwaysPullImages,NamespaceLifecycle,ServiceAccount')
           expect(extra_args.has_key?('disable-admission-plugins')).to be_falsey
         end
@@ -365,7 +365,7 @@ describe Pharos::Kubeadm::ClusterConfig do
         ) }
 
         it 'configures correct plugins to api server' do
-          extra_args = subject.generate['apiServerExtraArgs']
+          extra_args = subject.generate['apiServer']['extraArgs']
           expect(extra_args['disable-admission-plugins']).to eq('PodSecurityPolicy,AlwaysPullImages')
           expect(extra_args.has_key?('enable-admission-plugins')).to be_truthy
           expect(extra_args['enable-admission-plugins']).to eq('NodeRestriction,NamespaceLifecycle,ServiceAccount')

--- a/spec/pharos/kubeadm/init_config_spec.rb
+++ b/spec/pharos/kubeadm/init_config_spec.rb
@@ -21,7 +21,7 @@ describe Pharos::Kubeadm::InitConfig do
     it 'comes with correct master addresses' do
       config.hosts << master
       config = subject.generate
-      expect(config.dig('apiEndpoint', 'advertiseAddress')).to eq('private')
+      expect(config.dig('localApiEndpoint', 'advertiseAddress')).to eq('private')
     end
 
     context 'with cri-o configuration' do


### PR DESCRIPTION
Followed kubeadm [godocs](https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm) and changed schema to match with `v1beta1` version.

`v1alpha3` will be removed in Kubernetes 1.14

