### PR TITLE
Fix SSH event loop deadlock

### DIFF
--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -119,7 +119,12 @@ module Pharos
           @event_loop ||= Thread.new do
             Thread.current.report_on_exception = logger.level == Logger::DEBUG
             logger.debug "Started SSH event loop"
-            @session.loop(0.1) { @session.busy?(true) || !@session.forward.active_locals.empty? }
+            while @session
+              synchronize do
+                @session.process(0.1)
+              end
+              Thread.pass
+            end
           rescue IOError, Errno::EBADF => ex
             logger.debug "Received #{ex.class.name} (expected when tunnel has been closed)"
           ensure


### PR DESCRIPTION
Fixes #1206

SSH exec was `session.loop`ing in another thread and causing a conflict with the event loop thread.

Before:

```
[1] pry(#<Pharos::UpCommand>)> load_config.hosts.first.transport.exec('ls -al')
=> #<Pharos::Transport::Command::Result:0x00007fc508d101d0
 @output=
  "total 32\ndrwxr-xr-x 5 vagrant vagrant 4096 Mar 18 09:35 .\ndrwxr-xr-x 4 root    root    4096 Mar 18 09:27 ..\n-rw-r--r-- 1 vagrant vagrant  220 Mar  6  2018 .bash_logout\n-rw-r--r-- 1 vagrant vagrant 3771 Mar  6  2018 .bashrc\ndrwx------ 2 vagrant vagrant 4096 Mar 18 09:27 .cache\ndrwx------ 4 vagrant vagrant 4096 Mar 19 11:22 .kube\n-rw-r--r-- 1 vagrant vagrant  655 Mar  6  2018 .profile\ndrwx------ 2 vagrant vagrant 4096 Mar  6  2018 .ssh\n">

[2] pry(#<Pharos::UpCommand>)> load_config.hosts.first.bastion.host.transport.exec('ls -al')
^CInterrupt:
```

After:

```
[1] pry(#<Pharos::UpCommand>)> load_config.hosts.first.transport.exec('ls -al')
=> #<Pharos::Transport::Command::Result:0x00007fc508d101d0
 @output=
  "total 32\ndrwxr-xr-x 5 vagrant vagrant 4096 Mar 18 09:35 .\ndrwxr-xr-x 4 root    root    4096 Mar 18 09:27 ..\n-rw-r--r-- 1 vagrant vagrant  220 Mar  6  2018 .bash_logout\n-rw-r--r-- 1 vagrant vagrant 3771 Mar  6  2018 .bashrc\ndrwx------ 2 vagrant vagrant 4096 Mar 18 09:27 .cache\ndrwx------ 4 vagrant vagrant 4096 Mar 19 11:22 .kube\n-rw-r--r-- 1 vagrant vagrant  655 Mar  6  2018 .profile\ndrwx------ 2 vagrant vagrant 4096 Mar  6  2018 .ssh\n">

[2] pry(#<Pharos::UpCommand>)> load_config.hosts.first.bastion.host.transport.exec('ls -al')
=> #<Pharos::Transport::Command::Result:0x00007f82483d7c88
 @output=
  "total 40\ndrwxr-xr-x 4 vagrant vagrant 4096 Mar 19 07:32 .\ndrwxr-xr-x 4 root    root    4096 Mar 18 09:28 ..\n-rw------- 1 vagrant vagrant 1329 Mar 19 08:25 .bash_history\n-rw-r--r-- 1 vagrant vagrant  220 Mar  6  2018 .bash_logout\n-rw-r--r-- 1 vagrant vagrant 3771 Mar  6  2018 .bashrc\ndrwx------ 2 vagrant vagrant 4096 Mar 18 09:28 .cache\n-rw-rw-r-- 1 vagrant vagrant    0 Mar 18 09:28 .cloud-locale-test.skip\n-rw------- 1 vagrant vagrant   32 Mar 19 07:32 .lesshst\n-rw-r--r-- 1 vagrant vagrant  655 Mar  6  2018 .profile\ndrwx------ 2 vagrant vagrant 4096 Mar  6  2018 .ssh\n-rw------- 1 root    root     679 Mar 18 09:29 .viminfo\n"
```
