### PR TITLE
Release v2.3.5

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.4"
+  VERSION = "2.3.5"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.3.4

- CRI-O v1.13.4 (#1287)
- Add kubernetes-cni package to version list (#1285)
- Pharos-license-enforcer addon v0.3.1 (#1286) [Pro]