### PR TITLE
Fix previous config retrieval

### DIFF
--- a/lib/pharos/phase.rb
+++ b/lib/pharos/phase.rb
@@ -131,6 +131,11 @@ module Pharos
       cluster_context['kube_client'] || raise("No Kubernetes API client available")
     end
 
+    # @return [Boolean] true if there's a configured kube_client available
+    def kube_client?
+      !!cluster_context['kube_client']
+    end
+
     # @param name [String]
     # @param vars [Hash]
     def kube_stack(name, **vars)

--- a/lib/pharos/phases/load_cluster_configuration.rb
+++ b/lib/pharos/phases/load_cluster_configuration.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Load cluster configuration"
 
       def call
-        return unless cluster_context['kubeconfig']
+        return unless kube_client?
 
         logger.info { "Loading cluster configuration configmap ..." }
 


### PR DESCRIPTION
Fixes #1366 

And probably several undiscovered bugs.

The `LoadClusterConfiguration` phase never went past the initial guard clause, because there's never a `cluster_context['kubeconfig']` anymore, there's just the `cluster_context['kube_client']`.

This was likely caused by #1233 

