### PR TITLE
Add ExternalIP to kubelet-preferred-address-types for metric-server

### DIFF
--- a/lib/pharos/resources/metrics-server/metrics-server-deployment.yml.erb
+++ b/lib/pharos/resources/metrics-server/metrics-server-deployment.yml.erb
@@ -29,7 +29,7 @@ spec:
         command:
         - /metrics-server
         - --logtostderr=true
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
Fixes #1292 