### PR TITLE
Drop the "optional:" keyword from ConfigureClient phase

### DIFF
--- a/lib/pharos/cluster_manager.rb
+++ b/lib/pharos/cluster_manager.rb
@@ -58,7 +58,7 @@ module Pharos
     def gather_facts
       apply_phase(Phases::ConnectSSH, config.hosts.reject(&:local?), parallel: true)
       apply_phase(Phases::GatherFacts, config.hosts, parallel: true)
-      apply_phase(Phases::ConfigureClient, [config.master_host], parallel: false, optional: true)
+      apply_phase(Phases::ConfigureClient, [config.master_host], parallel: false)
       apply_phase(Phases::LoadClusterConfiguration, [config.master_host]) if config.master_host.master_sort_score.zero?
       apply_phase(Phases::ConfigureClusterName, %w(localhost))
     end
@@ -78,7 +78,7 @@ module Pharos
       apply_phase(Phases::MigrateMaster, master_hosts, parallel: true)
       apply_phase(Phases::ConfigureHost, config.hosts, parallel: true)
       apply_phase(Phases::ConfigureFirewalld, config.hosts, parallel: true)
-      apply_phase(Phases::ConfigureClient, master_only, parallel: false, optional: true)
+      apply_phase(Phases::ConfigureClient, master_only, parallel: false)
 
       unless @config.etcd&.endpoints
         etcd_hosts = config.etcd_hosts
@@ -90,7 +90,7 @@ module Pharos
 
       apply_phase(Phases::ConfigureSecretsEncryption, master_hosts, parallel: false)
       apply_phase(Phases::SetupMaster, master_hosts, parallel: true)
-      apply_phase(Phases::UpgradeMaster, master_hosts, parallel: false) # requires optional early ConfigureClient
+      apply_phase(Phases::UpgradeMaster, master_hosts, parallel: false)
 
       apply_phase(Phases::MigrateWorker, config.worker_hosts, parallel: true)
       apply_phase(Phases::ConfigureKubelet, config.hosts, parallel: true)

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -8,22 +8,27 @@ module Pharos
       REMOTE_FILE = "/etc/kubernetes/admin.conf"
 
       def call
-        return unless kubeconfig_file.exist?
+        return unless kubeconfig?
 
         cluster_context['kubeconfig'] = kubeconfig
 
         client_prefetch
       end
 
-      # @return [Pharos::Transport::TransportFile]
-      def kubeconfig_file
-        @kubeconfig_file ||= transport.file(REMOTE_FILE)
+      # @return [String]
+      def kubeconfig?
+        transport.file(REMOTE_FILE).exist?
+      end
+
+      # @return [K8s::Config]
+      def read_kubeconfig
+        transport.file(REMOTE_FILE).read
       end
 
       # @return [K8s::Config]
       def kubeconfig
         logger.info { "Fetching kubectl config ..." }
-        config = YAML.safe_load(kubeconfig_file.read)
+        config = YAML.safe_load(read_kubeconfig)
 
         logger.debug { "New config: #{config}" }
         K8s::Config.new(config)

--- a/lib/pharos/phases/load_cluster_configuration.rb
+++ b/lib/pharos/phases/load_cluster_configuration.rb
@@ -6,6 +6,8 @@ module Pharos
       title "Load cluster configuration"
 
       def call
+        return unless cluster_context['kubeconfig']
+
         logger.info { "Loading cluster configuration configmap ..." }
 
         pharos_config_map = pharos_config_configmap


### PR DESCRIPTION
The `ConfigureClient` is currently the only phase that takes an extra argument.

The argument `optional` is used to let it fail silently if the host doesn't have a kubeconfig, which is the case when the cluster is just being set up.

The phases that require kubeclient should not be reached if the configuration was unsuccesful or if they are, they will fail because there is no kubeclient, which is not much worse than failing in the `ConfigureKubeclient` phase before it.

After this and #1125 the only parameter that a phase needs is the host (and the phase class can be modified to generate a list of hosts when given a config/context)

