### PR TITLE
Release v2.3.0-beta.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ jobs:
         - NETWORK_PROVIDER=calico
     - stage: publish binary
       script: ./build/travis/macos.sh
-      rvm: 2.5.4
       os: osx
       install: ls -l
       deploy:
@@ -63,7 +62,6 @@ jobs:
           all_branches: true
     - stage: publish binary
       script: ./build/travis/macos_oss.sh
-      rvm: 2.5.4
       os: osx
       install: ls -l
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - stage: e2e
       name: "e2e: docker with weave"
       script: ./e2e/travis.sh
-      rvm: 2.5
+      rvm: 2.5.4
       dist: xenial
       env:
         - CONTAINER_RUNTIME=docker
@@ -23,7 +23,7 @@ jobs:
     - stage: e2e
       name: "e2e: docker with calico"
       script: ./e2e/travis.sh
-      rvm: 2.5
+      rvm: 2.5.4
       dist: xenial
       env:
         - CONTAINER_RUNTIME=docker
@@ -31,7 +31,7 @@ jobs:
     - stage: e2e
       name: "e2e: cri-o with weave"
       script: ./e2e/travis.sh
-      rvm: 2.5
+      rvm: 2.5.4
       dist: xenial
       env:
         - CONTAINER_RUNTIME=cri-o
@@ -39,14 +39,14 @@ jobs:
     - stage: e2e
       name: "e2e: cri-o with calico"
       script: ./e2e/travis.sh
-      rvm: 2.5
+      rvm: 2.5.4
       dist: xenial
       env:
         - CONTAINER_RUNTIME=cri-o
         - NETWORK_PROVIDER=calico
     - stage: publish binary
       script: ./build/travis/macos.sh
-      rvm: 2.5
+      rvm: 2.5.4
       os: osx
       install: ls -l
       deploy:
@@ -63,7 +63,7 @@ jobs:
           all_branches: true
     - stage: publish binary
       script: ./build/travis/macos_oss.sh
-      rvm: 2.5
+      rvm: 2.5.4
       os: osx
       install: ls -l
       env:

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.0-beta.1"
+  VERSION = "2.3.0-beta.2"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.3.0-beta.1

- Calico 3.6 (#1172)
- Allow to install helm charts via helm addon (#1162)
- Update Kontena Lens to 1.5.0-rc.2 (#1183) [Pro, EE]
- Upgrade net-ssh to 5.2.0 (#1158)
- Improve oss upgrade warning (#1177)
- Reduce retry logging verbosity (#1175)
- Allow to use custom node roles for workers (#1181)
- Add missing terraform.examples.tfvars to packet example (#1169)