### PR TITLE
Release v2.4.0-alpha.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.0-alpha.0"
+  VERSION = "2.4.0-alpha.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since 2.3.x

- Kubernetes v1.14.1 (#1300)
- New sub-command: `pharos worker up` (#1235)
- Pharos cloud-controller (#953)
- Improved out-of-tree cloud provider support (#1186)
  - Hetzner Cloud cloud-controller + csi
  - Packet cloud-controller
- Weave flying-shuttle v0.3.0 (#1309)
- Allow to set extra args for kubelet (#1279)