### PR TITLE
Drop unused constant PROXY_ADDRESS from JoinNode

### DIFF
--- a/lib/pharos/phases/join_node.rb
+++ b/lib/pharos/phases/join_node.rb
@@ -4,8 +4,6 @@ module Pharos
   module Phases
     class JoinNode < Pharos::Phase
       title "Join nodes"
-      PROXY_ADDRESS = '127.0.0.1:6443'
-
       def already_joined?
         transport.file("/etc/kubernetes/kubelet.conf").exist?
       end


### PR DESCRIPTION
`Phases::JoinNode::PROXY_ADDRESS` does not seem to be used anywhere.
