### PR TITLE
Fix kontena-storage mgr upgrade wait

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-storage/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-storage/addon.rb
@@ -158,7 +158,7 @@ Pharos.addon 'kontena-storage' do
     upgraded = false
     while !upgraded
       upgraded = rs_client.list(labelSelector: 'app=rook-ceph-mgr').any? { |rs|
-        rs.spec.template.spec.containers.first.image.include?("ceph/ceph:v#{ceph_version}")
+        rs.spec.template.spec.containers.first.image.include?("/ceph:v#{ceph_version}")
       }
       sleep 1
     end


### PR DESCRIPTION
Upgrade from 2.3.x -> 2.4.0-beta.1 hangs because of this (if kontena-storage is enabled).