### PR TITLE
Validate configuration host address uniqueness

### DIFF
--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -53,7 +53,10 @@ describe Pharos::Config do
       ] }
       it 'fails to load' do
         expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
-          expect(exc.errors[:hosts]).to match array_including("address is not unique")
+          expect(exc.errors[:hosts]).to match hash_including(
+            0 => hash_including(address: array_including("is not unique")),
+            1 => hash_including(address: array_including("is not unique"))
+          )
         end
       end
     end

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -46,6 +46,17 @@ describe Pharos::Config do
       end
     end
 
+    context 'non unique ip' do
+      let(:hosts) { [
+        { 'address' => ' 192.0.2.1', 'role' => 'master' },
+        { 'address' => ' 192.0.2.1', 'role' => 'worker' }
+      ] }
+      it 'fails to load' do
+        expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
+          expect(exc.errors[:hosts]).to match array_including("address is not unique")
+        end
+      end
+    end
 
     context 'without hosts' do
       let(:data) { {} }


### PR DESCRIPTION
Fixes #1256 

The error messages are misleading without this if you have non-unique ip's in cluster.yml:

```
- host-00:
    Pharos::InvalidHostError: Cannot change master host role to worker
```