### PR TITLE
Allow to enable feature gates

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -98,6 +98,7 @@ module Pharos
       apply_phase(Phases::PullMasterImages, master_hosts, parallel: true)
       apply_phase(Phases::ConfigureMaster, master_hosts, parallel: false)
       apply_phase(Phases::ConfigureClient, master_only, parallel: false)
+      apply_phase(Phases::ReconfigureKubelet, config.hosts, parallel: true)
 
       # master is now configured and can be used
       # configure essential services

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -94,7 +94,6 @@ module Pharos
         optional(:name).filled(:str?)
         optional(:api).schema do
           optional(:endpoint).filled(:str?)
-          optional(:feature_gates).filled
         end
         optional(:network).schema do
           optional(:provider).filled(included_in?: %w(weave calico custom))
@@ -189,6 +188,7 @@ module Pharos
         end
         optional(:control_plane).schema do
           optional(:use_proxy).filled(:bool?)
+          optional(:feature_gates).filled
         end
         optional(:telemetry).schema do
           optional(:enabled).filled(:bool?)

--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -94,6 +94,7 @@ module Pharos
         optional(:name).filled(:str?)
         optional(:api).schema do
           optional(:endpoint).filled(:str?)
+          optional(:feature_gates).filled
         end
         optional(:network).schema do
           optional(:provider).filled(included_in?: %w(weave calico custom))
@@ -184,6 +185,7 @@ module Pharos
         optional(:addons).value(type?: Hash)
         optional(:kubelet).schema do
           optional(:read_only_port).filled(:bool?)
+          optional(:feature_gates).filled
         end
         optional(:control_plane).schema do
           optional(:use_proxy).filled(:bool?)

--- a/lib/pharos/configuration/api.rb
+++ b/lib/pharos/configuration/api.rb
@@ -4,6 +4,7 @@ module Pharos
   module Configuration
     class Api < Pharos::Configuration::Struct
       attribute :endpoint, Pharos::Types::String
+      attribute :feature_gates, Pharos::Types::Strict::Hash
     end
   end
 end

--- a/lib/pharos/configuration/api.rb
+++ b/lib/pharos/configuration/api.rb
@@ -4,7 +4,6 @@ module Pharos
   module Configuration
     class Api < Pharos::Configuration::Struct
       attribute :endpoint, Pharos::Types::String
-      attribute :feature_gates, Pharos::Types::Strict::Hash
     end
   end
 end

--- a/lib/pharos/configuration/control_plane.rb
+++ b/lib/pharos/configuration/control_plane.rb
@@ -4,6 +4,7 @@ module Pharos
   module Configuration
     class ControlPlane < Pharos::Configuration::Struct
       attribute :use_proxy, Pharos::Types::Bool.default(false)
+      attribute :feature_gates, Pharos::Types::Strict::Hash
     end
   end
 end

--- a/lib/pharos/configuration/kubelet.rb
+++ b/lib/pharos/configuration/kubelet.rb
@@ -4,6 +4,7 @@ module Pharos
   module Configuration
     class Kubelet < Pharos::Configuration::Struct
       attribute :read_only_port, Pharos::Types::Bool.default(false)
+      attribute :feature_gates, Pharos::Types::Strict::Hash
     end
   end
 end

--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -60,6 +60,13 @@ module Pharos
           }
         }
 
+        if @config.api&.feature_gates
+          feature_gates = @config.api.feature_gates.map{ |k, v| "#{k}=#{v}" }.join(',')
+          config['apiServer']['extraArgs']['feature-gates'] = feature_gates
+          config['scheduler']['extraArgs']['feature-gates'] = feature_gates
+          config['controllerManager']['extraArgs']['feature-gates'] = feature_gates
+        end
+
         if @config.cloud && @config.cloud.provider != 'external'
           config['apiServer']['extraArgs']['cloud-provider'] = @config.cloud.provider
           config['controllerManager']['extraArgs']['cloud-provider'] = @config.cloud.provider

--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -60,8 +60,8 @@ module Pharos
           }
         }
 
-        if @config.api&.feature_gates
-          feature_gates = @config.api.feature_gates.map{ |k, v| "#{k}=#{v}" }.join(',')
+        if @config.control_plane&.feature_gates
+          feature_gates = @config.control_plane.feature_gates.map{ |k, v| "#{k}=#{v}" }.join(',')
           config['apiServer']['extraArgs']['feature-gates'] = feature_gates
           config['scheduler']['extraArgs']['feature-gates'] = feature_gates
           config['controllerManager']['extraArgs']['feature-gates'] = feature_gates

--- a/lib/pharos/kubeadm/kubelet_config.rb
+++ b/lib/pharos/kubeadm/kubelet_config.rb
@@ -31,7 +31,7 @@ module Pharos
           config['readOnlyPort'] = 10_255
         end
         if feature_gates = @config.kubelet&.feature_gates
-          config['featureGates'] = @config.kubelet.feature_gates
+          config['featureGates'] = feature_gates
         end
 
         config

--- a/lib/pharos/kubeadm/kubelet_config.rb
+++ b/lib/pharos/kubeadm/kubelet_config.rb
@@ -30,7 +30,7 @@ module Pharos
         if @config.kubelet&.read_only_port
           config['readOnlyPort'] = 10_255
         end
-        if @config.kubelet&.feature_gates
+        if feature_gates = @config.kubelet&.feature_gates
           config['featureGates'] = @config.kubelet.feature_gates
         end
 

--- a/lib/pharos/kubeadm/kubelet_config.rb
+++ b/lib/pharos/kubeadm/kubelet_config.rb
@@ -30,9 +30,8 @@ module Pharos
         if @config.kubelet&.read_only_port
           config['readOnlyPort'] = 10_255
         end
-        if feature_gates = @config.kubelet&.feature_gates
-          config['featureGates'] = feature_gates
-        end
+        feature_gates = @config.kubelet&.feature_gates
+        config['featureGates'] = feature_gates if feature_gates
 
         config
       end

--- a/lib/pharos/kubeadm/kubelet_config.rb
+++ b/lib/pharos/kubeadm/kubelet_config.rb
@@ -30,6 +30,9 @@ module Pharos
         if @config.kubelet&.read_only_port
           config['readOnlyPort'] = 10_255
         end
+        if @config.kubelet&.feature_gates
+          config['featureGates'] = @config.kubelet.feature_gates
+        end
 
         config
       end

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -31,7 +31,6 @@ module Pharos
           logger.info { 'Configuring kubelet ...' }
         else
           logger.info { 'Reconfiguring kubelet ...' }
-          reconfigure_kubelet
         end
         ensure_dropin(build_systemd_dropin)
       end
@@ -129,20 +128,6 @@ module Pharos
         args << "--cloud-provider=#{@config.cloud.provider}" if @config.cloud
         args << "--cloud-config=#{CLOUD_CONFIG_FILE}" if @config.cloud&.config
         args
-      end
-
-      def reconfigure_kubelet
-        config = transport.file('/var/lib/kubelet/config.yaml')
-        unless config.exist?
-          logger.error "Cannot read existing configuration file, skipping reconfigure ..."
-          return
-        end
-        org_config = config.read
-        transport.exec!("sudo kubeadm upgrade node config --kubelet-version #{Pharos::KUBE_VERSION}")
-        new_config = config.read
-        return if new_config == org_config
-
-        transport.exec!("sudo systemctl restart kubelet")
       end
     end
   end

--- a/lib/pharos/phases/reconfigure_kubelet.rb
+++ b/lib/pharos/phases/reconfigure_kubelet.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Reconfigure kubelet"
 
       def call
-        return unless host.new?
+        return if host.new?
 
         logger.info { 'Reconfiguring kubelet ...' }
         reconfigure_kubelet

--- a/lib/pharos/phases/reconfigure_kubelet.rb
+++ b/lib/pharos/phases/reconfigure_kubelet.rb
@@ -23,7 +23,7 @@ module Pharos
         new_config = config.read
         return if new_config == org_config
 
-        transport.exec!("sudo systemctl restart kubelet")
+        transport.exec!('sudo systemctl restart kubelet')
       end
     end
   end

--- a/lib/pharos/phases/reconfigure_kubelet.rb
+++ b/lib/pharos/phases/reconfigure_kubelet.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Pharos
+  module Phases
+    class ReconfigureKubelet < Pharos::Phase
+      title "Reconfigure kubelet"
+
+      def call
+        return unless host.new?
+
+        logger.info { 'Reconfiguring kubelet ...' }
+        reconfigure_kubelet
+      end
+
+      def reconfigure_kubelet
+        config = transport.file('/var/lib/kubelet/config.yaml')
+        unless config.exist?
+          logger.error "Cannot read existing configuration file, skipping reconfigure ..."
+          return
+        end
+        org_config = config.read
+        transport.exec!("sudo kubeadm upgrade node config --kubelet-version #{Pharos::KUBE_VERSION}")
+        new_config = config.read
+        return if new_config == org_config
+
+        transport.exec!("sudo systemctl restart kubelet")
+      end
+    end
+  end
+end

--- a/lib/pharos/scripts/kubeadm-reconfigure.sh
+++ b/lib/pharos/scripts/kubeadm-reconfigure.sh
@@ -8,4 +8,4 @@ fi
 
 kubeadm init phase control-plane all --config "${CONFIG}"
 kubeadm init phase mark-control-plane --config "${CONFIG}"
-
+kubeadm init phase upload-config all --config "${CONFIG}"

--- a/spec/pharos/kubeadm/cluster_config_spec.rb
+++ b/spec/pharos/kubeadm/cluster_config_spec.rb
@@ -285,6 +285,33 @@ describe Pharos::Kubeadm::ClusterConfig do
       end
     end
 
+    context 'with control plane feature gates' do
+      let(:config) { Pharos::Config.new(
+        hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
+        network: {},
+        control_plane: {
+          feature_gates: {
+            foo: true
+          }
+        }
+      ) }
+
+      it 'adds feature gates in apiServer extraArgs' do
+        extra_args = subject.generate.dig('apiServer','extraArgs')
+        expect(extra_args['feature-gates']).to eq('foo=true')
+      end
+
+      it 'adds feature gates in scheduler extraArgs' do
+        extra_args = subject.generate.dig('scheduler','extraArgs')
+        expect(extra_args['feature-gates']).to eq('foo=true')
+      end
+
+      it 'adds feature gates in controllerManager extraArgs' do
+        extra_args = subject.generate.dig('controllerManager','extraArgs')
+        expect(extra_args['feature-gates']).to eq('foo=true')
+      end
+    end
+
     context 'with admission plugins' do
       context 'with proper config' do
         let(:config) { Pharos::Config.new(

--- a/spec/pharos/kubeadm/kubelet_config_spec.rb
+++ b/spec/pharos/kubeadm/kubelet_config_spec.rb
@@ -35,5 +35,23 @@ describe Pharos::Kubeadm::KubeletConfig do
         expect(config['readOnlyPort']).to eq(10_255)
       end
     end
+
+    context 'with kubelet.feature_gates' do
+      let(:config) { Pharos::Config.new(
+        hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
+        network: {},
+        kubelet: {
+          feature_gates: {
+            foo: true
+          }
+
+        }
+      ) }
+
+      it 'configures featureGates' do
+        config = subject.generate
+        expect(config['featureGates']).to eq({ foo: true })
+      end
+    end
   end
 end

--- a/spec/pharos/phases/reconfigure_kubelet_spec.rb
+++ b/spec/pharos/phases/reconfigure_kubelet_spec.rb
@@ -1,0 +1,67 @@
+require "pharos/host/configurer"
+require "pharos/phases/reconfigure_kubelet"
+
+describe Pharos::Phases::ReconfigureKubelet do
+  let(:host) { instance_double(Pharos::Configuration::Host) }
+  let(:ssh) { instance_double(Pharos::Transport::SSH) }
+  subject { described_class.new(host) }
+
+  before do
+    allow(host).to receive(:transport).and_return(ssh)
+  end
+
+  describe '#call' do
+    context 'when host is new' do
+      it 'does not reconfigure kubelet' do
+        allow(host).to receive(:new?).and_return(true)
+        expect(subject).not_to receive(:reconfigure_kubelet)
+        subject.call
+      end
+    end
+
+    context 'when host is not new' do
+      it 'reconfigures kubelet' do
+        allow(host).to receive(:new?).and_return(false)
+        expect(subject).to receive(:reconfigure_kubelet)
+        subject.call
+      end
+    end
+  end
+
+  describe '#reconfigure_kubelet' do
+    it 'reads kubelet config' do
+      expect(ssh).to receive(:file).with('/var/lib/kubelet/config.yaml').and_return(double(:exist? => false))
+      subject.reconfigure_kubelet
+    end
+
+    it 'upgrades kubelet config from configmap' do
+      allow(ssh).to receive(:file).with('/var/lib/kubelet/config.yaml').and_return(double(:exist? => true, :read => 'config'))
+      expect(ssh).to receive(:exec!).with("sudo kubeadm upgrade node config --kubelet-version #{Pharos::KUBE_VERSION}")
+      subject.reconfigure_kubelet
+    end
+
+    context 'when kubelet config has been changed' do
+      it 'restarts kubelet service' do
+        kubelet_config = double(:exist? => true)
+        allow(kubelet_config).to receive(:read).and_return('foo', 'bar') # config has been updated between reads
+        allow(ssh).to receive(:file).with('/var/lib/kubelet/config.yaml').and_return(kubelet_config)
+        allow(ssh).to receive(:exec!).with("sudo kubeadm upgrade node config --kubelet-version #{Pharos::KUBE_VERSION}")
+
+        expect(ssh).to receive(:exec!).with('sudo systemctl restart kubelet')
+        subject.reconfigure_kubelet
+      end
+    end
+
+    context 'when kubelet config has NOT been changed' do
+      it 'does not restart kubelet service' do
+        kubelet_config = double(:exist? => true)
+        allow(kubelet_config).to receive(:read).and_return('foo')
+        allow(ssh).to receive(:file).with('/var/lib/kubelet/config.yaml').and_return(kubelet_config)
+        allow(ssh).to receive(:exec!).with("sudo kubeadm upgrade node config --kubelet-version #{Pharos::KUBE_VERSION}")
+
+        expect(ssh).not_to receive(:exec!).with('sudo systemctl restart kubelet')
+        subject.reconfigure_kubelet
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows to configure feature gates in `cluster.yml`
```
...
control_plane:
  feature_gates:
    featureA: true
kubelet:
  feature_gates:
    featureA: true
...
```
feature gates for **control_plane** are passed as extraArgs for `apiServer`, `scheduler` and `controllerManager`  kubeadm components.

`kubeadm-reconfigure.sh` uploads now kubeadm config to cluster and new phase `ReconfigureKubelet` that will read kubelet config from cluster and reloads kubelet if needed.

fixes #1068 