### PR TITLE
Increase exec error verbosity

### DIFF
--- a/lib/pharos/error.rb
+++ b/lib/pharos/error.rb
@@ -34,7 +34,7 @@ module Pharos
     end
 
     def message
-      "exec failed with code #{@exit_status}: #{@cmd}\n#{@output}"
+      "exec failed with code #{@exit_status}: #{@cmd}\n#{@output.gsub(/^/m, '  ')}"
     end
   end
 end

--- a/lib/pharos/logging.rb
+++ b/lib/pharos/logging.rb
@@ -13,17 +13,11 @@ module Pharos
     end
 
     def self.format_exception(exc, severity = "ERROR")
-      return exc unless exc.is_a?(Exception)
-
-      if ENV["DEBUG"] || severity == "DEBUG"
-        message = exc.message.strip
+      if !ENV['DEBUG'].to_s.empty? || severity == "DEBUG"
         backtrace = "\n    #{exc.backtrace.join("\n    ")}"
-      else
-        message = exc.message[/\A(.+?)$/m, 1]
-        backtrace = nil
       end
 
-      "Error: #{message}#{backtrace}"
+      "Error: #{exc.message.strip}#{backtrace}"
     end
 
     def self.log_level
@@ -34,8 +28,9 @@ module Pharos
       @logger ||= Logger.new($stdout).tap do |logger|
         logger.progname = 'API'
         logger.level = Pharos::Logging.log_level
-        logger.formatter = proc do |_severity, _datetime, _progname, msg|
-          "    %<msg>s\n" % { msg: msg }
+        logger.formatter = proc do |severity, _datetime, _progname, msg|
+          message = msg.is_a?(Exception) ? Pharos::Logging.format_exception(msg, severity) : msg
+          "    %<msg>s\n" % { msg: message }
         end
       end
     end

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -36,23 +36,26 @@ module Pharos
       @host.transport
     end
 
-    FORMATTER_COLOR = proc do |severity, _datetime, progname, msg|
-      message = Pharos::Logging.format_exception(msg, severity)
+    FORMATTER_COLOR = proc do |severity, _datetime, hostname, msg|
+      message = msg.is_a?(Exception) ? Pharos::Logging.format_exception(msg, severity) : msg
+
       color = case severity
               when "DEBUG" then :dim
               when "INFO" then :to_s
               when "WARN" then :yellow
               else :red
               end
-      "    [%<progname>s] %<msg>s\n" % { progname: progname.send(color), msg: message }
+
+      message.gsub(/^/m) { "    [#{hostname.send(color)}] " } + "\n"
     end
 
-    FORMATTER_NO_COLOR = proc do |severity, _datetime, progname, msg|
-      message = Pharos::Logging.format_exception(msg, severity)
+    FORMATTER_NO_COLOR = proc do |severity, _datetime, hostname, msg|
+      message = msg.is_a?(Exception) ? Pharos::Logging.format_exception(msg, severity) : msg
+
       if severity == "INFO"
-        "    [%<progname>s] %<msg>s\n" % { progname: progname, msg: message }
+        message.gsub(/^/m) { "    [#{hostname}] " } + "\n"
       else
-        "    [%<progname>s] [%<severity>s] %<msg>s\n" % { progname: progname, severity: severity, msg: message }
+        message.gsub(/^/m) { "    [#{hostname}] [#{severity}] " } + "\n"
       end
     end
 


### PR DESCRIPTION
Displays all of the error message lines but indents/prefixes them with the hostname column.

![image](https://user-images.githubusercontent.com/224971/54606033-56c4f480-4a53-11e9-99db-0b25106319c4.png)
