### PR TITLE
Release v2.3.0

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.0-rc.1"
+  VERSION = "2.3.0"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since 2.2.x

- Kontena Lens 1.5.0 (#1205, #1130, #1129, #1160, #1183) [Pro]
- Improved Terraform integration: pharos tf apply/destroy (#1087, #1145, #1192)
- Weave multi-cluster pod network (#1058, #1100)
- Calico 3.6 (#1085, #1172)
- Node local DNS cache (#1114, #1189)
- Allow to install system-level helm charts via helm addon (#1162, #1197)
- Kubernetes 1.13.4 (#1149)
- Kontena-backup v0.9.11+kontena.1 (#1107) [Pro]
- Cri-o v1.13.3 & arm64 support (#1193)
- Set or generate names for clusters (#1134)
- Allow to enable feature gates (#1155)
- Add host ssh_port option (#1191)
- License enforcement addon (#1101, #1094, #1115, #1128, #1127, #1148, #1159, #1157, #1161, #1200, #1214) [Pro]
- License assign for another cluster (#1199) [Pro]
- Pharos dev console (#1156)
- Fix global option parsing and phase thread error handling (#1142)
- Drop Net::SSH::Gateway dependency (#1185)
- Minimal fix for misleading error message when ping command missing (#1202)
- Download el7 cfssl from pharos repo (#1196)
- Increase exec error verbosity (#1203)
- Add Addon#to_s to improve spec error messages (#1165)
- e2e: tag droplets for easier gc (#1195)
- Improve oss upgrade warning (#1177)
- Reduce retry logging verbosity (#1175)
- Allow to use custom node roles for workers (#1181)
- Add missing terraform.examples.tfvars to packet example (#1169)
- Upgrade net-ssh to 5.2.0 (#1158)
- Drop IPAddr Loopback backport usage (#1133)
- Fix Host#local? raising IPAddr::InvalidAddressError (#1137)
- Add --tf-json to pharos reset command (#1139)
- Update kubeadm config schemas to v1beta1 (#1140)
- Use cdn for downloading bintray public key (#1144)
- Decorate output based on message severity (#1146)
- Read cluster name from pharos-config on license assign (#1147) [Pro]
- Fix generated node selectors for nginx-ingress (#1150)
- Increase Lens Helm API memory limit (#1153) [Pro]
- Reconfigure kubelet on kubelet-config change (#1113)
- Generic env handling for calico, including enabling metrics (#1079)
- Localhost access without SSH (#1044, #1095, #1098)
- Extract Host::ResolvConf and Route into separate files (#1049)
- Use csi volume provider on digitalocean (#1093)
- Simplify the config option copying for kubeconfig hint (#1099)
- Fix DeepTransformKeys and spec (#1091)
- Refactor output colorization (#802, #1103)
- Export complete HTTP proxy environment (#1112)
- Also run OSS specs during NON-OSS spec run (#1078)
- Add dev gems to Gemfile, drop Gemfile.lock from VCS (#1045)
- Fix failing addon manager spec (#1117)
- Load addons using AddonContext instance_eval (#1108)
- Fix ED25519 passphrase prompting (#1213)
- Fix enforcer check interval (#1214)