### PR TITLE
Read kubernetes api endpoint from cluster config

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -208,7 +208,7 @@ Pharos.addon 'kontena-lens' do
   # @param cluster_url [String]
   # @return [K8s::Resource]
   def update_configmap(name, cluster_url)
-    configmap.data.clusterName = new_name
+    configmap.data.clusterName = name
     configmap.data.clusterUrl = cluster_url
     kube_client.api('v1').resource('configmaps', namespace: 'kontena-lens').update_resource(configmap)
   end

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -209,7 +209,7 @@ Pharos.addon 'kontena-lens' do
   # @return [K8s::Resource]
   def update_configmap(name, cluster_url)
     configmap.data.clusterName = new_name
-    configmap.data.clusterUrl = api_url
+    configmap.data.clusterUrl = cluster_url
     kube_client.api('v1').resource('configmaps', namespace: 'kontena-lens').update_resource(configmap)
   end
 


### PR DESCRIPTION
This PR reads kubernetes api endpoint from cluster.yml if provided. Kubernetes API endpoint is used in Lens generated `kubeconfig`.

Fixes #1290