### PR TITLE
Allow to disable node local DNS cache

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -100,6 +100,7 @@ module Pharos
           optional(:dns_replicas).filled(:int?, gt?: 0)
           optional(:service_cidr).filled(:str?)
           optional(:pod_network_cidr).filled(:str?)
+          optional(:node_local_dns_cache).filled(:bool?)
           optional(:firewalld).schema do
             required(:enabled).filled(:bool?)
             optional(:open_ports).filled do

--- a/lib/pharos/configuration/network.rb
+++ b/lib/pharos/configuration/network.rb
@@ -75,6 +75,7 @@ module Pharos
       attribute :dns_replicas, Pharos::Types::Integer
       attribute :service_cidr, Pharos::Types::String.default('10.96.0.0/12')
       attribute :pod_network_cidr, Pharos::Types::String.default('10.32.0.0/12')
+      attribute :node_local_dns_cache, Pharos::Types::Bool.default(true)
       attribute :firewalld, Firewalld
       attribute :weave, Weave
       attribute :calico, Calico

--- a/lib/pharos/kubeadm/kubelet_config.rb
+++ b/lib/pharos/kubeadm/kubelet_config.rb
@@ -22,11 +22,11 @@ module Pharos
             }
           },
           'serverTLSBootstrap' => true,
-          'tlsCipherSuites' => ClusterConfig::TLS_CIPHERS.split(','),
-          'clusterDNS' => [
-            Pharos::Configuration::Network::CLUSTER_DNS
-          ]
+          'tlsCipherSuites' => ClusterConfig::TLS_CIPHERS.split(',')
         }
+
+        config['clusterDNS'] = [Pharos::Configuration::Network::CLUSTER_DNS] if @config.network.node_local_dns_cache
+
         if @config.kubelet&.read_only_port
           config['readOnlyPort'] = 10_255
         end

--- a/lib/pharos/phases/configure_dns.rb
+++ b/lib/pharos/phases/configure_dns.rb
@@ -3,6 +3,8 @@
 module Pharos
   module Phases
     class ConfigureDNS < Pharos::Phase
+      DNS_CACHE_STACK_NAME = 'node_local_dns'
+
       title "Configure DNS"
 
       register_component(
@@ -21,7 +23,12 @@ module Pharos
           max_unavailable: max_unavailable
         )
 
-        deploy_node_dns_cache
+        if @config.network.node_local_dns_cache
+          deploy_node_dns_cache
+        else
+          logger.info { "Removing node dns cache ..." }
+          delete_stack(DNS_CACHE_STACK_NAME)
+        end
       end
 
       # @return [Integer]
@@ -105,7 +112,7 @@ module Pharos
       def deploy_node_dns_cache
         logger.info { "Deploying node dns cache ..." }
         apply_stack(
-          'node_local_dns',
+          DNS_CACHE_STACK_NAME,
           version: Pharos::DNS_NODE_CACHE_VERSION,
           image_repository: @config.image_repository,
           nodelocal_dns: Pharos::Configuration::Network::CLUSTER_DNS,


### PR DESCRIPTION
Node local DNS cache can be disabled with:
```
network:
  node_local_dns_cache: false
```

`node_local_dns_cache` defaults to `true`.

fixes #1187 

Needs docs PR too.