### PR TITLE
PoC Addon supermagic

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -22,12 +22,6 @@ module Pharos
     using Pharos::CoreExt::DeepTransformKeys
     include Pharos::Logging
 
-    class << self
-      def to_s
-        "#{addon_name.capitalize} Addon"
-      end
-    end
-
     # return class for use as superclass in Dry::Validation.Params
     Schema = Dry::Validation.Schema(build: false) do
       configure do
@@ -60,6 +54,10 @@ module Pharos
     class << self
       attr_reader :addon_name
       attr_writer :addon_location
+
+      def to_s
+        "#{addon_name&.capitalize || 'Base'} Addon"
+      end
 
       # @return [String]
       def addon_location

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -22,6 +22,12 @@ module Pharos
     using Pharos::CoreExt::DeepTransformKeys
     include Pharos::Logging
 
+    class << self
+      def to_s
+        "#{addon_name.capitalize} Addon"
+      end
+    end
+
     # return class for use as superclass in Dry::Validation.Params
     Schema = Dry::Validation.Schema(build: false) do
       configure do

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -46,8 +46,9 @@ module Pharos
 
     # @param file [String]
     def self.load_addon(file)
-      source = File.read(file)
-      Pharos::AddonContext.new.context.instance_eval(source, file)
+      require file
+      #source = File.read(file)
+      #Pharos::AddonContext.new.context.instance_eval(source, file)
     end
 
     # @param config [Pharos::Configuration]

--- a/lib/pharos/core-ext/string_casing.rb
+++ b/lib/pharos/core-ext/string_casing.rb
@@ -18,13 +18,13 @@ module Pharos
       def camelcase
         return self if empty?
 
-        extend(StringCasing).underscore.split('_').map(&:capitalize).join
+        dup.extend(StringCasing).underscore.split('_').map(&:capitalize).join
       end
 
       def camelback
         return self if empty?
 
-        camelcased = extend(StringCasing).camelcase
+        camelcased = dup.extend(StringCasing).camelcase
         camelcased[0] = camelcased[0].downcase
         camelcased
       end


### PR DESCRIPTION
The loader takes `block.source_location` which contains the filename and starting line of the `Pharos.addon "xyz" do` block,

then `File.read`s the lines from that location into a string which has `class Xyz < Pharos::Addon` in the beginning,

then `module_eval`s that thing and sets source location.

This results in:

- The classes have names from the start
- Constants are namespaced
- The addon can be `require`d and ruby can worry about not loading duplicates
- Any `requires` or such that were before `Pharos.addon` are handled normally.
- **Backtraces have correct line numbers**:

```
#openebs/addon.rb:
....
36: install {
37:   raise 'foo'
38: }
```

```
  3) Pharos::Addons::Openebs#install with given partial config applies stack with default values
     Failure/Error: instance_exec(&hooks[:install])

     RuntimeError:
       foo
     # ./addons/openebs/addon.rb:37:in `block in <class:Openebs>'
```

But obviously this is quite ugly.
