### PR TITLE
Release v2.3.3

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.2"
+  VERSION = "2.3.3"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.3.2

- Fix cni dependency error on upgrade (#1249)
- Fixes for proxied environments (#1245)
- Connect to local etcd peer first (#1259)
- Remove kubernetes-cni on el7 reset (#1257)
- Drop the useless exports (#1254)
- Set environment for local command execs (#1253)