### PR TITLE
cert-manager extra_args

### DIFF
--- a/addons/cert-manager/addon.rb
+++ b/addons/cert-manager/addon.rb
@@ -26,7 +26,7 @@ Pharos.addon 'cert-manager' do
       required(:email).filled(:str?)
       optional(:server).filled(:str?)
     }
-    
+
     optional(:extra_args).each(:str?)
 
     optional(:ca_issuer).schema {

--- a/addons/cert-manager/addon.rb
+++ b/addons/cert-manager/addon.rb
@@ -17,7 +17,7 @@ Pharos.addon 'cert-manager' do
   config {
     attribute :issuer, issuer
     attribute :ca_issuer, ca_issuer.default(proc { ca_issuer.new(enabled: true) })
-    attribute :extra_args, Pharos::Types::Array.default([])
+    attribute :extra_args, Pharos::Types::Array.default(proc { [] })
   }
 
   config_schema {

--- a/addons/cert-manager/addon.rb
+++ b/addons/cert-manager/addon.rb
@@ -25,8 +25,9 @@ Pharos.addon 'cert-manager' do
       required(:name).filled(:str?)
       required(:email).filled(:str?)
       optional(:server).filled(:str?)
-      optional(:extra_args).each(:str?)
     }
+    
+    optional(:extra_args).each(:str?)
 
     optional(:ca_issuer).schema {
       optional(:enabled).filled(:bool?)

--- a/addons/cert-manager/addon.rb
+++ b/addons/cert-manager/addon.rb
@@ -17,6 +17,7 @@ Pharos.addon 'cert-manager' do
   config {
     attribute :issuer, issuer
     attribute :ca_issuer, ca_issuer.default(proc { ca_issuer.new(enabled: true) })
+    attribute :extra_args, Pharos::Types::Array.default([])
   }
 
   config_schema {
@@ -24,6 +25,7 @@ Pharos.addon 'cert-manager' do
       required(:name).filled(:str?)
       required(:email).filled(:str?)
       optional(:server).filled(:str?)
+      optional(:extra_args).each(:str?)
     }
 
     optional(:ca_issuer).schema {

--- a/addons/cert-manager/resources/20-deployment.yml.erb
+++ b/addons/cert-manager/resources/20-deployment.yml.erb
@@ -18,6 +18,9 @@ spec:
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)
+          <% config.extra_args.each do |arg| %>
+          - <%= arg %>
+          <% end %>
           env:
           - name: POD_NAMESPACE
             valueFrom:


### PR DESCRIPTION
Allowing cert-manager to use extra_args for dns01-validation
https://docs.cert-manager.io/en/latest/tasks/acme/configuring-dns01/index.html
--dns01-self-check-nameservers "8.8.8.8:53,1.1.1.1:53"

I hope this is enough change for extra_args to work, I am not sure of the syntax in addon.rb