### PR TITLE
Kontena Lens to 1.5.0

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -4,7 +4,7 @@ require 'bcrypt'
 require 'json'
 
 Pharos.addon 'kontena-lens' do
-  version '1.5.0-rc.2'
+  version '1.5.0'
   license 'Kontena License'
   priority 10
 


### PR DESCRIPTION
## Changelog
- Quality of Services (QoS) classes are for pods are displayed on pod list and details
- Service's type is now displayed on services list
- Rolebindings can be now created when user management is disabled
- Search fields are now focused by default, just start typing to find the resource
- Path based ingress rules are correctly displayed
- Readiness and liveness probes are displayed now in pod details
- Helm releases can be edited, rollbacked and upgraded
- User can now give a name for a Helm release when installing a chart
- Keywords and repository are displayed on Helm chart details
- Helm search has been improved and now also keywords are taken into an account
- User can enter into a node shell directly from the dashboard
- IE users might not see everything as planned. We display nice notification for those users now and hint to switch the browser.
- Kontena Pharos license information is displayed on the dashboard and user can easily assign a license to the cluster
- Labels column did not spark any joy on configmap list, so it's thrown away
- To make it easier to remove orphaned PVCs, dashboard will now show the pods where the volume claim is bound
- Some pods can have secrets and configmaps exposed via environment variables. Kontena Lens will show those relations better now
- Terminal window has now a better full screen mode