### PR TITLE
Kontena Lens 1.6.0-rc.1

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -11,12 +11,12 @@ Pharos.addon 'kontena-lens' do
     'kontena-stats'
   ]
 
-  helm_api_version = '1.6.0-beta.1'
-  terminal_gateway_version = '1.6.0-beta.1'
-  terminal_version = '1.6.0-beta.1'
-  user_management_version = '1.5.1'
-  resource_applier_version = '1.5.1'
-  authenticator_version = '1.5.1'
+  helm_api_version = '1.6.0'
+  terminal_gateway_version = '1.6.0'
+  terminal_version = '1.6.0'
+  user_management_version = '1.6.0'
+  resource_applier_version = '1.6.0'
+  authenticator_version = '1.6.+'
   redis_version = '4-alpine'
   tiller_version = '2.13.1'
   license_enforcer_version = '0.1.1'

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -4,7 +4,7 @@ require 'bcrypt'
 require 'json'
 
 Pharos.addon 'kontena-lens' do
-  version '1.6.0-beta.1'
+  version '1.6.0-beta.2'
   license 'Kontena License'
   priority 10
   depends_on [

--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -4,7 +4,7 @@ require 'bcrypt'
 require 'json'
 
 Pharos.addon 'kontena-lens' do
-  version '1.6.0-beta.2'
+  version '1.6.0-rc.1'
   license 'Kontena License'
   priority 10
   depends_on [
@@ -16,7 +16,7 @@ Pharos.addon 'kontena-lens' do
   terminal_version = '1.6.0'
   user_management_version = '1.6.0'
   resource_applier_version = '1.6.0'
-  authenticator_version = '1.6.+'
+  authenticator_version = '1.6.0'
   redis_version = '4-alpine'
   tiller_version = '2.13.1'
   license_enforcer_version = '0.1.1'

--- a/non-oss/pharos_pro/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
@@ -37,10 +37,14 @@ spec:
           name: dashboard
           imagePullPolicy: Always
           env:
-            - name: KUBE_KONTENA_URL
+            - name: KUBE_USERS_URL
               value: http://usermanagement:9999
             - name: KUBE_TERMINAL_URL
               value: http://localhost:9998
+            - name: KUBE_HELM_URL
+              value: "http://helmcharts:9292"
+            - name: KUBE_RESOURCE_APPLIER_URL
+              value: "http://k8s-resource-applier:9393"
             - name: REDIS_CLIENT_HOST
               value: redis
             - name: USER_MANAGEMENT_ENABLED
@@ -48,7 +52,7 @@ spec:
             - name: CHARTS_ENABLED
               value: "<%=  charts_enabled %>"
             - name: KUBE_METRICS_URL
-              value: "http://prometheus.kontena-stats.svc.cluster.local"
+              value: "http://rbac-proxy.kontena-stats.svc.cluster.local"
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
This PR updates Kontena Lens to 1.6.0-beta.2 adds missing environment variables and changes metrics url to point upcoming rbac-proxy service (#1393).

Depends on: https://github.com/kontena/pharos-addon-zipper/pull/15