### PR TITLE
Enable debug output for a selected phase only

### DIFF
--- a/lib/pharos/logging.rb
+++ b/lib/pharos/logging.rb
@@ -12,6 +12,10 @@ module Pharos
       @debug = true
     end
 
+    def self.no_debug!
+      @debug = false
+    end
+
     def self.format_exception(exc, severity = "ERROR")
       if !ENV['DEBUG'].to_s.empty? || severity == "DEBUG"
         backtrace = "\n    #{exc.backtrace.join("\n    ")}"

--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -93,11 +93,14 @@ module Pharos
       phases = hosts.map { |host| prepare_phase(phase_class, host, **options) }
 
       run(phases, parallel: parallel) do |phase|
+        Pharos::Logging.debug!  if ENV['DEBUG'].to_s == phase.class.name.split('::').last
+
         start = Time.now
 
         phase.call
 
         phase.logger.info 'Completed phase in %<duration>.2fs' % { duration: Time.now - start }
+        Pharos::Logging.no_debug! if ENV['DEBUG'].to_s == phase.class.name.split('::').last
       end
     end
   end


### PR DESCRIPTION
Enable debug output for a single phase:

```
$ DEBUG=GatherFacts bin/pharos up
```

Useful while developing.
