### PR TITLE
Fix version validation when cluster SSL has expired or is invalid

### DIFF
--- a/lib/pharos/phases/validate_version.rb
+++ b/lib/pharos/phases/validate_version.rb
@@ -8,20 +8,11 @@ module Pharos
       title "Validate cluster version"
 
       include Pharos::Phases::Mixins::ClusterVersion
-      REMOTE_KUBECONFIG = "/etc/kubernetes/admin.conf"
 
       def call
-        return unless kubeconfig?
+        return unless cluster_context['previous-config-map']
 
-        if @host.master_sort_score.positive?
-          logger.warn { "Master seems unhealthy, can't detect cluster version." }
-          return
-        end
-
-        cluster_context['kubeconfig'] = kubeconfig
-        config_map = previous_config_map
-        if config_map
-          existing_version = config_map.data['pharos-version']
+        if existing_version = cluster_context['previous-config-map'].data['pharos-version']
           cluster_context['existing-pharos-version'] = existing_version
           validate_version(existing_version)
         else
@@ -40,43 +31,6 @@ module Pharos
           logger.warn { "Invalid cluster version detected: #{cluster_version}" }
           cluster_context['unsafe_upgrade'] = true
         end
-      end
-
-      # @return [String]
-      def kubeconfig?
-        transport.file(REMOTE_KUBECONFIG).exist?
-      end
-
-      # @return [String]
-      def read_kubeconfig
-        transport.file(REMOTE_KUBECONFIG).read
-      end
-
-      # @return [Hash]
-      def kubeconfig
-        logger.debug { "Fetching kubectl config ..." }
-        config = Pharos::Kube::Config.new(read_kubeconfig)
-        config.update_server_address(@host.api_address)
-
-        logger.debug { "New config: #{config}" }
-        config.to_h
-      end
-
-      # @return [K8s::Resource, nil]
-      def previous_config_map
-        original_ssl_verify_peer = kube_client.transport.options[:ssl_verify_peer]
-
-        kube_client.api('v1').resource('configmaps', namespace: 'kube-system').get('pharos-config')
-      rescue Excon::Error::Socket => ex
-        raise if !kube_client.transport.options[:ssl_verify_peer] # don't retry if ssl verify is false
-
-        kube_client.transport.options[:ssl_verify_peer] = false
-        logger.warn { "Encountered #{ex.class.name} : #{ex.message} - retrying with ssl verify peer disabled" }
-        retry
-      rescue K8s::Error::NotFound
-        nil
-      ensure
-        kube_client.transport.options[:ssl_verify_peer] = original_ssl_verify_peer
       end
 
       private


### PR DESCRIPTION
Fixes #1219 

This PR makes LoadClusterConfiguration retry the K8s client requests with SSL check turned off.

The ValidateVersion phase does not need to fetch the configs, the LoadClusterConfiguration has already done that.
