### PR TITLE
Add missing flags for tf destroy

### DIFF
--- a/lib/pharos/terraform/apply_command.rb
+++ b/lib/pharos/terraform/apply_command.rb
@@ -6,8 +6,7 @@ module Pharos
   module Terraform
     class ApplyCommand < BaseCommand
       options :load_config
-      option "--var", "VAR", "set a variable in the terraform configuration.", multivalued: true
-      option "--var-file", "FILE", 'set variables in the terraform configuration from a file (default: terraform.tfvars or any .auto.tfvars)'
+
       option ['-f', '--force'], :flag, "force upgrade"
 
       def execute
@@ -23,9 +22,7 @@ module Pharos
 
       def tf_apply
         cmd = ["terraform", "apply"]
-        cmd << "-auto-approve" if yes?
-        cmd << "-var-file #{var_file}" if var_file
-        cmd += var_list.map { |var| "-var #{var}" } if var_list
+        cmd += common_tf_options
 
         run_cmd! cmd.join(' ')
       end

--- a/lib/pharos/terraform/base_command.rb
+++ b/lib/pharos/terraform/base_command.rb
@@ -8,6 +8,9 @@ module Pharos
       options :yes?
 
       option "--workspace", "NAME", "terraform workspace", default: "default"
+      option "--var", "VAR", "set a variable in the terraform configuration.", multivalued: true
+      option "--var-file", "FILE", 'set variables in the terraform configuration from a file (default: terraform.tfvars or any .auto.tfvars)'
+      option "--state", "PATH", "Path to the state file. Defaults to 'terraform.tfstate'."
 
       def tf_workspace
         return 0 if run_cmd("terraform workspace select #{workspace} 2> /dev/null")
@@ -28,6 +31,18 @@ module Pharos
       # @return [Boolean]
       def run_cmd(cmd)
         system(cmd)
+      end
+
+      # Returns common options for both apply and destroy commands.
+      # @return [Array<String>]
+      def common_tf_options
+        opts = []
+        opts << "-auto-approve" if yes?
+        opts << "-state #{state}" if state
+        opts << "-var-file #{var_file}" if var_file
+        opts += var_list.map { |var| "-var #{var}" } if var_list
+
+        opts
       end
     end
   end

--- a/lib/pharos/terraform/destroy_command.rb
+++ b/lib/pharos/terraform/destroy_command.rb
@@ -12,7 +12,7 @@ module Pharos
 
       def tf_destroy
         cmd = ["terraform", "destroy"]
-        cmd << "-auto-approve" if yes?
+        cmd += common_tf_options
 
         run_cmd!(cmd.join(' '))
         unless workspace == 'default'


### PR DESCRIPTION
As all the flags for TF `apply` & `destroy` commands are the [same](https://www.terraform.io/docs/commands/destroy.html#usage) moved handling of those into the base.

Added also `--state` flag to point to other than default state file.

fixes #1190 