### PR TITLE
Release v2.3.6

### DIFF
--- a/lib/pharos/configuration/host.rb
+++ b/lib/pharos/configuration/host.rb
@@ -38,6 +38,8 @@ module Pharos
       end
 
       def local?
+        return false if ssh_key_path || user
+
         ip_address = Resolv.getaddress(address)
         IPAddr.new(ip_address).loopback?
       rescue Resolv::ResolvError, IPAddr::InvalidAddressError

--- a/lib/pharos/resources/metrics-server/metrics-server-deployment.yml.erb
+++ b/lib/pharos/resources/metrics-server/metrics-server-deployment.yml.erb
@@ -29,7 +29,7 @@ spec:
         command:
         - /metrics-server
         - --logtostderr=true
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP
         resources:
           requests:
             cpu: 10m

--- a/lib/pharos/scripts/configure-firewalld.sh
+++ b/lib/pharos/scripts/configure-firewalld.sh
@@ -16,7 +16,9 @@ fi
 
 firewall-cmd --permanent --add-service pharos-worker
 firewall-cmd --permanent --add-source ipset:pharos --zone trusted
-firewall-cmd --add-masquerade --permanent
+if firewall-cmd --query-masquerade > /dev/null 2>&1 ; then
+    firewall-cmd --remove-masquerade --permanent
+fi
 
 if [[ "${RELOAD}" = "true" ]]; then
     firewall-cmd --reload

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.3.5"
+  VERSION = "2.3.6"
 
   def self.version
     VERSION + "+oss"

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -55,6 +55,7 @@ Pharos.addon 'kontena-lens' do
     host = config.ingress&.host || config.host || "lens.#{gateway_node_ip}.nip.io"
     tls_email = config.ingress&.tls&.email || config.tls&.email
     name = config.name || cluster_config.name || 'pharos-cluster'
+    cluster_url = kubernetes_api_url
     charts_enabled = config.charts&.enabled != false
     helm_repositories = config.charts&.repositories || [stable_helm_repo]
     tiller_version = '2.12.2'
@@ -70,11 +71,7 @@ Pharos.addon 'kontena-lens' do
     protocol = tls_enabled? ? 'https' : 'http'
     message = "Kontena Lens is configured to respond at: " + "#{protocol}://#{host}".cyan
     message << "\nStarting up Kontena Lens the first time might take couple of minutes, until that you'll see 503 with the address given above."
-    if config_exists?
-      update_lens_name(name) if configmap.data.clusterName != name
-    else
-      create_config(name, "https://#{master_host_ip}:6443")
-    end
+    create_or_update_configmap(name, cluster_url)
     if user_management_enabled? && !admin_exists?
       create_admin_user(admin_password)
       message << "\nYou can sign in with the following admin credentials (you won't see these again): " + "admin / #{admin_password}".cyan
@@ -105,6 +102,23 @@ Pharos.addon 'kontena-lens' do
     false
   end
 
+  # @param name [String]
+  # @param cluster_url [String]
+  # @return [K8s::Resource]
+  def create_or_update_configmap(name, cluster_url)
+    if config_exists?
+      update_configmap(name, cluster_url)
+    else
+      create_configmap(name, cluster_url)
+    end
+  end
+
+  # @return [String]
+  def kubernetes_api_url
+    endpoint = cluster_config.api&.endpoint || master_host_ip
+    "https://#{endpoint}:6443"
+  end
+
   # @return [Boolean]
   def admin_exists?
     kube_client.api('beta.kontena.io/v1').resource('users').get('admin')
@@ -131,9 +145,9 @@ Pharos.addon 'kontena-lens' do
   end
 
   # @param name [String]
-  # @param kubernetes_api_url [String]
+  # @param cluster_url [String]
   # @return [K8s::Resource]
-  def create_config(name, kubernetes_api_url)
+  def create_configmap(name, cluster_url)
     config = K8s::Resource.new(
       apiVersion: 'v1',
       kind: 'ConfigMap',
@@ -143,7 +157,7 @@ Pharos.addon 'kontena-lens' do
       },
       data: {
         clusterName: name,
-        clusterUrl: kubernetes_api_url
+        clusterUrl: cluster_url
       }
     )
     kube_client.api('v1').resource('configmaps').create_resource(config)
@@ -203,10 +217,12 @@ Pharos.addon 'kontena-lens' do
     nil
   end
 
-  # @param new_name [String]
+  # @param name [String]
+  # @param cluster_url [String]
   # @return [K8s::Resource]
-  def update_lens_name(new_name)
-    configmap.data.clusterName = new_name
+  def update_configmap(name, cluster_url)
+    configmap.data.clusterName = name
+    configmap.data.clusterUrl = cluster_url
     kube_client.api('v1').resource('configmaps', namespace: 'kontena-lens').update_resource(configmap)
   end
 

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/02-redis-network-policy.yml
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/02-redis-network-policy.yml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis
+  namespace: kontena-lens
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} # matches to all pods within kontena-lens namespace
+    ports:
+    - port: 6379
+      protocol: TCP

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -46,6 +46,20 @@ describe Pharos::Config do
       end
     end
 
+    context 'non unique ip' do
+      let(:hosts) { [
+        { 'address' => ' 192.0.2.1', 'role' => 'master' },
+        { 'address' => ' 192.0.2.1', 'role' => 'worker' }
+      ] }
+      it 'fails to load' do
+        expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
+          expect(exc.errors[:hosts]).to match hash_including(
+            0 => hash_including(address: array_including("is not unique")),
+            1 => hash_including(address: array_including("is not unique"))
+          )
+        end
+      end
+    end
 
     context 'without hosts' do
       let(:data) { {} }


### PR DESCRIPTION
## Changes since v2.3.5

- Add ExternalIP to kubelet-preferred-address-types for metric-server (#1293)
- Kontena Lens: read kubernetes api endpoint from cluster config (#1291) [Pro]
- Kontena Lens: add missing redis network policy (#1298) [Pro]
- Validate configuration host address uniqueness (#1260)
- Fix local transport mode detect (#1280)
- Firewalld: remove masquerade (#1297)