### PR TITLE
Fix debian firewalld start error

### DIFF
--- a/lib/pharos/host/debian/scripts/configure-essentials.sh
+++ b/lib/pharos/host/debian/scripts/configure-essentials.sh
@@ -11,11 +11,6 @@ if ! dpkg -l apt-transport-https software-properties-common curl > /dev/null; th
     apt-get install -y apt-transport-https software-properties-common curl
 fi
 
-if ! dpkg -l firewalld > /dev/null; then
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get install -y firewalld ipset
-fi
-
 autoupgrade_file="/etc/apt/apt.conf.d/20auto-upgrades"
 if [ ! -f "$autoupgrade_file" ]; then
     touch "$autoupgrade_file"

--- a/lib/pharos/host/debian/scripts/configure-firewalld.sh
+++ b/lib/pharos/host/debian/scripts/configure-firewalld.sh
@@ -4,9 +4,7 @@ set -e
 
 if ! dpkg -l firewalld > /dev/null; then
     export DEBIAN_FRONTEND=noninteractive
-    systemctl mask ebtables
-    apt-get install -y firewalld ipset
-
+    apt-get install -y firewalld ipset ebtables
     if ! systemctl is-active --quiet firewalld; then
         systemctl enable firewalld
         systemctl start firewalld


### PR DESCRIPTION
As seen on e2e. Might cause also CNI init-containers to fail.