### PR TITLE
Use cdn for downloading bintray public key

### DIFF
--- a/lib/pharos/host/debian/scripts/repos/pharos_stretch.sh
+++ b/lib/pharos/host/debian/scripts/repos/pharos_stretch.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ ! -e /etc/apt/sources.list.d/pharos-kubernetes.list ]; then
-    curl -fsSL https://bintray.com/user/downloadSubjectPublicKey?username=bintray | apt-key add -
+    curl -fsSL https://bintray-pk.pharos.sh/?username=bintray | apt-key add -
     cat <<EOF >/etc/apt/sources.list.d/pharos-kubernetes.list
 deb https://dl.bintray.com/kontena/pharos-debian stretch main
 EOF

--- a/lib/pharos/host/el7/scripts/repos/pharos_centos7.sh
+++ b/lib/pharos/host/el7/scripts/repos/pharos_centos7.sh
@@ -10,6 +10,6 @@ baseurl=https://dl.bintray.com/kontena/pharos-rpm
 gpgcheck=0
 repo_gpgcheck=1
 enabled=1
-gpgkey=https://bintray.com/user/downloadSubjectPublicKey?username=bintray
+gpgkey=https://bintray-pk.pharos.sh?username=bintray
 EOF
 fi

--- a/lib/pharos/host/ubuntu/scripts/repos/pharos_bionic.sh
+++ b/lib/pharos/host/ubuntu/scripts/repos/pharos_bionic.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ ! -e /etc/apt/sources.list.d/pharos-kubernetes.list ]; then
-    curl -fsSL https://bintray.com/user/downloadSubjectPublicKey?username=bintray | apt-key add -
+    curl -fsSL https://bintray-pk.pharos.sh/?username=bintray | apt-key add -
     cat <<EOF >/etc/apt/sources.list.d/pharos-kubernetes.list
 deb https://dl.bintray.com/kontena/pharos-debian bionic main
 EOF

--- a/lib/pharos/host/ubuntu/scripts/repos/pharos_xenial.sh
+++ b/lib/pharos/host/ubuntu/scripts/repos/pharos_xenial.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ ! -e /etc/apt/sources.list.d/pharos-kubernetes.list ]; then
-    curl -fsSL https://bintray.com/user/downloadSubjectPublicKey?username=bintray | apt-key add -
+    curl -fsSL https://bintray-pk.pharos.sh/?username=bintray | apt-key add -
     cat <<EOF >/etc/apt/sources.list.d/pharos-kubernetes.list
 deb https://dl.bintray.com/kontena/pharos-debian xenial main
 EOF


### PR DESCRIPTION
Bintray.com seems to be a bit flaky at times.. this PR switches to public key downloading to bintray-pk.pharos.sh CDN.