### PR TITLE
Allow to use custom node roles for workers

### DIFF
--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -78,7 +78,7 @@ module Pharos
         labels = @attributes[:labels] || {}
 
         labels['node-address.kontena.io/external-ip'] = address
-        labels['node-role.kubernetes.io/worker'] = '' if worker?
+        labels['node-role.kubernetes.io/worker'] = '' if worker? && !labels.find{ |k, _| k.to_s.start_with?("node-role.kubernetes.io") }
 
         labels
       end

--- a/spec/pharos/configuration/host_spec.rb
+++ b/spec/pharos/configuration/host_spec.rb
@@ -51,13 +51,26 @@ describe Pharos::Configuration::Host do
         expect(subject.labels).to include(foo: 'bar', baz: 'baf')
       end
 
-      it 'returns default worker label' do
+      it 'returns default worker label if no custom roles defined' do
         subject = described_class.new(
           address: '192.168.100.100',
           role: 'worker',
           user: 'root'
         )
         expect(subject.labels).to include('node-role.kubernetes.io/worker' => "")
+      end
+
+      it 'returns custom role label if one defined' do
+        subject = described_class.new(
+          address: '192.168.100.100',
+          role: 'worker',
+          user: 'root',
+          labels: {
+            'node-role.kubernetes.io/my-precious' => ''
+          }
+        )
+        expect(subject.labels).not_to include('node-role.kubernetes.io/worker' => "")
+        expect(subject.labels).to include('node-role.kubernetes.io/my-precious' => "")
       end
     end
   end


### PR DESCRIPTION
So adding any `node-role.kubernetes.io/zyx` labels to a worker node makes the node to ignore the default `node-role.kubernetes.io/worker` label and use that custom label for node role.

fixes #1170 

