### PR TITLE
Add kube-state-metrics agent

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-stats/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-stats/addon.rb
@@ -3,6 +3,7 @@
 Pharos.addon('kontena-stats') do
   prometheus_version = '2.9.2'
   node_exporter_version = '0.18.0'
+  kube_state_metrics_version = '1.6.0'
   version "#{prometheus_version}+kontena.1"
   license 'Kontena License'
   priority 9
@@ -43,7 +44,8 @@ Pharos.addon('kontena-stats') do
     apply_resources(
       prometheus_version: prometheus_version,
       prometheus_pvc_size: prometheus_pvc_size,
-      node_exporter_version: node_exporter_version
+      node_exporter_version: node_exporter_version,
+      kube_state_metrics_version: kube_state_metrics_version
     )
     if config.persistence&.enabled
       logger.info "Calculated PVC size: #{prometheus_pvc_size}"

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/12-kube-state-metrics-clusterrole.yml
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/12-kube-state-metrics-clusterrole.yml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - ingresses
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/12.kube-state-metrics-sa.yml
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/12.kube-state-metrics-sa.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kontena-stats

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/13-kube-state-metrics-clusterrole-binding.yml
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/13-kube-state-metrics-clusterrole-binding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kontena-stats

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-deployment.yml.erb
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: kontena-stats
+spec:
+  selector:
+    matchLabels:
+      name: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: <%= image_repository %>/prometheus-kube-state-metrics:v<%= kube_state_metrics_version %>
+        ports:
+        - name: metrics
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 300Mi

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-deployment.yml.erb
@@ -29,7 +29,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 200Mi
+            memory: 150Mi
           limits:
-            cpu: 200m
-            memory: 300Mi
+            cpu: 100m
+            memory: 150Mi

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-svc.yml
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-svc.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: kontena-stats
+  labels:
+    name: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    name: kube-state-metrics


### PR DESCRIPTION
This PR adds [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) agent to `kontena-stats` addon.

Fixes #1350 
Depends on: https://github.com/kontena/pharos-addon-zipper/pull/8