### PR TITLE
Drop non-functional shell variable exports when updating env file

### DIFF
--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -164,9 +164,6 @@ module Pharos
           "#{key}=\"#{val.shellescape}\""
         end
         host_env_file.write(new_content.join("\n") + "\n")
-        new_content.each do |kv_pair|
-          transport.exec!("export #{kv_pair}")
-        end
       end
 
       # @return [String, NilClass]

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -77,8 +77,6 @@ describe Pharos::Host::Configurer do
 
       it 'adds a line to /etc/environment' do
         expect(file).to receive(:write).with("TEST=\"foo\"\nPATH=\"/bin:/usr/local/bin\"\n")
-        expect(ssh).to receive(:exec!).with("export TEST=\"foo\"")
-        expect(ssh).to receive(:exec!).with("export PATH=\"/bin:/usr/local/bin\"")
         subject.update_env_file
       end
     end
@@ -88,7 +86,6 @@ describe Pharos::Host::Configurer do
 
       it 'modifies a line in /etc/environment' do
         expect(file).to receive(:write).with("PATH=\"/bin\"\n")
-        expect(ssh).to receive(:exec!).with("export PATH=\"/bin\"")
         subject.update_env_file
       end
     end
@@ -98,7 +95,6 @@ describe Pharos::Host::Configurer do
       let(:config_environment) { { 'PATH' => nil } }
 
       it 'removes a line in /etc/environment' do
-        expect(ssh).to receive(:exec!).with("export TEST=\"foo\"")
         expect(file).to receive(:write).with("TEST=\"foo\"\n")
         subject.update_env_file
       end


### PR DESCRIPTION
Base is #1245

Drop the unnecessary exports from Configurer (and related specs)
