### PR TITLE
Add "terraform" alias for "tf" subcommand

### DIFF
--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -15,7 +15,7 @@ module Pharos
     subcommand "kubeconfig", "fetch admin kubeconfig file", KubeconfigCommand
     subcommand "reset", "reset cluster", ResetCommand
     subcommand %w(exec ssh), "run a command or an interactive session on a host", ExecCommand
-    subcommand "tf", "terraform specific commands", TerraformCommand
+    subcommand %w(tf terraform), "terraform specific commands", TerraformCommand
     subcommand "version", "show version information", VersionCommand
   end
 end


### PR DESCRIPTION
Before:

```
$ pharos terraform --help
ERROR: No such subcommand 'terraform'
```

After:

```
$ pharos terraform --help
Usage:
    pharos terraform [OPTIONS] SUBCOMMAND [ARG] ...
```
