### PR TITLE
Fix Lens redis toleration

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/10-redis-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/10-redis-deployment.yml.erb
@@ -20,6 +20,7 @@ spec:
       tolerations:
         - effect: NoSchedule
           operator: Exists
+          key: node-role.kubernetes.io/master
       priorityClassName: pharos-cluster-critical
       containers:
       - name: redis


### PR DESCRIPTION
This PR adds `node-role.kubernetes.io/master` toleration key to  Lens redis deployment.