### PR TITLE
Pharos init command for cluster.yml bootstrapping

### DIFF
--- a/lib/pharos/init_command.rb
+++ b/lib/pharos/init_command.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Pharos
+  class InitCommand < Pharos::Command
+    using Pharos::CoreExt::DeepTransformKeys
+
+    option %w(-c --config), 'FILE', 'output filename', default: 'cluster.yml', attribute_name: :config_file
+    option '--defaults', :flag, 'include all configuration default values'
+
+    option %w(-m --master), 'HOST', 'master host [user@]address[:port]' do |master|
+      @hosts ||= []
+      @hosts << parse_host(master).merge(role: 'master')
+    end
+
+    option %w(-w --worker), 'HOST', 'worker host [user@]address[:port]' do |worker|
+      @hosts ||= []
+      @hosts << parse_host(worker).merge(role: 'worker')
+    end
+
+    option %w(-b --bastion), 'HOST', 'bastion (ssh proxy) host [user@]address[:port]' do |bastion|
+      parse_host(bastion)
+    end
+
+    option %w(-n --name), 'NAME', 'cluster name'
+
+    def parse_host(host_str)
+      user = host_str[/(.+?)@/, 1]
+      address = host_str[/(?:.+?@)?([^:]+)/, 1]
+      ssh_port = host_str[/:(\d+)/, 1]&.to_i
+      { address: address, user: user, ssh_port: ssh_port }
+    end
+
+    PRESET_CFG = <<~CONFIG_TPL
+      # For full configuration reference, see https://pharos.sh/docs/configuration/
+      ---
+      name: <%= name  %>
+
+      host_defaults: &host_defaults
+        user: <%= host_defaults[:user] %>
+        ssh_key_path: <%= host_defaults[:ssh_key_path] %>
+        ssh_port: 22
+        # environment:
+        #   HTTP_PROXY: 192.168.0.1
+        <%- if bastion -%>
+        bastion:
+          address: <%= bastion[:address] %>
+          <%- if bastion[:user] -%>
+          user: <%= bastion[:user] %>
+          <%- end -%>
+          <%- if bastion[:ssh_port] -%>
+          ssh_port: <%= bastion[:ssh_port] %>
+          <%- end -%>
+          # ssh_key_path: ~/.ssh/id_rsa
+        <%- else -%>
+        # bastion:
+        #   address: 192.168.0.1
+        #   user: bastion
+        #   ssh_key_path: ~/.ssh/id_rsa
+        <%- end -%>
+
+      hosts:
+        <%- hosts.each do |host| -%>
+        - <<: *host_defaults
+          address: <%= host[:address] %>
+          <%- if host[:user] != host_defaults[:user] -%>
+          user: <%= host[:user] %>
+          <%- end -%>
+          <%- if host[:private_address] -%>
+          private_address: <%= host[:private_address] %>
+          <%- end -%>
+          <%- if host[:ssh_port] != host_defaults[:ssh_port] -%>
+          ssh_port: <%= host[:ssh_port] %>
+          <%- end -%>
+          role: <%= host[:role] %>
+        <%- end -%>
+
+      network:
+        provider: weave
+
+      addons:
+        ingress-nginx:
+          enabled: true
+    CONFIG_TPL
+
+    def default_name
+      Pharos::Phases::ConfigureClusterName.new('').random_name
+    end
+
+    def host_defaults
+      {}.tap do |defaults|
+        defaults[:ssh_key_path] = '~/.ssh/id_rsa'
+        defaults[:bastion] = bastion if bastion
+        defaults[:user] = hosts.find { |h| h[:user] }&.fetch(:user) || ENV['USER'] || 'username'
+      end
+    end
+
+    def hosts
+      @hosts ||= [
+        { address: '10.0.0.1', private_address: '172.16.0.1', role: 'master', ssh_key_path: '~/.ssh/id_rsa' },
+        { address: '10.0.0.2', private_address: '172.16.0.2', role: 'worker', ssh_key_path: '~/.ssh/id_rsa' }
+      ]
+    end
+
+    def config_content
+      require 'pharos/phases/configure_cluster_name'
+
+      if defaults?
+        hosts.each { |h| h.replace(host_defaults.merge(h)) }
+        {
+          name: name,
+          hosts: hosts.map { |h| h.merge(host_defaults) }
+        }.merge(Pharos::Config.new.to_h).deep_stringify_keys.to_yaml
+      else
+        Pharos::YamlFile.new(StringIO.new(PRESET_CFG)).erb_result(
+          hosts: hosts,
+          bastion: bastion,
+          host_defaults: host_defaults,
+          name: name
+        )
+      end
+    end
+
+    def execute
+      signal_error "configuration file #{config_file} already exists" if File.exist?(config_file)
+      File.write(config_file, config_content)
+    end
+  end
+end
+

--- a/lib/pharos/init_command.rb
+++ b/lib/pharos/init_command.rb
@@ -4,15 +4,17 @@ module Pharos
   class InitCommand < Pharos::Command
     using Pharos::CoreExt::DeepTransformKeys
 
+    banner 'Create a Pharos cluster configuration'
+
     option %w(-c --config), 'FILE', 'output filename', default: 'cluster.yml', attribute_name: :config_file
     option '--defaults', :flag, 'include all configuration default values'
 
-    option %w(-m --master), 'HOST', 'master host [user@]address[:port]' do |master|
+    option %w(-m --master), 'HOST', 'master host [user@]address[:port] (can be given multiple times)' do |master|
       @hosts ||= []
       @hosts << parse_host(master).merge(role: 'master')
     end
 
-    option %w(-w --worker), 'HOST', 'worker host [user@]address[:port]' do |worker|
+    option %w(-w --worker), 'HOST', 'worker host [user@]address[:port] (can be given multiple times)' do |worker|
       @hosts ||= []
       @hosts << parse_host(worker).merge(role: 'worker')
     end

--- a/lib/pharos/phases/configure_cluster_name.rb
+++ b/lib/pharos/phases/configure_cluster_name.rb
@@ -71,9 +71,13 @@ module Pharos
         return false if @config.name
         return nil if cluster_context['no-generate-name']
 
-        new_name = "#{ADJECTIVES.sample}-#{NOUNS.sample}-#{'%04d' % rand(9999)}"
+        new_name = random_name
         logger.info "Using generated random name #{new_name.magenta} as cluster name"
         new_name
+      end
+
+      def random_name
+        "#{ADJECTIVES.sample}-#{NOUNS.sample}-#{'%04d' % rand(9999)}"
       end
     end
   end

--- a/lib/pharos/root_command.rb
+++ b/lib/pharos/root_command.rb
@@ -6,6 +6,7 @@ require_relative 'version_command'
 require_relative 'kubeconfig_command'
 require_relative 'exec_command'
 require_relative 'terraform_command'
+require_relative 'init_command'
 
 module Pharos
   class RootCommand < Pharos::Command
@@ -16,6 +17,7 @@ module Pharos
     subcommand "reset", "reset cluster", ResetCommand
     subcommand %w(exec ssh), "run a command or an interactive session on a host", ExecCommand
     subcommand %w(tf terraform), "terraform specific commands", TerraformCommand
+    subcommand "init", "create an initial cluster configuration file", InitCommand
     subcommand "version", "show version information", VersionCommand
   end
 end


### PR DESCRIPTION
Fixes #1276 

Adds a `pharos init` subcommand for creating an initial pharos cluster.yml configuration file.

### Help
```
$ pharos init --help
Usage:
    pharos init [OPTIONS]

  Create a Pharos cluster configuration

Options:
    -c, --config FILE             output filename (default: "cluster.yml")
    --defaults                    include all configuration default values
    -m, --master HOST             master host [user@]address[:port]
    -w, --worker HOST             worker host [user@]address[:port]
    -b, --bastion HOST            bastion (ssh proxy) host [user@]address[:port]
    -n, --name NAME               cluster name
    -e, --env KEY=VALUE           host environment variables (can be given multiple times)
    -i, --ssh-key-path PATH       ssh key path
    -h, --help                    print help
    --[no-]color                  colorize output (default: true)
    -v, --version                 print pharos version
    -d, --debug                   enable debug output (default: $DEBUG)
```

### No params:

```
$ pharos init; cat cluster.yml
```

-->

```yaml
# For full configuration reference, see https://pharos.sh/docs/configuration/
---
name: dark-wind-5414

host_defaults: &host_defaults
  user: kimmo
  ssh_key_path: ~/.ssh/id_rsa
  ssh_port: 22
  # environment:
  #   HTTP_PROXY: 192.168.0.1
  # bastion:
  #   address: 192.168.0.1
  #   user: bastion
  #   ssh_key_path: ~/.ssh/id_rsa

hosts:
  - <<: *host_defaults
    address: 10.0.0.1
    user:
    private_address: 172.16.0.1
    role: master
  - <<: *host_defaults
    address: 10.0.0.2
    user:
    private_address: 172.16.0.2
    role: worker

network:
  provider: weave

addons:
  ingress-nginx:
    enabled: true
```

### Pharos::Config defaults:

```
$ pharos init --defaults; cat cluster.yml
```

--->

```yaml
---
name: white-bird-6458
hosts:
- ssh_key_path: "~/.ssh/id_rsa"
  user: kimmo
  address: 10.0.0.1
  private_address: 172.16.0.1
  role: master
- ssh_key_path: "~/.ssh/id_rsa"
  user: kimmo
  address: 10.0.0.2
  private_address: 172.16.0.2
  role: worker
network:
  provider: weave
  service_cidr: 10.96.0.0/12
  pod_network_cidr: 10.32.0.0/12
  node_local_dns_cache: true
  firewalld:
    enabled: false
    open_ports:
    - port: '22'
      protocol: tcp
      roles:
      - "*"
    - port: '80'
      protocol: tcp
      roles:
      - worker
    - port: '443'
      protocol: tcp
      roles:
      - worker
    - port: '6443'
      protocol: tcp
      roles:
      - master
    - port: 30000-32767
      protocol: tcp
      roles:
      - "*"
    - port: 30000-32767
      protocol: udp
      roles:
      - "*"
  weave:
    no_masq_local: false
  calico:
    ipip_mode: Always
    nat_outgoing: true
    environment: {}
    mtu: 1500
  custom: {}
kube_proxy:
  mode: iptables
api: {}
etcd: {}
cloud: {}
authentication:
  token_webhook: {}
  oidc: {}
audit:
  webhook: {}
  file: {}
kubelet:
  read_only_port: false
control_plane:
  use_proxy: false
telemetry:
  enabled: true
pod_security_policy:
  default_policy: 00-pharos-privileged
image_repository: registry.pharos.sh/kontenapharos
addon_paths: []
addons: {}
container_runtime:
  insecure_registries: []
```

### Initialize with ssh user@host and bastion

```
$ pharos init -m vagrant@192.168.100.100 -w vagrant@10.0.0.1:2444 -w root@10.0.0.2 -b bastion@127.0.0.1:224; cat cluster.yml
```

-->

```yaml
# For full configuration reference, see https://pharos.sh/docs/configuration/
---
name: billowing-river-7649

host_defaults: &host_defaults
  user: vagrant
  ssh_key_path: ~/.ssh/id_rsa
  ssh_port: 22
  # environment:
  #   HTTP_PROXY: 192.168.0.1
  bastion:
    address: 127.0.0.1
    user: bastion
    ssh_port: 224
    # ssh_key_path: ~/.ssh/id_rsa

hosts:
  - <<: *host_defaults
    address: 192.168.100.100
    role: master
  - <<: *host_defaults
    address: 10.0.0.1
    ssh_port: 2444
    role: worker
  - <<: *host_defaults
    address: 10.0.0.2
    user: root
    role: worker

network:
  provider: weave

addons:
  ingress-nginx:
    enabled: true
```

### SSH user@host, bastion + defaults

```
$ pharos init -m vagrant@192.168.100.100 -w vagrant@10.0.0.1:2444 -w root@10.0.0.2 -b bastion@127.0.0.1:224 --defaults; cat cluster.yml
```

-->

```yaml
---
name: black-snow-4463
hosts:
- ssh_key_path: "~/.ssh/id_rsa"
  bastion:
    address: 127.0.0.1
    user: bastion
    ssh_port: 224
  user: vagrant
  address: 192.168.100.100
  ssh_port:
  role: master
- ssh_key_path: "~/.ssh/id_rsa"
  bastion:
    address: 127.0.0.1
    user: bastion
    ssh_port: 224
  user: vagrant
  address: 10.0.0.1
  ssh_port: 2444
  role: worker
- ssh_key_path: "~/.ssh/id_rsa"
  bastion:
    address: 127.0.0.1
    user: bastion
    ssh_port: 224
  user: vagrant
  address: 10.0.0.2
  ssh_port:
  role: worker
network:
  provider: weave
  service_cidr: 10.96.0.0/12
  pod_network_cidr: 10.32.0.0/12
  node_local_dns_cache: true
  firewalld:
    enabled: false
    open_ports:
    - port: '22'
      protocol: tcp
      roles:
      - "*"
    - port: '80'
      protocol: tcp
      roles:
      - worker
    - port: '443'
      protocol: tcp
      roles:
      - worker
    - port: '6443'
      protocol: tcp
      roles:
      - master
    - port: 30000-32767
      protocol: tcp
      roles:
      - "*"
    - port: 30000-32767
      protocol: udp
      roles:
      - "*"
  weave:
    no_masq_local: false
  calico:
    ipip_mode: Always
    nat_outgoing: true
    environment: {}
    mtu: 1500
  custom: {}
```

