### PR TITLE
Release v2.3.0-beta.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.0-alpha.1"
+  VERSION = "2.3.0-beta.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.3.0-alpha.1
- Kubernetes 1.13.4 ([#1149](https://github.com/kontena/pharos-cluster/pull/1149))
- Kontena Lens 1.5.0-rc.1 ([#1160](https://github.com/kontena/pharos-cluster/pull/1160)) [Pro, EE]
- License Enforcer 0.2.0 ([#1148](https://github.com/kontena/pharos-cluster/pull/1148), [#1159](https://github.com/kontena/pharos-cluster/pull/1159)) [Pro, EE]
- Drop IPAddr Loopback backport usage ([#1133](https://github.com/kontena/pharos-cluster/pull/1133))
- Set or generate names for clusters ([#1134](https://github.com/kontena/pharos-cluster/pull/1134))
- Fix Host#local? raising IPAddr::InvalidAddressError ([#1137](https://github.com/kontena/pharos-cluster/pull/1137))
- Add --tf-json to pharos reset command ([#1139](https://github.com/kontena/pharos-cluster/pull/1139))
- Update kubeadm config schemas to v1beta1 ([#1140](https://github.com/kontena/pharos-cluster/pull/1140))
- Use cdn for downloading bintray public key ([#1144](https://github.com/kontena/pharos-cluster/pull/1144))
- Add "terraform" alias for "tf" subcommand ([#1145](https://github.com/kontena/pharos-cluster/pull/1145))
- Decorate output based on message severity ([#1146](https://github.com/kontena/pharos-cluster/pull/1146))
- Read cluster name from pharos-config on license assign ([#1147](https://github.com/kontena/pharos-cluster/pull/1147)) [Pro, EE]
- Fix generated node selectors for nginx-ingress ([#1150](https://github.com/kontena/pharos-cluster/pull/1150))
- Increase Lens Helm API memory limit ([#1153](https://github.com/kontena/pharos-cluster/pull/1153)) [Pro, EE]
- Allow to enable feature gates ([#1155](https://github.com/kontena/pharos-cluster/pull/1155))
- Reimplement license inspect command and refactor assign + config loading ([#1157](https://github.com/kontena/pharos-cluster/pull/1157)) [Pro, EE]
- Fix pharos-license-enforcer default interval ([#1161](https://github.com/kontena/pharos-cluster/pull/1161)) [Pro, EE]
