### PR TITLE
Release v2.3.4

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.3"
+  VERSION = "2.3.4"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.3.3

- Fix reset command remaining masters validation (#1269)
- Fix coredns version (#1282)
- Helm addon: wait for helm chart job to complete (#1275)
- Raise node-local-dns mem limit to 100Mi (#1272)
- Pin rubocop to 0.66 for now (#1273)
- Fix license assign NoMethodError (#1266)