### PR TITLE
Fix reset command remaining masters validation

### DIFF
--- a/lib/pharos/reset_command.rb
+++ b/lib/pharos/reset_command.rb
@@ -19,7 +19,7 @@ module Pharos
       all_hosts = load_config.hosts.dup
       load_config.hosts.keep_if { |h| filtered_hosts.include?(h) }
       remaining_masters = all_hosts.select(&:master?) - load_config.hosts.select(&:master?)
-      if remaining_masters.size < 1
+      if remaining_masters.empty?
         signal_error 'There would be no master hosts left in the cluster after the reset. Reset the whole cluster by running this command without host filters.'
       elsif filtered_hosts.size > 1
         confirm_yes!("==> Do you really want to reset #{filtered_hosts.size} hosts #{filtered_hosts.map(&:address).join(',')} (data may be lost)?".bright_yellow, default: false)
@@ -28,7 +28,7 @@ module Pharos
       end
 
       start_time = Time.now
-      puts "==> Starting to reset host#{'s' if filtered_hosts.size > 1 } ...".green
+      puts "==> Starting to reset host#{'s' if filtered_hosts.size > 1} ...".green
       cluster_manager.apply_reset_hosts(filtered_hosts)
       reset_time = Time.now - start_time
       puts "==> #{filtered_hosts.size > 1 ? 'Hosts have' : 'Host has'} been reset! (took #{humanize_duration(reset_time.to_i)})".green

--- a/lib/pharos/reset_command.rb
+++ b/lib/pharos/reset_command.rb
@@ -16,8 +16,10 @@ module Pharos
     end
 
     def reset_hosts
+      all_hosts = load_config.hosts.dup
       load_config.hosts.keep_if { |h| filtered_hosts.include?(h) }
-      if load_config.hosts.none?(&:master?)
+      remaining_masters = all_hosts.select(&:master?) - load_config.hosts.select(&:master?)
+      if remaining_masters.size < 1
         signal_error 'There would be no master hosts left in the cluster after the reset. Reset the whole cluster by running this command without host filters.'
       elsif filtered_hosts.size > 1
         confirm_yes!("==> Do you really want to reset #{filtered_hosts.size} hosts #{filtered_hosts.map(&:address).join(',')} (data may be lost)?".bright_yellow, default: false)
@@ -26,10 +28,10 @@ module Pharos
       end
 
       start_time = Time.now
-      puts "==> Starting to reset hosts ...".green
+      puts "==> Starting to reset host#{'s' if filtered_hosts.size > 1 } ...".green
       cluster_manager.apply_reset_hosts(filtered_hosts)
       reset_time = Time.now - start_time
-      puts "==> Hosts have been reset! (took #{humanize_duration(reset_time.to_i)})".green
+      puts "==> #{filtered_hosts.size > 1 ? 'Hosts have' : 'Host has'} been reset! (took #{humanize_duration(reset_time.to_i)})".green
     end
 
     def reset_all

--- a/spec/pharos/reset_command_spec.rb
+++ b/spec/pharos/reset_command_spec.rb
@@ -1,0 +1,64 @@
+describe Pharos::ResetCommand do
+  subject { described_class.new('') }
+
+  let(:hosts) { [] }
+  let(:data) { { hosts: hosts } }
+  let(:config) { Pharos::Config.new(data) }
+
+  before do
+    allow(subject).to receive(:load_config).and_return(config)
+    allow(subject).to receive(:config_yaml).and_return(double(dirname: __dir__))
+    allow(subject).to receive_message_chain("cluster_manager.disconnect")
+  end
+
+  describe '#execute' do
+    context 'confirmations' do
+      let(:hosts) do
+        [
+          { address: '10.0.0.1', role: 'master' },
+          { address: '10.0.0.2', role: 'master' },
+          { address: '10.0.0.3', role: 'worker' }
+        ]
+      end
+
+      context 'reset all' do
+        it 'prompts and resets all' do
+          expect(subject.prompt).to receive(:yes?).with(/Do you really want to reset all/, default: false).and_return(true)
+          expect(subject).to receive_message_chain("cluster_manager.apply_reset_hosts").with(config.hosts)
+          subject.run([])
+        end
+      end
+
+      context 'resetting masters' do
+        context 'would remove all masters' do
+          it 'aborts with error' do
+            expect{subject.run(%w(-r master))}.to raise_exception(Clamp::ExecutionError, /no master hosts left/)
+          end
+        end
+
+        context 'would remove some of the masters' do
+          it 'prompts' do
+            expect(subject.prompt).to receive(:yes?).with(/Do you really want/, default: false).and_return(false)
+            expect{subject.run(%w(-r master --first))}.to raise_error(SystemExit)
+          end
+        end
+      end
+
+      context 'resetting single host' do
+        context 'with --yes' do
+          it 'does not prompt' do
+            expect(subject).to receive_message_chain("cluster_manager.apply_reset_hosts").with([config.hosts.last])
+            subject.run(%w(--yes -a 10.0.0.3))
+          end
+        end
+
+        context 'without --yes' do
+          it 'prompts' do
+            expect(subject.prompt).to receive(:yes?).with(/Do you really want/, default: false).and_return(false)
+            expect{subject.run(%w(-a 10.0.0.3))}.to raise_error(SystemExit)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/pharos/reset_command_spec.rb
+++ b/spec/pharos/reset_command_spec.rb
@@ -16,6 +16,7 @@ describe Pharos::ResetCommand do
     allow(subject).to receive(:load_config).and_return(config)
     allow(subject).to receive(:config_yaml).and_return(double(dirname: __dir__))
     allow(subject).to receive_message_chain("cluster_manager.disconnect")
+    allow($stdin).to receive(:tty?).and_return(true)
   end
 
   describe '#execute' do

--- a/spec/pharos/reset_command_spec.rb
+++ b/spec/pharos/reset_command_spec.rb
@@ -1,7 +1,14 @@
 describe Pharos::ResetCommand do
   subject { described_class.new('') }
 
-  let(:hosts) { [] }
+  let(:hosts) do
+    [
+      { address: '10.0.0.1', role: 'master' },
+      { address: '10.0.0.2', role: 'master' },
+      { address: '10.0.0.3', role: 'worker' }
+    ]
+  end
+
   let(:data) { { hosts: hosts } }
   let(:config) { Pharos::Config.new(data) }
 
@@ -13,14 +20,6 @@ describe Pharos::ResetCommand do
 
   describe '#execute' do
     context 'confirmations' do
-      let(:hosts) do
-        [
-          { address: '10.0.0.1', role: 'master' },
-          { address: '10.0.0.2', role: 'master' },
-          { address: '10.0.0.3', role: 'worker' }
-        ]
-      end
-
       context 'reset all' do
         it 'prompts and resets all' do
           expect(subject.prompt).to receive(:yes?).with(/Do you really want to reset all/, default: false).and_return(true)


### PR DESCRIPTION
Fixes #1263 

The reset command refused to reset hosts unless the host filter result contained at least one master host.

