### PR TITLE
Pharos dev console

### DIFF
--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pry' if Gem.loaded_specs.has_key?('pry')
+require 'pry' if Gem.loaded_specs.key?('pry')
 
 module Pharos
   class Command < Clamp::Command
@@ -53,7 +53,7 @@ module Pharos
     end
 
     if Object.const_defined?(:Pry)
-      option ['--console'], :flag, "start console instead of execute" do
+      option ['--console'], :flag, "start console instead of execute", hidden: true do
         extend(Console)
       end
     end

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pry' if Gem.loaded_specs.has_key?('pry')
+
 module Pharos
   class Command < Clamp::Command
     include Pharos::Logging
@@ -40,6 +42,20 @@ module Pharos
 
     option ['-d', '--debug'], :flag, "enable debug output", environment_variable: "DEBUG" do
       ENV["DEBUG"] = "true"
+    end
+
+    module Console
+      def execute
+        # rubocop:disable Lint/Debugger
+        binding.pry
+        # rubocop:enable Lint/Debugger
+      end
+    end
+
+    if Object.const_defined?(:Pry)
+      option ['--console'], :flag, "start console instead of execute" do
+        extend(Console)
+      end
     end
 
     def prompt

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -44,15 +44,15 @@ module Pharos
       ENV["DEBUG"] = "true"
     end
 
-    # rubocop:disable Lint/Debugger
-    module Console
-      def execute
-        binding.pry
-      end
-    end
-    # rubocop:enable Lint/Debugger
-
     if Object.const_defined?(:Pry)
+      # rubocop:disable Lint/Debugger
+      module Console
+        def execute
+          binding.pry
+        end
+      end
+      # rubocop:enable Lint/Debugger
+
       option ['--console'], :flag, "start console instead of execute", hidden: true do
         extend(Console)
       end

--- a/lib/pharos/command.rb
+++ b/lib/pharos/command.rb
@@ -44,13 +44,13 @@ module Pharos
       ENV["DEBUG"] = "true"
     end
 
+    # rubocop:disable Lint/Debugger
     module Console
       def execute
-        # rubocop:disable Lint/Debugger
         binding.pry
-        # rubocop:enable Lint/Debugger
       end
     end
+    # rubocop:enable Lint/Debugger
 
     if Object.const_defined?(:Pry)
       option ['--console'], :flag, "start console instead of execute", hidden: true do


### PR DESCRIPTION
Closes #1122 (alternative)

Instead of a separate `bin/pharos-console` this PR adds `--console` to all commands when the `pry` dependency is included.

This makes it possible to start a console in the context of any pharos subcommand:

```
$ bundle exec bin/pharos up -c foofoo.yml --console
[1] pry(#<Pharos::UpCommand>)> load_config
==> Reading instructions ...
[2] pry(#<Pharos::UpCommand>)> load_config.hosts.first.transport.tap(&:connect).exec!('ls -al')
=> "total 36\ndrwxr-xr-x 5 vagrant vagrant 4096 Mar  4 10:53 .\ndrwxr-xr-x 4 root    root    4096 Mar  4 08:52 ..\n-rw------- 1 vagrant vagrant   35 Mar  4 10:53 .bash_history\n-rw-r--r-- 1 vagrant vagrant  220 Mar  6  2018 .bash_logout\n-rw-r--r-- 1 vagrant vagrant 3771 Mar  6  2018 .bashrc\ndrwx------ 2 vagrant vagrant 4096 Mar  4 08:52 .cache\n-rw-rw-r-- 1 vagrant vagrant    0 Mar  4 10:53 .cloud-locale-test.skip\ndrwx------ 4 vagrant vagrant 4096 Mar  7 13:52 .kube\n-rw-r--r-- 1 vagrant vagrant  655 Mar  6  2018 .profile\ndrwx------ 2 vagrant vagrant 4096 Mar  6  2018 .ssh\n"
```
