### PR TITLE
Connect to local etcd peer first

### DIFF
--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -136,7 +136,7 @@ module Pharos
         # let's put locally running etcd peer first
         # see: https://github.com/kubernetes/kubernetes/issues/72102
         endpoints = ["https://localhost:2379"]
-        endpoints += @config.etcd_hosts.select { |peer| peer != @host }.map { |h|
+        endpoints += @config.etcd_hosts.reject { |peer| peer == @host }.map { |h|
           "https://#{@config.etcd_peer_address(h)}:2379"
         }
         config['etcd'] = {

--- a/lib/pharos/kubeadm/cluster_config.rb
+++ b/lib/pharos/kubeadm/cluster_config.rb
@@ -133,11 +133,15 @@ module Pharos
 
       # @param config [Pharos::Config]
       def configure_internal_etcd(config)
+        # let's put locally running etcd peer first
+        # see: https://github.com/kubernetes/kubernetes/issues/72102
+        endpoints = ["https://localhost:2379"]
+        endpoints += @config.etcd_hosts.select { |peer| peer != @host }.map { |h|
+          "https://#{@config.etcd_peer_address(h)}:2379"
+        }
         config['etcd'] = {
           'external' => {
-            'endpoints' => @config.etcd_hosts.map { |h|
-              "https://#{@config.etcd_peer_address(h)}:2379"
-            },
+            'endpoints' => endpoints,
             'certFile' => '/etc/pharos/pki/etcd/client.pem',
             'caFile' => '/etc/pharos/pki/ca.pem',
             'keyFile' => '/etc/pharos/pki/etcd/client-key.pem'

--- a/spec/pharos/kubeadm/cluster_config_spec.rb
+++ b/spec/pharos/kubeadm/cluster_config_spec.rb
@@ -112,6 +112,26 @@ describe Pharos::Kubeadm::ClusterConfig do
       })
     end
 
+    context 'with internal etcd configuration' do
+      let(:config) {
+        Pharos::Config.new(
+          hosts: (1..3).map { |i| Pharos::Configuration::Host.new(
+            address: "10.10.0.#{i}", role: "master"
+          ) },
+          network: {},
+          addons: {}
+        )
+      }
+      subject { described_class.new(config, config.hosts.last) }
+
+      it 'sets etcd to localhost by default' do
+        config = subject.generate
+        expect(config.dig('etcd', 'external', 'endpoints')).to eq([
+          'https://localhost:2379', 'https://10.10.0.1:2379', 'https://10.10.0.2:2379',
+        ])
+      end
+    end
+
     context 'with etcd endpoint configuration' do
       let(:config) { Pharos::Config.new(
         hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },


### PR DESCRIPTION
Fixes upstream issue (https://github.com/kubernetes/kubernetes/issues/72102) where kube-apiserver refuses to work if first etcd server is not available.

