### PR TITLE
Fix license assign NoMethodError

### DIFF
--- a/non-oss/pharos_pro/commands/license_assign_command.rb
+++ b/non-oss/pharos_pro/commands/license_assign_command.rb
@@ -77,7 +77,7 @@ module Pharos
     end
 
     def subscription_token_request
-      logger.info "Exchanging license key for a subscription token" if $stdout.tty? && !print_subscription_token?
+      logger.info "Exchanging license key for a subscription token" if $stdout.tty? && !@cluster_id_given
 
       Excon.post(
         'https://get.pharos.sh/api/licenses/%<key>s/assign' % { key: license_key },


### PR DESCRIPTION
Fixes #1264

The `--print-subscription-token` flag was removed and the logic was changed to output the token when `--cluster-id` has been given.
