### PR TITLE
Display ruby and rubygems versions in "pharos version" output

### DIFF
--- a/lib/pharos/version_command.rb
+++ b/lib/pharos/version_command.rb
@@ -5,6 +5,11 @@ module Pharos
     def execute
       puts "Kontena Pharos:"
       puts "  - #{File.basename($PROGRAM_NAME)} version #{Pharos.version}"
+      puts "Ruby:"
+      puts "  - #{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
+      puts "Rubygems:"
+      Gem.loaded_specs.map { |name, spec| "  - #{name} #{spec.version} (#{spec.licenses.join(', ')})" }.sort.each { |g| puts g }
+
       ClusterManager.new(Pharos::Config.new({})).load
 
       phases.each do |os, phases|


### PR DESCRIPTION
```
$ pharos version
Kontena Pharos:
  - pharos version 2.4.0-rc.1+oss
Ruby:
  - 2.6.3p62
Rubygems:
  - ast 2.4.0 (MIT)
  - bcrypt 3.1.12 (MIT)
  - bcrypt_pbkdf 1.0.1 (MIT)
  - bundler 1.17.2 (MIT)
  - byebug 11.0.1 (BSD-2-Clause)
  - clamp 1.2.1 (MIT)
  - coderay 1.1.2 (MIT)
  - concurrent-ruby 1.1.5 (MIT)
  - curses 1.3.1 (Ruby, BSD-2-Clause)
  - did_you_mean 1.3.0 (MIT)
  - diff-lcs 1.3 (MIT, Artistic-2.0, GPL-2.0+)
  - dry-configurable 0.8.3 (MIT)
  - dry-container 0.7.0 (MIT)
  - dry-core 0.4.7 (MIT)
  - dry-equalizer 0.2.2 (MIT)
  - dry-inflector 0.1.2 (MIT)
  - dry-logic 0.4.2 (MIT)
  - dry-struct 0.5.0 (MIT)
  - dry-types 0.13.2 (MIT)
  - dry-validation 0.12.1 (MIT)
  - ed25519 1.2.4 (MIT)
  - equatable 0.5.0 ()
  - et-orbi 1.2.1 (MIT)
  - etc 1.0.1 (BSD-2-Clause)
  - excon 0.62.0 (MIT)
  - fakefs 0.20.1 (MIT)
  - forwardable 1.2.0 (BSD-2-Clause)
  - fugit 1.1.10 (MIT)
  - hashdiff 0.3.9 (MIT)
  - ice_nine 0.11.2 (MIT)
  - jaro_winkler 1.5.2 (MIT)
  - jsonpath 0.9.9 (MIT)
  - k8s-client 0.10.1 (Apache-2.0)
  - method_source 0.9.2 (MIT)
  - multi_json 1.13.1 (MIT)
  - necromancer 0.5.0 (MIT)
  - net-ssh 5.2.0 (MIT)
  - parallel 1.17.0 (MIT)
  - parser 2.6.3.0 (MIT)
  - pastel 0.7.2 (MIT)
  - pharos-cluster 2.4.0.rc.1 (Apache-2.0)
  - pry 0.12.2 (MIT)
  - pry-byebug 3.7.0 (MIT)
  - psych 3.1.0 (MIT)
  - raabro 1.1.6 (MIT)
  - rainbow 3.0.0 (MIT)
  - rake 10.5.0 (MIT)
  - recursive-open-struct 1.1.0 (MIT)
  - rouge 3.3.0 (MIT, BSD-2-Clause)
  - rspec 3.8.0 (MIT)
  - rspec-core 3.8.0 (MIT)
  - rspec-expectations 3.8.3 (MIT)
  - rspec-mocks 3.8.0 (MIT)
  - rspec-support 3.8.0 (MIT)
  - rubocop 0.66.0 (MIT)
  - ruby-progressbar 1.10.1 (MIT)
  - to_regexp 0.2.1 ()
  - tty-color 0.4.3 (MIT)
  - tty-cursor 0.7.0 (MIT)
  - tty-prompt 0.19.0 (MIT)
  - tty-reader 0.6.0 (MIT)
  - tty-screen 0.7.0 (MIT)
  - tzinfo 2.0.0 (MIT)
  - unicode-display_width 1.5.0 (MIT)
  - wisper 2.0.0 (MIT)
  - yajl-ruby 1.4.1 (MIT)
  - yaml-safe_load_stream 0.1.1 (Apache-2.0)
Common:
  - calico-cni 3.6.2 (Apache License 2.0)
  - calico-kube-controllers 3.6.2 (Apache License 2.0)
  - calico-node 3.6.2 (Apache License 2.0)
  - coredns 1.3.1 (Apache License 2.0)
  - dns-node-cache 1.15.1 (Apache License 2.0)
  - etcd 3.3.10 (Apache License 2.0)
  - kubelet-rubber-stamp 0.1.0 (Apache License 2.0)
  - kubernetes 1.14.3 (Apache License 2.0)
  - kubernetes-cni 0.7.5 (Apache License 2.0)
  - metrics-server 0.3.2 (Apache License 2.0)
  - pharos-kubelet-proxy 0.3.7 (Apache License 2.0)
  - weave-flying-shuttle 0.3.1 (Apache License 2.0)
  - weave-net 2.5.2 (Apache License 2.0)
Ubuntu 16.04:
  - cfssl 1.2 (MIT)
  - cri-o 1.14.2 (Apache License 2.0)
  - docker 18.09 (Apache License 2.0)
Debian 9:
  - cfssl 1.2 (MIT)
  - cri-o 1.14.2 (Apache License 2.0)
  - docker-ce 18.06.2 (Apache License 2.0)
Rhel 7.6:
  - cfssl 1.2 (MIT)
  - cri-o 1.14.2 (Apache License 2.0)
  - docker 1.13.1 (Apache License 2.0)
Rhel 7.5:
  - cfssl 1.2 (MIT)
  - cri-o 1.14.2 (Apache License 2.0)
  - docker 1.13.1 (Apache License 2.0)
Rhel 7.4:
  - cfssl 1.2 (MIT)
  - cri-o 1.14.2 (Apache License 2.0)
  - docker 1.13.1 (Apache License 2.0)
Centos 7:
  - cfssl 1.2 (MIT)
  - cri-o 1.14.2 (Apache License 2.0)
  - docker 1.13.1 (Apache License 2.0)
Ubuntu 18.04:
  - cfssl 1.2 (MIT)
  - cri-o 1.14.2 (Apache License 2.0)
  - docker 18.09 (Apache License 2.0)
Add-ons:
  - cert-manager 0.7.2 (Apache License 2.0)
  - helm 2.13.1 (Apache License 2.0)
  - host-upgrades 0.3.1 (Apache License 2.0)
  - ingress-nginx 0.23.0 (Apache License 2.0)
```

Could be hidden behind some ´--ruby` opt?
