### PR TITLE
Release v2.3.0-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.0-beta.2"
+  VERSION = "2.3.0-rc.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.3.0-beta.2

- Cri-o v1.13.3 & arm64 support (#1193)
- Add missing flags for tf destroy (#1192)
- Allow to disable node local DNS cache (#1189)
- Add host ssh_port option (#1191)
- Enforcer as static pods (#1200) [Pro, EE]
- License assign for another cluster (#1199) [Pro, EE]
- Pharos dev console (#1156)
- helm addon: fix chart name env (#1197)
- Fix global option parsing and phase thread error handling (#1142)
- Drop Net::SSH::Gateway dependency (#1185)
- Minimal fix for misleading error message when ping command missing (#1202)
- Download el7 cfssl from pharos repo (#1196)
- Increase exec error verbosity (#1203)
- Add Addon#to_s to improve spec error messages (#1165)
- e2e: tag droplets for easier gc (#1195)