### PR TITLE
Kontena Stats: allow to toggle persistence/node_exporter/state_metrics

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-stats/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-stats/addon.rb
@@ -15,7 +15,7 @@ Pharos.addon('kontena-stats') do
     attribute :size, Pharos::Types::String
   }
 
-  Persistence = custom_type {
+  FeatureFlag = custom_type {
     attribute :enabled, Pharos::Types::Bool
   }
 
@@ -24,7 +24,9 @@ Pharos.addon('kontena-stats') do
     attribute :tolerations, Pharos::Types::Array.default(proc { [] })
     attribute :node_selector, Pharos::Types::Hash.default(proc { {} })
     attribute :retention, Retention.default(proc { Retention.new(time: '90d', size: '1GB') })
-    attribute :persistence, Persistence
+    attribute :persistence, FeatureFlag.default(proc { FeatureFlag.new(enabled: true) })
+    attribute :node_exporter, FeatureFlag.default(proc { FeatureFlag.new(enabled: true) })
+    attribute :kube_state_metrics, FeatureFlag.default(proc { FeatureFlag.new(enabled: true) })
     attribute :alert_managers, Pharos::Types::Array.default(proc { [] })
   }
 
@@ -37,6 +39,12 @@ Pharos.addon('kontena-stats') do
       required(:size).filled(:str?)
     end
     optional(:persistence).schema do
+      required(:enabled).filled(:bool?)
+    end
+    optional(:node_exporter).schema do
+      required(:enabled).filled(:bool?)
+    end
+    optional(:kube_state_metrics).schema do
       required(:enabled).filled(:bool?)
     end
     optional(:alert_managers).each(:str?)

--- a/non-oss/pharos_pro/addons/kontena-stats/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-stats/addon.rb
@@ -24,7 +24,7 @@ Pharos.addon('kontena-stats') do
     attribute :tolerations, Pharos::Types::Array.default(proc { [] })
     attribute :node_selector, Pharos::Types::Hash.default(proc { {} })
     attribute :retention, Retention.default(proc { Retention.new(time: '90d', size: '1GB') })
-    attribute :persistence, FeatureFlag.default(proc { FeatureFlag.new(enabled: true) })
+    attribute :persistence, FeatureFlag.default(proc { FeatureFlag.new(enabled: false) })
     attribute :node_exporter, FeatureFlag.default(proc { FeatureFlag.new(enabled: true) })
     attribute :kube_state_metrics, FeatureFlag.default(proc { FeatureFlag.new(enabled: true) })
     attribute :alert_managers, Pharos::Types::Array.default(proc { [] })

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/03-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/03-deployment.yml.erb
@@ -71,7 +71,7 @@ spec:
         - name: data
           <%- if config.persistence&.enabled -%>
           persistentVolumeClaim:
-          claimName: prometheus
+            claimName: prometheus
           <%- else -%>
           emptyDir: {}
           <%- end -%>

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/03-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/03-deployment.yml.erb
@@ -29,6 +29,13 @@ spec:
       <%- end -%>
       <%- end -%>
       serviceAccountName: prometheus
+      initContainers:
+        - name: chown
+          image: <%= image_repository %>/alpine:3.9
+          command: ["chown", "-R", "65534:65534", "/var/lib/prometheus"]
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/prometheus
       containers:
         - name: prometheus
           image: <%= image_repository %>/prometheus:v<%= prometheus_version %>

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/10-node-exporter-ds.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/10-node-exporter-ds.yml.erb
@@ -1,3 +1,4 @@
+<% if config.node_exporter.enabled %>
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -69,3 +70,4 @@ spec:
         - name: root
           hostPath:
             path: /
+<% end %>

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/14-kube-state-metrics-deployment.yml.erb
@@ -1,3 +1,4 @@
+<% if config.kube_state_metrics.enabled %>
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,3 +34,4 @@ spec:
           limits:
             cpu: 100m
             memory: 150Mi
+<% end %>


### PR DESCRIPTION
Cluster might already have node_exporter or state_metrics.. it does not make sense run multiple of those.