### PR TITLE
Set host environment from config for each command execution

### DIFF
--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -164,9 +164,6 @@ module Pharos
           "#{key}=\"#{val.shellescape}\""
         end
         host_env_file.write(new_content.join("\n") + "\n")
-        new_content.each do |kv_pair|
-          transport.exec!("export #{kv_pair}")
-        end
       end
 
       # @return [String, NilClass]

--- a/lib/pharos/phases/gather_facts.rb
+++ b/lib/pharos/phases/gather_facts.rb
@@ -10,6 +10,9 @@ module Pharos
       FULL_HOSTNAME_CLOUD_PROVIDERS = %w(aws vsphere).freeze
 
       def call
+        transport.exec('env')
+        transport.exec('sudo env')
+
         logger.info { "Checking sudo access ..." }
         check_sudo
         logger.info { "Gathering host facts ..." }

--- a/lib/pharos/transport.rb
+++ b/lib/pharos/transport.rb
@@ -15,7 +15,7 @@ module Pharos
         opts[:proxy] = Net::SSH::Proxy::Command.new(host.ssh_proxy_command) if host.ssh_proxy_command
         opts[:bastion] = host.bastion if host.bastion
         opts[:port] = host.ssh_port
-        SSH.new(host.address, user: host.user, **opts.merge(options))
+        SSH.new(host, user: host.user, **opts.merge(options))
       end
     end
   end

--- a/lib/pharos/transport/command/ssh.rb
+++ b/lib/pharos/transport/command/ssh.rb
@@ -17,6 +17,9 @@ module Pharos
           result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
           response = @client.session.open_channel do |channel|
             channel.env('LC_ALL', 'C.UTF-8')
+            @client.host.environment&.each do |key, value|
+              channel.env(key, value)
+            end
             channel.exec @cmd do |_, success|
               raise Pharos::ExecError, "Failed to exec #{cmd}" unless success
 

--- a/lib/pharos/transport/command/ssh.rb
+++ b/lib/pharos/transport/command/ssh.rb
@@ -17,9 +17,6 @@ module Pharos
           result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
           response = @client.session.open_channel do |channel|
             channel.env('LC_ALL', 'C.UTF-8')
-            @client.host.environment&.each do |key, value|
-              channel.env(key, value)
-            end
             channel.exec @cmd do |_, success|
               raise Pharos::ExecError, "Failed to exec #{cmd}" unless success
 

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -38,10 +38,10 @@ module Pharos
         session_factory = bastion&.transport || Net::SSH
 
         synchronize do
-          logger.debug { "connect: #{@user}@#{@host} (#{@opts})" }
+          logger.debug { "connect: #{@user}@#{host} (#{@opts})" }
           non_interactive = true
           begin
-            @session = session_factory.start(@host, @user, @opts.merge(options).merge(non_interactive: non_interactive))
+            @session = session_factory.start(@host.address, @user, @opts.merge(options).merge(non_interactive: non_interactive))
             logger.debug "Connected"
             class_mutex.unlock if class_mutex.locked? && class_mutex.owned?
           rescue *RETRY_CONNECTION_ERRORS => exc

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -77,8 +77,6 @@ describe Pharos::Host::Configurer do
 
       it 'adds a line to /etc/environment' do
         expect(file).to receive(:write).with("TEST=\"foo\"\nPATH=\"/bin:/usr/local/bin\"\n")
-        expect(ssh).to receive(:exec!).with("export TEST=\"foo\"")
-        expect(ssh).to receive(:exec!).with("export PATH=\"/bin:/usr/local/bin\"")
         subject.update_env_file
       end
     end
@@ -88,7 +86,6 @@ describe Pharos::Host::Configurer do
 
       it 'modifies a line in /etc/environment' do
         expect(file).to receive(:write).with("PATH=\"/bin\"\n")
-        expect(ssh).to receive(:exec!).with("export PATH=\"/bin\"")
         subject.update_env_file
       end
     end
@@ -98,7 +95,6 @@ describe Pharos::Host::Configurer do
       let(:config_environment) { { 'PATH' => nil } }
 
       it 'removes a line in /etc/environment' do
-        expect(ssh).to receive(:exec!).with("export TEST=\"foo\"")
         expect(file).to receive(:write).with("TEST=\"foo\"\n")
         subject.update_env_file
       end


### PR DESCRIPTION


`FTP_PROXY` is in cluster.yml and update_env_file has not yet been run:

```
    192.168.100.102: $ env
    192.168.100.102: XDG_SESSION_ID=693
    192.168.100.102: SHELL=/bin/bash
    192.168.100.102: SSH_CLIENT=192.168.100.1 53072 22
    192.168.100.102: LC_ALL=C.UTF-8
    192.168.100.102: USER=vagrant
    192.168.100.102: FTP_PROXY=http://proxy.example.com

    192.168.100.102: $ sudo env
    192.168.100.102: LC_ALL=C.UTF-8
    192.168.100.102: PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
    192.168.100.102: LANG=en_US.UTF-8
    192.168.100.102: HOME=/home/vagrant
    192.168.100.102: MAIL=/var/mail/root
    192.168.100.102: LOGNAME=root
    192.168.100.102: USER=root
    192.168.100.102: USERNAME=root
    192.168.100.102: SHELL=/bin/bash
    192.168.100.102: TERM=unknown
    192.168.100.102: SUDO_COMMAND=/usr/bin/env
    192.168.100.102: SUDO_USER=vagrant
    192.168.100.102: SUDO_UID=1000
    192.168.100.102: SUDO_GID=1000
    192.168.100.102: FTP_PROXY=http://proxy.example.com
```
