### PR TITLE
Fix misleading error message when ping command missing

### DIFF
--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -52,6 +52,7 @@ module Pharos
 
       def validate_localhost_resolve
         return if transport.exec?("ping -c 1 -r -w 1 localhost")
+        raise Pharos::InvalidHostError, "Host does not have the 'ping' command installed" unless transport.exec?('command -v ping')
 
         raise Pharos::InvalidHostError, "Hostname 'localhost' does not seem to resolve to an address on the local host"
       end


### PR DESCRIPTION
Fixes #1176

A minimal fix for the issue. For the bigger picture of missing package installation / host-configurer prerequisites validation there's another issue #1201

