### PR TITLE
Add max time for command executions

### DIFF
--- a/lib/pharos/transport/command/local.rb
+++ b/lib/pharos/transport/command/local.rb
@@ -10,9 +10,11 @@ module Pharos
 
         # @param client [Pharos::Transport::Local] client instance
         # @param cmd [String,Array<String>] command to execute
+        # @param timeout [Integer,NilClass] max seconds to allow the command to run
         # @param stdin [String,IO] attach string or stream to command STDIN
         # @param source [String]
-        def initialize(client, cmd, stdin: nil, source: nil)
+        def initialize(client, cmd, timeout: 600, stdin: nil, source: nil)
+          @timeout = timeout.to_i
           @client = client
           @cmd = "env bash --noprofile --norc -x -c #{(cmd.is_a?(Array) ? cmd.join(' ') : cmd).shellescape}"
           @stdin = stdin.respond_to?(:read) ? stdin.read : stdin
@@ -40,33 +42,85 @@ module Pharos
 
         # @return [Pharos::Transport::Command::Result]
         def run
-          result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
-          Open3.popen3(@cmd) do |stdin, stdout, stderr, wait_thr|
-            unless stdin.closed?
-              stdin.write(@stdin) if @stdin
-              stdin.close
-            end
+          with_timeout do
+            result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
+            Open3.popen3(@cmd) do |stdin, stdout, stderr, wait_thr|
+              unless stdin.closed?
+                stdin.write(@stdin) if @stdin
+                stdin.close
+              end
 
-            until [stdout, stderr].all?(&:eof?)
-              readable = IO.select([stdout, stderr])
-              next unless readable&.first
+              until [stdout, stderr].all?(&:eof?)
+                readable = IO.select([stdout, stderr])
+                next unless readable&.first
 
-              readable.first.each do |stream|
-                data = +''
-                # rubocop:disable Lint/HandleExceptions
-                begin
-                  stream.read_nonblock(1024, data)
-                rescue EOFError
-                  # ignore, it's expected for read_nonblock to raise EOFError
-                  # when all is read
+                readable.first.each do |stream|
+                  data = +''
+                  # rubocop:disable Lint/HandleExceptions
+                  begin
+                    stream.read_nonblock(1024, data)
+                  rescue EOFError
+                    # ignore, it's expected for read_nonblock to raise EOFError
+                    # when all is read
+                  end
+                  # rubocop:enable Lint/HandleExceptions
+                  result.append(data, stream == stdout ? :stdout : :stderr) unless data.empty?
                 end
-                # rubocop:enable Lint/HandleExceptions
-                result.append(data, stream == stdout ? :stdout : :stderr) unless data.empty?
+              end
+              result.exit_status = wait_thr.value.exitstatus
+            end
+            result
+          end
+        end
+
+        private
+
+        def with_timeout
+          return yield unless @timeout.positive?
+
+          start_time = Time.now
+
+          thread = Thread.new do
+            Thread.current.report_on_exception = false
+            yield
+          end
+
+          keep_running = true
+          extra_time_start = nil
+          kill_switch_engage = true
+
+          loop do
+            break unless thread.alive?
+
+            sleep 0.1 unless extra_time_start
+
+            if kill_switch_engage && Time.now - start_time > @timeout
+              if !$stdin.tty?
+                warn "Command timeout reached"
+                thread.raise Timeout::Error
+                break
+              elsif extra_time_start.nil?
+                warn "Command timeout reached, to cancel automatic termination, press any key in 30 seconds"
+                extra_time_start = Time.now
+              end
+
+              if extra_time_start && Time.now - extra_time_start < 30
+                $stdin.noecho do
+                  $stdin.raw do
+                    if $stdin.wait_readable(0.1) && $stdin.getc
+                      kill_switch_engage = false
+                      puts "Automatic termination canceled"
+                    end
+                  end
+                end
+              else
+                thread.raise Timeout::Error
+                break
               end
             end
-            result.exit_status = wait_thr.value.exitstatus
           end
-          result
+
+          thread.value
         end
       end
     end

--- a/lib/pharos/transport/command/ssh.rb
+++ b/lib/pharos/transport/command/ssh.rb
@@ -14,35 +14,37 @@ module Pharos
         def run
           @client.connect unless @client.connected?
 
-          result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
-          response = @client.session.open_channel do |channel|
-            channel.env('LC_ALL', 'C.UTF-8')
-            channel.exec @cmd do |_, success|
-              raise Pharos::ExecError, "Failed to exec #{cmd}" unless success
+          with_timeout do
+            result.append(@source.nil? ? @cmd : "#{@cmd} < #{@source}", :cmd)
+            response = @client.session.open_channel do |channel|
+              channel.env('LC_ALL', 'C.UTF-8')
+              channel.exec @cmd do |_, success|
+                raise Pharos::ExecError, "Failed to exec #{cmd}" unless success
 
-              channel.on_data do |_, data|
-                result.append(data, :stdout)
-              end
+                channel.on_data do |_, data|
+                  result.append(data, :stdout)
+                end
 
-              channel.on_extended_data do |_c, _type, data|
-                result.append(data, :stderr)
-              end
+                channel.on_extended_data do |_c, _type, data|
+                  result.append(data, :stderr)
+                end
 
-              channel.on_request("exit-status") do |_, data|
-                result.exit_status = data.read_long
-              end
+                channel.on_request("exit-status") do |_, data|
+                  result.exit_status = data.read_long
+                end
 
-              if @stdin
-                result.append(@stdin, :stdin)
-                channel.send_data(@stdin)
-                channel.eof!
+                if @stdin
+                  result.append(@stdin, :stdin)
+                  channel.send_data(@stdin)
+                  channel.eof!
+                end
               end
             end
+
+            response.wait
+
+            result
           end
-
-          response.wait
-
-          result
         rescue IOError
           @client.disconnect
           retry

--- a/lib/pharos/transport/local.rb
+++ b/lib/pharos/transport/local.rb
@@ -31,8 +31,8 @@ module Pharos
 
       private
 
-      def command(cmd, **options)
-        Pharos::Transport::Command::Local.new(self, cmd, **options)
+      def command(cmd, timeout: 900, **options)
+        Pharos::Transport::Command::Local.new(self, cmd, timeout: timeout, **options)
       end
     end
   end

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -122,8 +122,8 @@ module Pharos
 
       private
 
-      def command(cmd, **options)
-        Pharos::Transport::Command::SSH.new(self, cmd, **options)
+      def command(cmd, timeout: 900, **options)
+        Pharos::Transport::Command::SSH.new(self, cmd, timeout: timeout, **options)
       end
 
       def ensure_event_loop


### PR DESCRIPTION
The automatic termination can be canceled when in an interactive terminal by pressing a key during a 30 second safe-period.
