### PR TITLE
Pin rubocop to 0.66 for now

### DIFF
--- a/pharos-cluster.gemspec
+++ b/pharos-cluster.gemspec
@@ -47,6 +47,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "fakefs", "~> 0.13"
-  spec.add_development_dependency "rubocop", "~> 0.57"
+  spec.add_development_dependency "rubocop", "0.66.0"
   spec.add_development_dependency "pry-byebug", "~> 3.6"
 end


### PR DESCRIPTION
Later versions make too many files fail for now
