### PR TITLE
Add --trust-hosts option to up command

### DIFF
--- a/lib/pharos/terraform/apply_command.rb
+++ b/lib/pharos/terraform/apply_command.rb
@@ -8,6 +8,7 @@ module Pharos
       options :load_config
 
       option ['-f', '--force'], :flag, "force upgrade"
+      option ['--trust-hosts'], :flag, "removes addresses from ~/.ssh/known_hosts before connecting"
 
       def execute
         tf_workspace
@@ -35,6 +36,7 @@ module Pharos
         cmd << ".#{workspace}.json"
         cmd << '-y' if yes?
         cmd << '--force' if force?
+        cmd << '--trust-hosts' if trust_hosts?
 
         Pharos::UpCommand.new('pharos').run(cmd)
       end

--- a/lib/pharos/up_command.rb
+++ b/lib/pharos/up_command.rb
@@ -8,6 +8,7 @@ module Pharos
 
     option ['-n', '--name'], 'NAME', 'use as cluster name', attribute_name: :new_name
     option ['-f', '--force'], :flag, "force upgrade"
+    option ['--trust-hosts'], :flag, "remove hosts from ~/.ssh/known_hosts before connecting"
 
     def execute
       puts "==> KONTENA PHAROS v#{Pharos.version} (Kubernetes v#{Pharos::KUBE_VERSION})".bright_green
@@ -16,6 +17,11 @@ module Pharos
 
       config = load_config
       config.attributes[:name] = new_name if new_name
+      if trust_hosts?
+        config.hosts.each do |host|
+          `ssh-keygen -R #{host.address}`
+        end
+      end
 
       # set workdir to the same dir where config was loaded from
       # so that the certs etc. can be referenced more easily


### PR DESCRIPTION
Adds `--trust-hosts` to `up` and `tf apply` commands.