### PR TITLE
Share existing SSH connections for port forwarding and detect multi-hop bastion

### DIFF
--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -33,6 +33,29 @@ module Pharos
       config = new(schema_data)
       config.data = raw_data.freeze
 
+      config.hosts.reject { |h| h.bastion.nil? }.each do |host_a|
+        host_b = config.hosts.find { |host| host_a.bastion.attributes_match?(host.attributes) }
+        next unless host_b
+
+        # Creating a new Pharos::Configuration::Bastion entry because otherwise it's an anonymous class
+        host_a.attributes[:bastion] = Pharos::Configuration::Bastion.new(host_a.bastion.attributes).tap { |bastion| bastion.host = host_b }
+
+        if host_a == host_b
+          raise Pharos::ConfigError, 'hosts' => { config.hosts.index(host_a) => ["host and its bastion point to the same address and port (#{host_a.address}:#{host_a.ssh_port})"] }
+        end
+
+        if host_b.bastion
+          raise Pharos::ConfigError, 'hosts' => { config.hosts.index(host_a) => ["multi-hop bastion not supported (#{host_a.address}:#{host_a.ssh_port} -> #{host_a.bastion.address}:#{host_a.bastion.ssh_port} -> #{host_b.bastion.address}:#{host_b.bastion.ssh_port}"] }
+        end
+      end
+
+      # de-duplicate bastions (if two hosts share an identical bastion, make it the same object to avoid multiple gateways)
+      config.hosts.reject { |h| h.bastion.nil? }.permutation(2) do |host_a, host_b|
+        if host_a.bastion.attributes == host_b.bastion.attributes && host_a.bastion.object_id != host_b.bastion.object_id
+          host_b.attributes[:bastion] = host_a.bastion
+        end
+      end
+
       # inject api_endpoint & config reference to each host object
       config.hosts.each do |host|
         host.api_endpoint = config.api&.endpoint

--- a/lib/pharos/configuration/bastion.rb
+++ b/lib/pharos/configuration/bastion.rb
@@ -11,7 +11,7 @@ module Pharos
       attr_writer :host
 
       # @param other [Hash]
-      # @return [Boolean] true when all attributes of the instance match the other
+      # @return [Boolean] true when all attributes of this instance match the input hash
       def attributes_match?(other)
         attributes.all? { |key, value| other[key] == value }
       end

--- a/lib/pharos/configuration/bastion.rb
+++ b/lib/pharos/configuration/bastion.rb
@@ -7,7 +7,15 @@ module Pharos
       attribute :user, Pharos::Types::Strict::String
       attribute :ssh_key_path, Pharos::Types::Strict::String
       attribute :ssh_port, Pharos::Types::Strict::Integer.default(22)
-      attribute :ssh_proxy_command, Pharos::Types::Strict::String
+
+      attr_writer :host
+
+      # Returns true when all attributes of the instance match the hash. Extra keys in the hash will be ignored.
+      # @param other [Hash]
+      # @return [Boolean]
+      def attributes_match?(other)
+        attributes.all? { |key, value| other[key] == value }
+      end
 
       def host
         @host ||= Host.new(attributes)

--- a/lib/pharos/configuration/bastion.rb
+++ b/lib/pharos/configuration/bastion.rb
@@ -10,9 +10,8 @@ module Pharos
 
       attr_writer :host
 
-      # Returns true when all attributes of the instance match the hash. Extra keys in the hash will be ignored.
       # @param other [Hash]
-      # @return [Boolean]
+      # @return [Boolean] true when all attributes of the instance match the other
       def attributes_match?(other)
         attributes.all? { |key, value| other[key] == value }
       end

--- a/lib/pharos/phases/connect_ssh.rb
+++ b/lib/pharos/phases/connect_ssh.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Open SSH connection"
 
       def call
-        host.transport.connect
+        host.transport.connect unless host.transport.connected?
       end
     end
   end

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -65,11 +65,16 @@ module Pharos
       def forward(host, port)
         connect unless connected?
 
+        local_port = next_port
+
         begin
-          local_port = next_port
-          @session.forward.local(local_port, host, port)
-          logger.debug "Opened port forward 127.0.0.1:#{local_port} -> #{host}:#{port}"
+          synchronize do
+            @session.forward.local(local_port, host, port)
+            logger.debug "Opened port forward 127.0.0.1:#{local_port} -> #{host}:#{port}"
+          end
         rescue Errno::EADDRINUSE
+          logger.debug "Port #{local_port} in use, trying next one"
+          local_port = next_port
           retry
         end
 

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -44,8 +44,8 @@ module Pharos
             @session = session_factory.start(@host, @user, @opts.merge(options).merge(non_interactive: non_interactive))
             logger.debug "Connected"
             class_mutex.unlock if class_mutex.locked? && class_mutex.owned?
-          rescue *RETRY_CONNECTION_ERRORS => exc
-            logger.debug "Received #{exc.class.name} : #{exc.message} when connecting to #{@user}@#{@host}"
+          rescue *RETRY_CONNECTION_ERRORS => e
+            logger.debug "Received #{e.class.name} : #{e.message} when connecting to #{@user}@#{@host}"
             raise if non_interactive == false || !$stdin.tty? # don't re-retry
 
             logger.debug { "Retrying in interactive mode" }


### PR DESCRIPTION
Fixes #1072 

- Makes identical bastion hosts refer to the same object.
  * **Before:** a new ssh session to the bastion host was opened for every host using it.
  * **After:** only one ssh session to the bastion host is opened and each host session is just another port forward on the same connection.
- Makes `bastion.host` refer to actual hosts in the config if all the bastion's attributes match one of the config `hosts:` host's attributes (address, ssh_port, user, ssh key, ..)
  * **Before:** two sessions would have been opened
  * **After:** the existing session for the host is used
- Detects multi-hop bastion (this could be made to work but maybe it isn't worth it):
  * **Before:** actually the port forward is from the first hop to target.
  * **After:** the problem is detected and an error is reported
- Detects bastion address / credentials being identical with the parent host. 
  * **Before:** two sessions are opened
  * **After:** the problem is detected and an error is reported
  * **Note:** This is perhaps unnecessary and counter productive  as it does exactly what has been asked and it works. When using TF for example, it might be easier to just let the one double-connection slip than to try to get one of the hosts not have the bastion configured (tf json parser does not handle per-host customizations very well).


