### PR TITLE
Always tunnel Kube API client through master ssh

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -186,19 +186,23 @@ module Pharos
       end
     end
 
-    attr_reader :config, :cpu_arch, :cluster_config, :kube_client
+    attr_reader :config, :cpu_arch, :cluster_config, :cluster_context
 
     # @param config [Hash,Dry::Validation::Result]
     # @param enabled [Boolean]
-    # @param kube_client [K8s::Client]
     # @param cpu_arch [String, NilClass]
     # @param cluster_config [Pharos::Config, NilClass]
-    def initialize(config = nil, enabled: true, kube_client:, cpu_arch:, cluster_config:)
+    # @param cluster_context [Hash]
+    def initialize(config = nil, enabled: true, cpu_arch:, cluster_config:, cluster_context:)
       @config = self.class.config? ? self.class.config.new(config) : RecursiveOpenStruct.new(Hash(config))
       @enabled = enabled
-      @kube_client = kube_client
       @cpu_arch = cpu_arch
       @cluster_config = cluster_config
+      @cluster_context = cluster_context
+    end
+
+    def kube_client
+      cluster_context['kube_client']
     end
 
     def name

--- a/lib/pharos/addon_manager.rb
+++ b/lib/pharos/addon_manager.rb
@@ -111,19 +111,11 @@ module Pharos
       end
     end
 
-    # @return [K8s::Client]
-    def kube_client
-      if !@kubeclient && @cluster_context['kubeconfig']
-        @kube_client = @config.kube_client(@cluster_context['kubeconfig'])
-      end
-      @kube_client
-    end
-
     def options
       {
-        kube_client: kube_client,
         cpu_arch: @config.master_host.cpu_arch, # needs to be resolved *after* Phases::ValidateHost runs
-        cluster_config: @config
+        cluster_config: @config,
+        cluster_context: @cluster_context
       }
     end
 

--- a/lib/pharos/command_options/load_config.rb
+++ b/lib/pharos/command_options/load_config.rb
@@ -34,11 +34,7 @@ module Pharos
 
         # @return [K8s::Client]
         def kube_client
-          return @kube_client if @kube_client
-
-          signal_error 'no usable master for k8s api client' unless cluster_manager.context['kubeconfig']
-
-          @kube_client = load_config.kube_client(cluster_manager.context['kubeconfig'])
+          cluster_manager.context['kube_client'] || signal_error('no usable master for k8s api client')
         end
 
         private

--- a/lib/pharos/config.rb
+++ b/lib/pharos/config.rb
@@ -114,22 +114,6 @@ module Pharos
       @regions ||= hosts.map(&:region).compact.uniq
     end
 
-    # @param kubeconfig [Hash]
-    # @return [K8s::Client]
-    def kube_client(kubeconfig)
-      return @kube_client if @kube_client
-
-      if master_host.bastion.nil?
-        api_address = master_host.api_address
-        api_port = 6443
-      else
-        api_address = 'localhost'
-        api_port = master_host.bastion.host.transport.forward(master_host.api_address, 6443)
-      end
-
-      @kube_client = Pharos::Kube.client(api_address, kubeconfig, api_port)
-    end
-
     # @param key [Symbol]
     # @param value [Pharos::Configuration::Struct]
     # @raise [Pharos::ConfigError]

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -106,9 +106,7 @@ module Pharos
 
     # @return [K8s::Client]
     def kube_client
-      fail "Phase #{self.class.name} does not have kubeconfig cluster_context" unless cluster_context['kubeconfig']
-
-      @config.kube_client(cluster_context['kubeconfig'])
+      cluster_context['kube_client'] || raise("Phase #{self.class.name} does not have a configured kube client")
     end
 
     # @param name [String]

--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -106,7 +106,7 @@ module Pharos
 
     # @return [K8s::Client]
     def kube_client
-      cluster_context['kube_client'] || raise("Phase #{self.class.name} does not have a configured kube client")
+      cluster_context['kube_client'] || raise("No Kubernetes API client available")
     end
 
     # @param name [String]

--- a/lib/pharos/transport/local.rb
+++ b/lib/pharos/transport/local.rb
@@ -3,7 +3,11 @@
 module Pharos
   module Transport
     class Local < Base
-      def forward
+      def forward(*_args)
+        raise TypeError, "Non-SSH connections do not provide port forwarding"
+      end
+
+      def close(*_args)
         raise TypeError, "Non-SSH connections do not provide port forwarding"
       end
 

--- a/non-oss/spec/pharos_pro/addons/backup_spec.rb
+++ b/non-oss/spec/pharos_pro/addons/backup_spec.rb
@@ -12,7 +12,7 @@ describe Pharos::AddonManager.addons['kontena-backup'] do
   let(:kube_client) { instance_double(K8s::Client) }
   let(:cpu_arch) { double(:cpu_arch ) }
 
-  subject { described_class.new(config, enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config) }
+  subject { described_class.new(config, enabled: true, cpu_arch: cpu_arch, cluster_config: cluster_config, cluster_context: { 'kube_client' => kube_client }) }
 
   describe '#validate' do
 

--- a/non-oss/spec/pharos_pro/addons/kontena_storage_spec.rb
+++ b/non-oss/spec/pharos_pro/addons/kontena_storage_spec.rb
@@ -24,7 +24,7 @@ describe Pharos::AddonManager.addons['kontena-storage'] do
           'use_all_nodes' => true
         }
 
-      }, kube_client: double, cpu_arch: double, cluster_config: double)
+      }, cpu_arch: double, cluster_config: double, cluster_context: { 'kube_client' => double })
       resource = subject.build_cluster_resource
       expect(resource.spec.dataDirHostPath).to eq('/var/lib/foo')
       expect(resource.spec.storage.useAllNodes).to be_truthy

--- a/non-oss/spec/pharos_pro/addons/network_lb_spec.rb
+++ b/non-oss/spec/pharos_pro/addons/network_lb_spec.rb
@@ -13,7 +13,7 @@ describe Pharos::AddonManager.addons['kontena-network-lb'] do
   let(:cpu_arch) { double(:cpu_arch ) }
 
   subject {
-    described_class.new(config, enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config)
+    described_class.new(config, enabled: true, cpu_arch: cpu_arch, cluster_config: cluster_config, cluster_context: { 'kube_client' => kube_client })
   }
 
   describe '#validate' do

--- a/spec/pharos/addon_spec.rb
+++ b/spec/pharos/addon_spec.rb
@@ -25,7 +25,7 @@ describe Pharos::Addon do
   let(:kube_client) { instance_double(K8s::Client) }
   let(:config) { {foo: 'bar'} }
 
-  subject { test_addon.new(config, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: double(image_repository: 'foo')) }
+  subject { test_addon.new(config, cpu_arch: cpu_arch, cluster_config: double(image_repository: 'foo'), cluster_context: { 'kube_client' => kube_client }) }
 
   describe ".addon_name" do
     it "returns configured name" do
@@ -134,7 +134,7 @@ describe Pharos::Addon do
           config.justatest
           apply_resources
         }
-      end.new(config, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: nil)
+      end.new(config, cluster_context: { 'kube_client' => kube_client }, cpu_arch: cpu_arch, cluster_config: nil)
     end
 
     let(:kube_stack) { double(:kube_stack) }

--- a/spec/pharos/addons/cert_manager_spec.rb
+++ b/spec/pharos/addons/cert_manager_spec.rb
@@ -15,7 +15,7 @@ describe Pharos::AddonManager.addons['cert-manager'] do
   let(:cpu_arch) { double(:cpu_arch ) }
 
   subject do
-    described_class.new(config, enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config)
+    described_class.new(config, enabled: true, cpu_arch: cpu_arch, cluster_config: cluster_config, cluster_context: { 'kube_client' => kube_client })
   end
 
   describe "#validate" do

--- a/spec/pharos/addons/helm_spec.rb
+++ b/spec/pharos/addons/helm_spec.rb
@@ -13,7 +13,7 @@ describe Pharos::AddonManager.addons['helm'] do
   let(:cpu_arch) { double(:cpu_arch ) }
 
   subject do
-    described_class.new(config, enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config)
+    described_class.new(config, enabled: true, cpu_arch: cpu_arch, cluster_config: cluster_config, cluster_context: { 'kube_client' => kube_client })
   end
 
   describe "#build_args" do

--- a/spec/pharos/addons/host_upgrades_spec.rb
+++ b/spec/pharos/addons/host_upgrades_spec.rb
@@ -10,7 +10,7 @@ describe Pharos::AddonManager.addons['host-upgrades'] do
   let(:cpu_arch) { double(:cpu_arch ) }
 
   subject do
-    described_class.new({enabled: true}.merge(config), enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config)
+    described_class.new({enabled: true}.merge(config), enabled: true, cpu_arch: cpu_arch, cluster_config: cluster_config, cluster_context: { 'kube_client' => kube_client })
   end
 
   describe "#validate" do

--- a/spec/pharos/addons/ingress_nginx_spec.rb
+++ b/spec/pharos/addons/ingress_nginx_spec.rb
@@ -13,7 +13,7 @@ describe Pharos::AddonManager.addons['ingress-nginx'] do
   let(:cpu_arch) { double(:cpu_arch ) }
 
   subject do
-    described_class.new(config, enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config)
+    described_class.new(config, enabled: true, cpu_arch: cpu_arch, cluster_config: cluster_config, cluster_context: { 'kube_client' => kube_client })
   end
 
   describe "#validate" do

--- a/spec/pharos/addons/openebs_spec.rb
+++ b/spec/pharos/addons/openebs_spec.rb
@@ -12,7 +12,7 @@ describe Pharos::AddonManager.addons['openebs'] do
   let(:kube_client) { instance_double(K8s::Client) }
   let(:cpu_arch) { double(:cpu_arch ) }
 
-  subject { described_class.new(config, enabled: true, kube_client: kube_client, cpu_arch: cpu_arch, cluster_config: cluster_config) }
+  subject { described_class.new(config, enabled: true, cpu_arch: cpu_arch, cluster_config: cluster_config, cluster_context: { 'kube_client' => kube_client }) }
 
   describe '#validate' do
     context 'with more replicas than workers' do

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -187,38 +187,6 @@ describe Pharos::Config do
         end
       end
     end
-
-    context 'kube_client' do
-      let(:data) { { 'hosts' => [ { 'address' => '192.0.2.1', 'role' => 'master' } ] } }
-      let(:kubeconfig) { {}  }
-
-      it 'creates a kube client' do
-        expect(Pharos::Kube).to receive(:client).with('192.0.2.1',kubeconfig, 6443)
-        subject.kube_client(kubeconfig)
-      end
-
-      context 'with bastion host' do
-        let(:master) { Pharos::Configuration::Host.new('address' => '192.0.2.1', 'role' => 'master', 'bastion' => { 'address' => '192.0.2.2', 'user' => 'bastion' }) }
-        let(:data) { { 'hosts' => [ { 'address' => '192.0.2.1', 'role' => 'master', 'bastion' => { 'address' => '192.0.2.2', 'user' => 'bastion' } } ] } }
-        let(:bastion) { Pharos::Configuration::Bastion.new('address' => '192.0.2.2', 'user' => 'bastion') }
-        let(:bastion_host) { instance_double(Pharos::Configuration::Host) }
-        let(:ssh) { instance_double(Pharos::Transport::SSH) }
-
-        before do
-          allow(subject).to receive(:master_host).and_return(master)
-          allow(master).to receive(:bastion).and_return(bastion)
-          allow(bastion).to receive(:host).and_return(bastion_host)
-          allow(bastion_host).to receive(:transport).and_return(ssh)
-          allow(master).to receive(:api_address).and_return('api.example.com')
-        end
-
-        it 'creates a kube client through ssh' do
-          expect(Pharos::Kube).to receive(:client).with('localhost', kubeconfig, 9999)
-          expect(ssh).to receive(:forward).with('api.example.com', 6443).and_return(9999)
-          subject.kube_client(kubeconfig)
-        end
-      end
-    end
   end
 
   describe '#master_hosts' do

--- a/spec/pharos/phases/configure_client_spec.rb
+++ b/spec/pharos/phases/configure_client_spec.rb
@@ -1,0 +1,40 @@
+require 'pharos/config'
+require 'pharos/phases/configure_client'
+
+describe Pharos::Phases::ConfigureClient do
+  let(:host) do
+    Pharos::Configuration::Host.new(
+      address: '10.10.10.2',
+      user: 'root',
+      ssh_key_path: '~/.ssh/id_rsa.pub',
+      role: 'master'
+    )
+  end
+  let(:config) { Pharos::Config.new(hosts: [host]) }
+
+  let(:transport) { instance_double(Pharos::Transport::SSH) }
+  let(:remote_file) { instance_double(Pharos::Transport::TransportFile) }
+  let(:cluster_context) { {} }
+  let(:kubeclient) { instance_double(K8s::Client) }
+  let(:k8s_config) { instance_double(K8s::Config) }
+
+  let(:subject) { described_class.new(host, config: config, cluster_context: cluster_context) }
+
+  before(:each) do
+    allow(host).to receive(:master_sort_score).and_return(0)
+    allow(host).to receive(:transport).and_return(transport)
+    allow(transport).to receive(:file).with('/etc/kubernetes/admin.conf').and_return(remote_file)
+    allow(remote_file).to receive(:exist?).and_return(true)
+    allow(kubeclient).to receive(:apis)
+    allow(K8s::Config).to receive(:new).and_return(k8s_config)
+  end
+
+  describe '#call' do
+    it 'loads kubeconfig from master and configures kubeclient through port forwarding' do
+      expect(remote_file).to receive(:read).and_return('content')
+      expect(transport).to receive(:forward).with('10.10.10.2', 6443).and_return(1234)
+      expect(Pharos::Kube).to receive(:client).with('localhost', k8s_config, 1234).and_return(kubeclient)
+      expect{subject.call}.to change{cluster_context}.from({}).to(hash_including('kube_client' => kubeclient))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1088 

K8s Client is now always tunneled through the SSH connection to primary master host.

Done via making ConfigureClient to actually configure the client, not just load the configuration. 

If the master host is localhost, don't try to forward.
