### PR TITLE
Weave flying-shuttle v0.3.0

### DIFF
--- a/lib/pharos/phases/configure_weave.rb
+++ b/lib/pharos/phases/configure_weave.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Configure Weave network"
 
       WEAVE_VERSION = '2.5.1'
-      WEAVE_FLYING_SHUTTLE_VERSION = '0.2.0'
+      WEAVE_FLYING_SHUTTLE_VERSION = '0.3.0'
 
       register_component(
         name: 'weave-net', version: WEAVE_VERSION, license: 'Apache License 2.0',

--- a/lib/pharos/resources/weave/01-cluster-role.yml.erb
+++ b/lib/pharos/resources/weave/01-cluster-role.yml.erb
@@ -26,6 +26,9 @@ rules:
   - apiGroups:
       - ''
     resources:
+    <% if flying_shuttle_enabled %>
+    - nodes
+    <% end -%>
     - nodes/status
     verbs:
     - patch

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -116,6 +116,12 @@ spec:
           resources:
             requests:
               cpu: 10m
+              memory: 20Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: xtables-lock
+              mountPath: /run/xtables.lock
         <% end %>
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Routes kubelet ports automatically via overlay network (based on region labels). Basically fixes broken logs/exec & metrics-server collection on clusters that have multiple datacenters with separate private networks. In theory should fix also cases where workers nodes are behind NAT, they just need to be able to call back home to kubernetes control-plane.