### PR TITLE
Fix line joining in gather facts spec

### DIFF
--- a/spec/pharos/phases/gather_facts_spec.rb
+++ b/spec/pharos/phases/gather_facts_spec.rb
@@ -134,7 +134,7 @@ describe Pharos::Phases::GatherFacts do
     ] }
 
     before do
-      allow(ssh).to receive(:exec!).with('sudo ip route').and_return(routes.join "\n" + "\n")
+      allow(ssh).to receive(:exec!).with('sudo ip route').and_return(routes.join("\n") + "\n")
     end
 
     it "returns valid routes" do


### PR DESCRIPTION
Minor spec change.

 `%w(a b).join "\n" + "\n"` => `a\n\nb`, I believe the intention was to get `a\nb\n`. It generates unnecessary errors in the debug log (and does not reflect real life output)
