### PR TITLE
Reduce retry logging verbosity

### DIFF
--- a/lib/pharos/logging.rb
+++ b/lib/pharos/logging.rb
@@ -5,11 +5,11 @@ require 'logger'
 module Pharos
   module Logging
     def self.format_exception(exc, severity = "ERROR")
-      return exc unless exc.kind_of?(Exception)
+      return exc unless exc.is_a?(Exception)
 
       if ENV["DEBUG"] || severity == "DEBUG"
         message = exc.message.strip
-        backtrace = "\n    #{exc.backtrace.join("\n    ") }"
+        backtrace = "\n    #{exc.backtrace.join("\n    ")}"
       else
         message = exc.message[/\A(.+?)$/m, 1]
         backtrace = nil

--- a/lib/pharos/logging.rb
+++ b/lib/pharos/logging.rb
@@ -4,12 +4,26 @@ require 'logger'
 
 module Pharos
   module Logging
+    def self.format_exception(exc, severity = "ERROR")
+      return exc unless exc.kind_of?(Exception)
+
+      if ENV["DEBUG"] || severity == "DEBUG"
+        message = exc.message.strip
+        backtrace = "\n    #{exc.backtrace.join("\n    ") }"
+      else
+        message = exc.message[/\A(.+?)$/m, 1]
+        backtrace = nil
+      end
+
+      "Error: #{message}#{backtrace}"
+    end
+
     def self.initialize_logger(log_target = $stdout, log_level = Logger::INFO)
       @logger = Logger.new(log_target)
       @logger.progname = 'API'
       @logger.level = ENV["DEBUG"] ? Logger::DEBUG : log_level
-      logger.formatter = proc do |_severity, _datetime, _progname, msg|
-        "    %<msg>s\n" % { msg: msg }
+      logger.formatter = proc do |severity, _datetime, _progname, msg|
+        "    %<msg>s\n" % { msg: Pharos::Logging.format_exception(msg, severity) }
       end
 
       @logger

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -37,20 +37,22 @@ module Pharos
     end
 
     FORMATTER_COLOR = proc do |severity, _datetime, progname, msg|
+      message = Pharos::Logging.format_exception(msg, severity)
       color = case severity
               when "DEBUG" then :dim
               when "INFO" then :to_s
               when "WARN" then :yellow
               else :red
               end
-      "    [%<progname>s] %<msg>s\n" % { progname: progname.send(color), msg: msg }
+      "    [%<progname>s] %<msg>s\n" % { progname: progname.send(color), msg: message }
     end
 
     FORMATTER_NO_COLOR = proc do |severity, _datetime, progname, msg|
+      message = Pharos::Logging.format_exception(msg, severity)
       if severity == "INFO"
-        "    [%<progname>s] %<msg>s\n" % { progname: progname, msg: msg }
+        "    [%<progname>s] %<msg>s\n" % { progname: progname, msg: message }
       else
-        "    [%<progname>s] [%<severity>s] %<msg>s\n" % { progname: progname, severity: severity, msg: msg }
+        "    [%<progname>s] [%<severity>s] %<msg>s\n" % { progname: progname, severity: severity, msg: message }
       end
     end
 

--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -33,7 +33,7 @@ module Pharos
       threads = phases.map { |phase|
         Thread.new do
           Thread.current.report_on_exception = false
-          Retry.perform(yield_object: phase, logger: logger, exceptions: RETRY_ERRORS, &block)
+          Retry.perform(yield_object: phase, logger: phase.logger, exceptions: RETRY_ERRORS, &block)
         end
       }
       threads.map(&:value)
@@ -43,7 +43,7 @@ module Pharos
     # @return [Array<...>]
     def run_serial(phases, &block)
       phases.map do |phase|
-        Retry.perform(yield_object: phase, logger: logger, exceptions: RETRY_ERRORS, &block)
+        Retry.perform(yield_object: phase, logger: phase.logger, exceptions: RETRY_ERRORS, &block)
       end
     end
 


### PR DESCRIPTION
Fixes #1174

- Adds exception formatter when you pass an exception to logger, Logger default formatter has that, pharos Logging didn't.
- Uses phase's own logger as the retry logger, giving retry messages the host-header `   [host] Retrying..`
- Only shows backtrace when `DEBUG`
- Starts showing the first line of exception's message once retry count reaches 5.
- Replaced the `got error: ` that was intended to be seen only when `DEBUG` with something more pleasant.

### Before

![image](https://user-images.githubusercontent.com/224971/54268890-e4e93880-4584-11e9-8560-5ad3a2afbc02.png)


### After

![image](https://user-images.githubusercontent.com/224971/54268781-aa7f9b80-4584-11e9-94e3-c54002669e2c.png)

