### PR TITLE
Fix excess CPU usage while waiting for phases to finish

### DIFF
--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -48,7 +48,7 @@ module Pharos
         end
       end
 
-      Thread.pass until threads.none?(&:alive?)
+      sleep 0.1 until threads.none?(&:alive?)
 
       # Thread status is false when terminated normally, nil when it terminated with exception
       # rubocop:disable Lint/RescueException


### PR DESCRIPTION
The main thread was using up all the CPU while waiting for phase threads to finish.

This PR changes the [`Thread.pass`](https://ruby-doc.org/core-2.6.1/Thread.html#method-c-pass) to `sleep 0.1`, which seems to work better.

