### PR TITLE
Release v2.4.0-beta.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.0-alpha.1"
+  VERSION = "2.4.0-beta.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.4.0-alpha.1

- Kubernetes v1.14.2 (#1332)
- Kontena-universal-lb addon (#1320) [Pro]
- Kontena-stats addon (#988, #1345, #1351) [Pro]
- Kontena-lens addon: add access to Lens service account to create tokenreviews (#1348) [Pro]
- Kontena-lens addon: add license manager (#1341) [Pro]
- Kontena-lens addon: version 1.6.0-alpha.2 (#1353) [Pro]
- Kontena-storage addon: version 0.9.3 (#1349) [Pro]
- Ingress-NGINX addon: version 0.23.0 (#1212)
- Cert-manager addon: version 0.7.2 (#1328)
- Cert-manager addon: extra_args (#1317)
- CRI-O v1.14.1 (#1329)
- Allow user to configure CFS quota setting for kubelet (#1327)
- Improved container-runtime upgrade logic (#1321)
- Calico 3.6.2 (#1333)
- Weave net 2.5.2 (#1334)
- Kontena-lens addon: fix Lens redis tolerations (#1326) [Pro]
- Add --trust-hosts option (#1339)
- Always tunnel Kube API client through master ssh (#1233)
- Make LabelNode phase run on single host (#1228)
- Ignore preflight errors during node join (#1294)
- Disable docker0 bridge (#1331)
- Addon deps (#1344)
