### PR TITLE
Drop Net::SSH::Gateway dependency

### DIFF
--- a/e2e/digitalocean/main.tf
+++ b/e2e/digitalocean/main.tf
@@ -119,6 +119,11 @@ output "pharos_hosts" {
       role              = "worker"
       user              = "root"
       ssh_key_path      = "./ssh_key.pem"
+      bastion = {
+        address           = "${digitalocean_droplet.pharos_master.*.ipv4_address[0]}"
+        ssh_key_path      = "./ssh_key.pem"
+        user              = "root"
+      }
 
       label = {
         "beta.kubernetes.io/instance-type"         = "${var.worker_size}"

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -124,7 +124,7 @@ module Pharos
         api_port = 6443
       else
         api_address = 'localhost'
-        api_port = master_host.bastion.host.transport.gateway(master_host.api_address, 6443)
+        api_port = master_host.bastion.host.transport.forward(master_host.api_address, 6443)
       end
 
       @kube_client = Pharos::Kube.client(api_address, kubeconfig, api_port)

--- a/lib/pharos/configuration/bastion.rb
+++ b/lib/pharos/configuration/bastion.rb
@@ -8,7 +8,15 @@ module Pharos
       attribute :ssh_key_path, Pharos::Types::Strict::String
 
       def host
-        Host.new(address: address, user: user, ssh_key_path: ssh_key_path)
+        @host ||= Host.new(address: address, user: user, ssh_key_path: ssh_key_path)
+      end
+
+      def method_missing(meth, *args)
+        host.respond_to?(meth) ? host.send(meth, *args) : super
+      end
+
+      def respond_to_missing?(meth, include_private = false)
+        host.respond_to?(meth) || super
       end
     end
   end

--- a/lib/pharos/transport/command/ssh.rb
+++ b/lib/pharos/transport/command/ssh.rb
@@ -12,7 +12,7 @@ module Pharos
 
         # @return [Pharos::Transport::CommandResult]
         def run
-          raise Pharos::ExecError, "Connection not established" unless @client.connected?
+          @client.connect unless @client.connected?
 
           result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
           response = @client.session.open_channel do |channel|
@@ -43,6 +43,9 @@ module Pharos
           response.wait
 
           result
+        rescue IOError
+          @client.disconnect
+          retry
         end
       end
     end

--- a/lib/pharos/transport/local.rb
+++ b/lib/pharos/transport/local.rb
@@ -3,8 +3,8 @@
 module Pharos
   module Transport
     class Local < Base
-      def gateway
-        raise TypeError, "Non-SSH connections do not provide an ssh gateway"
+      def forward
+        raise TypeError, "Non-SSH connections do not provide port forwarding"
       end
 
       def connect(**_options)

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -120,7 +120,7 @@ module Pharos
             Thread.current.report_on_exception = true
             logger.debug "Started SSH event loop"
             @session.loop(0.1) { @session.busy?(true) || !@session.forward.active_locals.empty? }
-          rescue Errno::EBADF => ex
+          rescue IOError, Errno::EBADF => ex
             logger.debug "Received #{ex.class.name} (expected when tunnel has been closed)"
           ensure
             logger.debug "Closed SSH event loop"

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -56,7 +56,7 @@ module Pharos
         begin
           local_port = next_port
           @session.forward.local(local_port, host, port)
-          logger.debug "Opened port forward 127.0.0.1#{local_port} -> #{host}:#{port}"
+          logger.debug "Opened port forward 127.0.0.1:#{local_port} -> #{host}:#{port}"
         rescue Errno::EADDRINUSE
           retry
         end
@@ -117,7 +117,7 @@ module Pharos
       def ensure_event_loop
         synchronize do
           @event_loop ||= Thread.new do
-            Thread.current.report_on_exception = true
+            Thread.current.report_on_exception = logger.level == Logger::DEBUG
             logger.debug "Started SSH event loop"
             @session.loop(0.1) { @session.busy?(true) || !@session.forward.active_locals.empty? }
           rescue IOError, Errno::EBADF => ex

--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "clamp", "1.2.1"
   spec.add_runtime_dependency "pastel", "~> 0.7"
   spec.add_runtime_dependency "net-ssh", "~> 5.2.0"
-  spec.add_runtime_dependency "net-ssh-gateway", "2.0.0"
   spec.add_runtime_dependency "ed25519", "~> 1.2"
   spec.add_runtime_dependency "bcrypt", "~> 3.1"
   spec.add_runtime_dependency "bcrypt_pbkdf", "~> 1.0"

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -165,7 +165,7 @@ describe Pharos::Config do
 
         it 'creates a kube client through ssh' do
           expect(Pharos::Kube).to receive(:client).with('localhost', kubeconfig, 9999)
-          expect(ssh).to receive(:gateway).with('api.example.com', 6443).and_return(9999)
+          expect(ssh).to receive(:forward).with('api.example.com', 6443).and_return(9999)
           subject.kube_client(kubeconfig)
         end
       end


### PR DESCRIPTION
The Net::SSH::Gateway class is [rather simple](https://github.com/net-ssh/net-ssh-gateway/blob/master/lib/net/ssh/gateway.rb), but still a bit inflexible.

For example, it does not allow reusing an existing connection and a new one will be always opened for each gateway.

Port forwarding on Net::SSH is quite simple:

> ### "Um, all I want to do is X, just show me how!"
> #### X == "forward connections on a local port to a remote host"
> ```
> Net::SSH.start("host", "user", :password => "password") do |ssh|
>   ssh.forward.local(1234, "www.google.com", 80)
>   ssh.loop { true }
> end
> ```

The IOError rescue retries are there to make it automatically reconnect both self + tunnel in case the tunnel has died. (The current connection does not know if the underlying tunnel has disconnected until it tries to send / receive)

This on its own doesn't fix anything (because it's missing all the host/bastion dereferencing et all), but having this could simplify #1090 and #1003 

