### PR TITLE
Fix ED25519 passphrase prompting

### DIFF
--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -9,7 +9,8 @@ module Pharos
 
       RETRY_CONNECTION_ERRORS = [
         Net::SSH::AuthenticationFailed,
-        Net::SSH::Authentication::KeyManagerError
+        Net::SSH::Authentication::KeyManagerError,
+        Net::SSH::Authentication::ED25519::OpenSSHPrivateKeyLoader::DecryptError
       ].freeze
 
       # @param host [String]


### PR DESCRIPTION
Fixes #1055

#1158 just upgraded Net::SSH, but the behavior did not actually change.

It used to raise ArgumentError, but that was fixed. Now it raises `Net::SSH::Authentication::ED25519::OpenSSHPrivateKeyLoader::DecryptError` which needed to be added to `SSH::RETRY_EXCEPTIONS`.


