### PR TITLE
Lower SSH connect timeout from 60 to 5 seconds [cluster-e2e]

### DIFF
--- a/lib/pharos/phases/connect_ssh.rb
+++ b/lib/pharos/phases/connect_ssh.rb
@@ -6,7 +6,7 @@ module Pharos
       title "Open SSH connection"
 
       def call
-        Retry.perform(60, logger: logger, exceptions: [Net::SSH::Disconnect, Net::SSH::Timeout, Net::SSH::ConnectionTimeout]) do
+        Retry.perform(60, logger: logger, exceptions: [Net::SSH::Disconnect, Net::SSH::Timeout, Net::SSH::ConnectionTimeout, Errno::EHOSTDOWN]) do
           host.transport.connect
         end
       end

--- a/lib/pharos/transport.rb
+++ b/lib/pharos/transport.rb
@@ -18,6 +18,7 @@ module Pharos
         opts[:keepalive] = true
         opts[:keepalive_interval] = 30
         opts[:keepalive_maxcount] = 5
+        opts[:timeout] = 5
         SSH.new(host.address, user: host.user, **opts.merge(options))
       end
     end


### PR DESCRIPTION
Fixes #1383 

Complements #1364 + #1372 

Before:
```
==> KONTENA PHAROS v2.4.0-beta.1 (Kubernetes v1.14.2)
==> Reading instructions ...
==> Sharpening tools ...
==> Check for Pharos upgrade @ localhost
    [localhost] Checking for a new version ...
    [localhost] Already at the latest version
    [localhost] Completed phase in 0.09s
==> Open SSH connection @ 192.168.100.100 192.168.100.101 192.168.100.102
    [192.168.100.102] Retry time limit exceeded
    [192.168.100.100] Retry time limit exceeded
    [192.168.100.101] Retry time limit exceeded
ERROR: Pharos::PhaseManager::Error : Phase failed on 3 hosts:
- 192.168.100.100:
    Net::SSH::ConnectionTimeout: Net::SSH::ConnectionTimeout
- 192.168.100.101:
    Net::SSH::ConnectionTimeout: Net::SSH::ConnectionTimeout
- 192.168.100.102:
    Net::SSH::ConnectionTimeout: Net::SSH::ConnectionTimeout
```

After:

```
==> KONTENA PHAROS v2.4.0-beta.1 (Kubernetes v1.14.2)
==> Reading instructions ...
==> Sharpening tools ...
==> Check for Pharos upgrade @ localhost
    [localhost] Checking for a new version ...
    [localhost] Already at the latest version
    [localhost] Completed phase in 0.07s
==> Open SSH connection @ 192.168.100.100 192.168.100.101 192.168.100.102
    [192.168.100.101] Retrying after 2 seconds (#1) ...
    [192.168.100.100] Retrying after 2 seconds (#1) ...
    [192.168.100.102] Retrying after 2 seconds (#1) ...
    [192.168.100.100] Retrying after 2 seconds (#2) ...
    [192.168.100.101] Retrying after 2 seconds (#2) ...
    [192.168.100.102] Retrying after 2 seconds (#2) ...
ERROR: Pharos::PhaseManager::Error : Phase failed on 3 hosts:
- 192.168.100.100:
    Errno::EHOSTDOWN: Host is down - connect(2) for 192.168.100.100:22
- 192.168.100.101:
    Errno::EHOSTDOWN: Host is down - connect(2) for 192.168.100.100:22
- 192.168.100.102:
    Errno::EHOSTDOWN: Host is down - connect(2) for 192.168.100.102:22
```

^ added EHOSTDOWN to retry errors, it should keep trying for the intended full minute now even if the host is down.

