### PR TITLE
Allow to pass Lens admin password via envs

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -189,7 +189,7 @@ Pharos.addon 'kontena-lens' do
 
   # @return [String]
   def admin_password
-    @admin_password ||= ENV['LENS_ADMIN_PASSWORD'] || SecureRandom.hex(8)
+    @admin_password ||= ENV['LENS_ADMIN_PASSWORD'] || SecureRandom.hex(8)
   end
 
   def config_exists?

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -189,7 +189,7 @@ Pharos.addon 'kontena-lens' do
 
   # @return [String]
   def admin_password
-    @admin_password ||= SecureRandom.hex(8)
+    @admin_password ||= ENV['LENS_ADMIN_PASSWORD'] || SecureRandom.hex(8)
   end
 
   def config_exists?


### PR DESCRIPTION
This PR makes it possible to pass `LENS_ADMIN_PASSWORD` to `pharos up` command and use the given password as admin password.

