### PR TITLE
Increase Helm API memory limit

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/15-helm-api-statefulset.yml.erb
@@ -31,7 +31,7 @@ spec:
               memory: "128Mi"
               cpu: "0.1"
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
           readinessProbe:
             httpGet:
               path: /ping


### PR DESCRIPTION
Helm CLI commands uses quite a lot of memory and helm api executes these commands parallel so we need to increase memory limit. After the command execution, memory usage drops to tolerable level.