### PR TITLE
Upgrade net-ssh to 5.2.0

### DIFF
--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "clamp", "1.2.1"
   spec.add_runtime_dependency "pastel", "~> 0.7"
-  spec.add_runtime_dependency "net-ssh", "5.1.0"
+  spec.add_runtime_dependency "net-ssh", "~> 5.2.0.rc3"
   spec.add_runtime_dependency "net-ssh-gateway", "2.0.0"
   spec.add_runtime_dependency "ed25519", "~> 1.2"
   spec.add_runtime_dependency "bcrypt", "~> 3.1"

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "clamp", "1.2.1"
   spec.add_runtime_dependency "pastel", "~> 0.7"
-  spec.add_runtime_dependency "net-ssh", "~> 5.2.0.rc3"
+  spec.add_runtime_dependency "net-ssh", "~> 5.2.0"
   spec.add_runtime_dependency "net-ssh-gateway", "2.0.0"
   spec.add_runtime_dependency "ed25519", "~> 1.2"
   spec.add_runtime_dependency "bcrypt", "~> 3.1"


### PR DESCRIPTION
Fixes #1055 

```
=== 5.2.0.rc3

  * Fix check_host_ip read from config
  * Support ssh-ed25519 in kown hosts

=== 5.2.0.rc2

  * Read check_host_ip from ssh config files

=== 5.2.0.rc1

  * Interpret * and ? in know_hosts file [Romain Tartière, #660]
  * New :check_host_ip so ip checking can be disabled in known hosts [Romain Tartière, #656]
```
