### PR TITLE
Allow user to configure CFS quota setting for kubelet

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -206,6 +206,8 @@ module Pharos
           optional(:read_only_port).filled(:bool?)
           optional(:feature_gates).filled
           optional(:extra_args).each(type?: String)
+          optional(:cpu_cfs_quota).filled(:bool?)
+          optional(:cpu_cfs_quota_period).filled(:str?)
         end
         optional(:control_plane).schema do
           optional(:use_proxy).filled(:bool?)

--- a/lib/pharos/configuration/kubelet.rb
+++ b/lib/pharos/configuration/kubelet.rb
@@ -6,6 +6,8 @@ module Pharos
       attribute :read_only_port, Pharos::Types::Bool.default(false)
       attribute :feature_gates, Pharos::Types::Strict::Hash
       attribute :extra_args, Pharos::Types::Strict::Array.of(Pharos::Types::String)
+      attribute :cpu_cfs_quota, Pharos::Types::Bool.default(true)
+      attribute :cpu_cfs_quota_period, Pharos::Types::String
     end
   end
 end

--- a/lib/pharos/kubeadm/kubelet_config.rb
+++ b/lib/pharos/kubeadm/kubelet_config.rb
@@ -36,6 +36,10 @@ module Pharos
         end
 
         config['featureGates'] = feature_gates unless feature_gates.empty?
+
+        config['cpuCFSQuotaPeriod'] = @config&.kubelet&.cpu_cfs_quota_period if @config&.kubelet&.cpu_cfs_quota_period
+        config['cpuCFSQuota'] = !!@config&.kubelet&.cpu_cfs_quota
+
         config
       end
     end

--- a/lib/pharos/phases/configure_kubelet.rb
+++ b/lib/pharos/phases/configure_kubelet.rb
@@ -143,6 +143,7 @@ module Pharos
         args << "--pod-infra-container-image=#{@config.image_repository}/pause:3.1"
         args << "--cloud-provider=#{@config.cloud.resolve_provider}" if @config.cloud
         args << "--cloud-config=#{CLOUD_CONFIG_FILE}" if @config.cloud&.intree_provider? && @config.cloud&.config
+
         args
       end
     end

--- a/spec/pharos/kubeadm/kubelet_config_spec.rb
+++ b/spec/pharos/kubeadm/kubelet_config_spec.rb
@@ -53,5 +53,57 @@ describe Pharos::Kubeadm::KubeletConfig do
         expect(config['featureGates']).to eq({ foo: true })
       end
     end
+
+    context 'with kubelet.cpu_cfs_quota' do
+      let(:config) { Pharos::Config.new(
+        hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
+        network: {},
+        kubelet: {}
+      ) }
+
+      it 'is true by default' do
+        config = subject.generate
+        expect(config['cpuCFSQuota']).to eq(true)
+      end
+
+      it 'is false only when set so' do
+        cfg = Pharos::Config.new(
+          hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
+          network: {},
+          kubelet: {
+            cpu_cfs_quota: false
+          }
+        )
+        config = described_class.new(cfg, master).generate
+        expect(config['cpuCFSQuota']).to eq(false)
+      end
+    end
+
+    context 'with kubelet.cpu_cfs_quota_period' do
+      let(:config) { Pharos::Config.new(
+        hosts: (1..config_hosts_count).map { |i| Pharos::Configuration::Host.new() },
+        network: {},
+        kubelet: kubelet_config
+      ) }
+
+      let(:kubelet_config) {}
+
+      context "by default" do
+        it 'is not set' do
+          config = subject.generate
+          expect(config['cpuCFSQuotaPeriod']).to be_nil
+        end
+      end
+
+      context "when set" do
+        let(:kubelet_config) {
+          {cpu_cfs_quota_period: "5ms"}
+        }
+        it 'is set' do
+          config = subject.generate
+          expect(config['cpuCFSQuotaPeriod']).to eq("5ms")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
By default CFS quota is on with period of 100ms. That can cause serious latencies in many cases. See:
- https://github.com/kubernetes/kubernetes/issues/51135
- https://github.com/kubernetes/kubernetes/issues/67577
- https://github.com/zalando-incubator/kubernetes-on-aws/issues/1026
- https://github.com/zalando/public-presentations/blob/master/files/2019-05-15_Optimizing_Kubernetes_Resource_Requests_Limits_for_Cost-Efficiency_and_Latency_-_JAX_DevOps_London.pdf

This PR makes both the CFS quota itself as well as the period configurable for users.
