### PR TITLE
Release v2.4.0-rc.3

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.0-rc.2"
+  VERSION = "2.4.0-rc.3"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.4.0-rc.2

- Kontena Lens 1.6.0-rc.3 (#1411, #1416) [Pro]
- Kontena Storage: ceph-prom-exporter 0.2.0 (#1410) [Pro]
- Kontena Stats: allow to toggle persistence/node_exporter/state_metrics (#1409) [Pro]
- Kontena Stats: switch to StatefulSet (#1423) [Pro]
- Ingress-NGINX: allow optionally deploy as service type=loadbalancer (#1419)
- Make package repos configurable (#1271)
- Cert-manager: optional webhook (#1413)
- Fix e2e worker up fw issue (#1416)
- Allow to set addon defaults values without typed structs (#1422)