### PR TITLE
Release v2.4.0-rc.1

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.0-beta.1"
+  VERSION = "2.4.0-rc.1"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.4.0-beta.1

- Kontena Lens: 1.6.0-beta.1 (#1377, #1378, #1382) [Pro]
- Terraform 0.12 support (#1371)
- Cert-manager: allow to set multiple issuers/clusterissuers (#1370)
- Helm addon: version 2.13.1 (#1375)
- Metrics-server 0.3.2 (#1376)
- Fix weave net ipam consensus race cond (#1360)
- Kontena-Lens: add node_selector and tolerations config options (#1355, #1380) [Pro]
- Don't log pharos kubelet proxy wait retries (#1374)
- k8s-client v0.10.1 (#1373)
- Weave flying shuttle 0.3.1 (#1381)
- Retry initial SSH connection opening for 60 seconds (#1372)
- Fix debian firewalld start error (#1365)
- Only set cloud provider in worker up when given [cluster-e2e] (#1347)
- Run "docker ps" in subshell using sudo (#1368)
- More SSH keepalive in e2e (#1364)
- Fix kontena-storage mgr upgrade wait (#1359) [Pro]
- Fix kontena-storage discovery toleration (#1388) [Pro]
- Remove deprecated openebs addon (#1358)
- Fix previous config retrieval (#1385)
- Lower SSH connect timeout from 60 to 5 seconds (#1386)
- Fix kontena-storage toolbox deployment (#1387) [Pro]
