### PR TITLE
Pro: pharos license assign for another cluster

### DIFF
--- a/non-oss/pharos_pro/commands/license_assign_command.rb
+++ b/non-oss/pharos_pro/commands/license_assign_command.rb
@@ -8,9 +8,8 @@ module Pharos
 
     parameter "[LICENSE_KEY]", "kontena pharos license key (default: <stdin>)"
     option '--description', 'DESCRIPTION', "license description [DEPRECATED]", hidden: true
-    option '--print-subscription-token', :flag, 'only output subscription token'
 
-    option '--cluster-id', '[ID]', 'request for a specified cluster id (requires --cluster-name)' do |cluster_id|
+    option '--cluster-id', '[ID]', 'request for a specified cluster id. outputs the subscription token. (requires --cluster-name)' do |cluster_id|
       @cluster_id_given = true
       cluster_id
     end
@@ -27,7 +26,7 @@ module Pharos
       signal_usage_error '--cluster-name required when --cluster-id given' if @cluster_id_given && !@cluster_name_given
       signal_usage_error '--cluster-id required when --cluster-name given' if @cluster_name_given && !@cluster_id_given
 
-      if print_subscription_token?
+      if @cluster_id_given
         puts jwt_token.token
         return
       end

--- a/non-oss/pharos_pro/commands/license_inspect_command.rb
+++ b/non-oss/pharos_pro/commands/license_inspect_command.rb
@@ -10,6 +10,7 @@ module Pharos
 
     option '--subscription-token', '[TOKEN]', 'pharos license subscription token'
     option '--cluster-id', '[ID]', 'pharos cluster id'
+    option '--print-cluster-info', :flag, "output cluster information only"
 
     def prepare_config
       return if @prepared_config
@@ -33,6 +34,11 @@ module Pharos
     end
 
     def execute
+      if print_cluster_info?
+        puts cluster_info
+        return
+      end
+
       puts [license_type, owner, valid_until, contact_note].compact
 
       exit 1 unless valid?
@@ -105,6 +111,10 @@ module Pharos
       return if license_key.nil?
 
       "Licensed to #{license_key.owner.cyan}"
+    end
+
+    def cluster_info
+      "Cluster ID: #{cluster_id.cyan}\nCluster name: #{load_config.name.cyan}"
     end
 
     def contact_note

--- a/non-oss/pharos_pro/commands/license_inspect_command.rb
+++ b/non-oss/pharos_pro/commands/license_inspect_command.rb
@@ -10,7 +10,7 @@ module Pharos
 
     option '--subscription-token', '[TOKEN]', 'pharos license subscription token'
     option '--cluster-id', '[ID]', 'pharos cluster id'
-    option '--print-cluster-info', :flag, "output cluster information only"
+    option '--cluster-info', :flag, "output cluster information only", attribute_name: :print_cluster_info
 
     def prepare_config
       return if @prepared_config

--- a/non-oss/spec/pharos_pro/commands/license_assign_command_spec.rb
+++ b/non-oss/spec/pharos_pro/commands/license_assign_command_spec.rb
@@ -45,7 +45,7 @@ describe Pharos::LicenseAssignCommand do
       end
     end
 
-    context '--print-subscription-token, --cluster-name and --cluster-id given' do
+    context '--cluster-name and --cluster-id given' do
       it 'assigns a license without loading configuration and outputs jwt' do
         expect(http_client).to receive(:post).and_return(double(body: success_response))
         expect(subject).not_to receive(:cluster_manager)
@@ -65,13 +65,6 @@ describe Pharos::LicenseAssignCommand do
     it 'runs kubectl on master' do
       expect(ssh).to receive(:exec!).with("kubectl create secret generic pharos-license --namespace=kube-system --from-literal='license.jwt=123' --dry-run -o yaml | kubectl apply -f -")
       expect{subject.run([license_key])}.to output(/Assigned the subscription token/).to_stdout
-    end
-
-    context '--print-subscription-token given' do
-      it 'outputs the subscription token jwt' do
-        allow(ssh).to receive(:exec!).with("kubectl create secret generic pharos-license --namespace=kube-system --from-literal='license.jwt=123' --dry-run -o yaml | kubectl apply -f -")
-        expect{subject.run(['--print-subscription-token', license_key])}.to output(/^123$/m).to_stdout
-      end
     end
   end
 end

--- a/non-oss/spec/pharos_pro/commands/license_assign_command_spec.rb
+++ b/non-oss/spec/pharos_pro/commands/license_assign_command_spec.rb
@@ -50,7 +50,7 @@ describe Pharos::LicenseAssignCommand do
         expect(http_client).to receive(:post).and_return(double(body: success_response))
         expect(subject).not_to receive(:cluster_manager)
         expect(subject).not_to receive(:load_config)
-        expect{subject.run(%w(--print-subscription-token --cluster-id 6c6289c0-1fb0-11e9-bac4-02f41f34da68 --cluster-name defg) + [license_key])}.to output("123\n").to_stdout
+        expect{subject.run(%w(--cluster-id 6c6289c0-1fb0-11e9-bac4-02f41f34da68 --cluster-name defg) + [license_key])}.to output("123\n").to_stdout
       end
     end
 


### PR DESCRIPTION
Fixes #1194 

Makes it possible to assign a license to another cluster by giving `--cluster-id` and `--cluster-name`. The `--config` is not needed in that case and there will be no attempt to connect to the cluster.

```
$ pharos license assign --cluster-id abcd --cluster-name foo abcd-defg-123
FDSKJVNDSKJNVkjdsnvcksdjnckdsjnckjsd.CJDNkcjdsnkcjdnskcjn.dskvdsvdsv
$ pharos license assign --cluster-id abcd --cluster-name foo abcd-defg-123
ERROR: License is already in use
````

The `pharos license inspect` can output the cluster id and name with `--cluster-info`:

```
$ pharos license inspect -c cluster.yml --cluster-info
=> Sharpening tools ...
...
...
Cluster ID: 37cxxveb-4961-11e9-9xxx51-0yyy1f34da68
Cluster name: lively-sound-7972
```
