### PR TITLE
[poc] Normalize command execution

### DIFF
--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -11,9 +11,6 @@ module Pharos
         unless @host.environment.nil? || @host.environment.empty?
           logger.info "Updating environment file ..."
           host_configurer.update_env_file
-          logger.info "Reconnecting ..."
-          @host.transport.disconnect
-          @host.transport.connect
         end
 
         logger.info "Configuring script helpers ..."

--- a/lib/pharos/phases/gather_facts.rb
+++ b/lib/pharos/phases/gather_facts.rb
@@ -10,6 +10,12 @@ module Pharos
       FULL_HOSTNAME_CLOUD_PROVIDERS = %w(aws vsphere).freeze
 
       def call
+        logger.debug "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+        logger.debug transport.exec!('sudo env')
+        logger.debug "-----------------------------------"
+        logger.debug transport.exec!('echo $(sudo env)')
+        logger.debug ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+
         logger.info { "Checking sudo access ..." }
         check_sudo
         logger.info { "Gathering host facts ..." }

--- a/lib/pharos/transport.rb
+++ b/lib/pharos/transport.rb
@@ -7,7 +7,7 @@ module Pharos
   module Transport
     def self.for(host, **options)
       if host.local?
-        Local.new('localhost', **options)
+        Local.new(host, **options)
       else
         opts = {}
         opts[:keys] = [host.ssh_key_path] if host.ssh_key_path
@@ -19,7 +19,8 @@ module Pharos
         opts[:keepalive_interval] = 30
         opts[:keepalive_maxcount] = 5
         opts[:timeout] = 5
-        SSH.new(host.address, user: host.user, **opts.merge(options))
+        opts[:user] = host.user
+        SSH.new(host, **opts.merge(options))
       end
     end
   end

--- a/lib/pharos/transport/base.rb
+++ b/lib/pharos/transport/base.rb
@@ -20,7 +20,7 @@ module Pharos
 
       attr_reader :host
 
-      # @param host [String]
+      # @param host [Pharos::Configuration::Host]
       # @param opts [Hash]
       def initialize(host, **opts)
         super()
@@ -68,18 +68,12 @@ module Pharos
       end
 
       # @param name [String] name of script
-      # @param env [Hash] environment variables hash
       # @param path [String] real path to file, defaults to script
       # @raise [Pharos::ExecError]
       # @return [String] stdout
-      def exec_script!(name, env: {}, path: nil, **options)
+      def exec_script!(name, path: nil, **options)
         script = ::File.read(path || name)
-        cmd = %w(sudo env -i -)
-
-        cmd.concat(EXPORT_ENVS.merge(env).map { |key, value| "#{key}=\"#{value}\"" })
-        cmd.concat(%w(bash --norc --noprofile -x -s))
-        logger.debug { "exec: #{cmd}" }
-        exec!(cmd, stdin: script, source: name, **options)
+        exec!(nil, stdin: script, source: name, **options)
       end
 
       # @param cmd [String] command to execute

--- a/lib/pharos/transport/ssh.rb
+++ b/lib/pharos/transport/ssh.rb
@@ -21,7 +21,7 @@ module Pharos
         Net::SSH::Authentication::ED25519::OpenSSHPrivateKeyLoader::DecryptError
       ].freeze
 
-      # @param host [String]
+      # @param host [Pharos::Configuration::Host]
       # @param opts [Hash]
       def initialize(host, **opts)
         super(host, opts)
@@ -41,7 +41,7 @@ module Pharos
           logger.debug { "connect: #{@user}@#{@host} (#{@opts})" }
           non_interactive = true
           begin
-            @session = session_factory.start(@host, @user, @opts.merge(options).merge(non_interactive: non_interactive))
+            @session = session_factory.start(@host.address, @user, @opts.merge(options).merge(non_interactive: non_interactive))
             logger.debug "Connected"
             class_mutex.unlock if class_mutex.locked? && class_mutex.owned?
           rescue *RETRY_CONNECTION_ERRORS => exc


### PR DESCRIPTION
Normalize command execution environment.

Cons:
- Ugly (sudo is now a function because aliases can't be inherited into subshells)
- Complex conditional logic
- It's not exactly normalized because of ^

Pros:
- Even subshells now have the env they're supposed to
- No need to reconnect
- Should work on `Transport::Local`
- No more `env bash --noprofile --norc -x env -i sudo bash --noprofile --norc -s`

Might be simpler and saner to create some sort of `/usr/local/share/pharos/shell-exec`
