### PR TITLE
Cyclic barrier for coordinated reconnect

### DIFF
--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -136,5 +136,9 @@ module Pharos
     def self.mutex
       @mutex ||= Mutex.new
     end
+
+    def checkpoint
+      Thread.main[:checkpoint]
+    end
   end
 end

--- a/lib/pharos/phase_manager.rb
+++ b/lib/pharos/phase_manager.rb
@@ -40,6 +40,8 @@ module Pharos
     # @param phases [Array<Pharos::Phases::Base>]
     # @return [Array<...>]
     def run_parallel(phases, &block)
+      Thread.main[:checkpoint] = Concurrent::CyclicBarrier.new(phases.size)
+
       threads = phases.map do |phase|
         Thread.new do
           Thread.current.report_on_exception = false

--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -33,21 +33,12 @@ module Pharos
       end
 
       def coordinated_reconnect
-        @host.transport.disconnect
-
-        if @config.hosts.any? { |host| !host.bastion.nil? }
-          mutex.synchronize do
-            unless cluster_context['configure-host:all-disconnected']
-              logger.info "Coordinating reconnect..."
-              sleep 0.1 until @config.hosts.all? { |host| !host.transport.connected? }
-            end
-
-            cluster_context['configure-host:all-disconnected'] = true
-          end
-        end
-
+        logger.info "Disconnecting ..."
+        checkpoint.wait
+        transport.disconnect
+        checkpoint.wait
         logger.info "Reconnecting ..."
-        @host.transport.connect
+        transport.connect
       end
     end
   end


### PR DESCRIPTION
(base is #1245)

(poc)

Use [CyclicBarrier](https://www.rubydoc.info/gems/concurrent-ruby/Concurrent/CyclicBarrier) for coordinated reconnect
