### PR TITLE
Decorate output based on message severity

### DIFF
--- a/lib/pharos/core-ext/colorize.rb
+++ b/lib/pharos/core-ext/colorize.rb
@@ -13,6 +13,10 @@ module Pharos
         @pastel = Pastel.new(enabled: false)
       end
 
+      def self.enabled?
+        pastel.enabled?
+      end
+
       refine String do
         Pastel::ANSI::ATTRIBUTES.each_key do |meth|
           next if meth == :underscore

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -4,6 +4,8 @@ require 'logger'
 
 module Pharos
   class Phase
+    using Pharos::CoreExt::Colorize
+
     RESOURCE_PATH = Pathname.new(File.expand_path(File.join(__dir__, 'resources'))).freeze
 
     # @return [String]
@@ -38,8 +40,14 @@ module Pharos
       @logger ||= Logger.new($stdout).tap do |logger|
         logger.progname = @host.to_s
         logger.level = ENV["DEBUG"] ? Logger::DEBUG : Logger::INFO
-        logger.formatter = proc do |_severity, _datetime, progname, msg|
-          "    [%<progname>s] %<msg>s\n" % { progname: progname, msg: msg }
+        logger.formatter = proc do |severity, _datetime, progname, msg|
+          color = case severity
+                  when "DEBUG" then :dim
+                  when "INFO" then :to_s
+                  when "WARN" then :yellow
+                  else :red
+                  end
+          "    [%<progname>s] %<msg>s\n" % { progname: progname.send(color), msg: msg }
         end
       end
     end


### PR DESCRIPTION
The severity is currently completely ignored. This PR colorizes the hostname part or if the colorization is disabled, adds severity to non-info messages.

![image](https://user-images.githubusercontent.com/224971/53866522-6e838e00-3ffa-11e9-9116-3bc477ce207c.png)

Without color:

![image](https://user-images.githubusercontent.com/224971/53867453-8f4ce300-3ffc-11e9-83d3-c1f657febf99.png)
