### PR TITLE
Ingress-NGINX addon: add resource requests

### DIFF
--- a/addons/ingress-nginx/resources/daemonset.yml.erb
+++ b/addons/ingress-nginx/resources/daemonset.yml.erb
@@ -95,3 +95,7 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 90Mi


### PR DESCRIPTION
Currently ingress-nginx might not get enough cpu shares because QoS is `BestEffort`. 