### PR TITLE
Fix e2e worker up fw issue

### DIFF
--- a/.drone1.yml
+++ b/.drone1.yml
@@ -54,233 +54,233 @@ steps:
     when:
       event: [ push ]
       status: [ failure, success ]
-# ---
-# kind: pipeline
-# name: e2e-bionic-tf-0.12
-# depends_on:
-# - test
-# platform:
-#   os: linux
-#   arch: amd64
-# steps:
-#   # E2E steps
-#   - name: setup-e2e
-#     image: docker.io/hashicorp/terraform:0.12.0
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - apk add --update bash jq
-#       - cp e2e/digitalocean/terraform-0.12/* e2e/digitalocean/
-#       - ./e2e/drone_setup.sh ubuntu-18-04-x64
-#     when:
-#       event: [ push ]
-#   - name: e2e
-#     image: ruby:2.5
-#     commands:
-#       - ./e2e/drone.sh
-#     when:
-#       event: [ push ]
-#   - name: teardown-e2e
-#     image: docker.io/hashicorp/terraform:0.12.0
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - ./e2e/drone_teardown.sh
-#     when:
-#       event: [ push ]
-#       status: [ failure, success ]
-# ---
-# kind: pipeline
-# name: e2e-xenial
-# depends_on:
-# - e2e-bionic
-# platform:
-#   os: linux
-#   arch: amd64
-# steps:
-#   # E2E steps
-#   - name: setup-e2e
-#     image: docker.io/hashicorp/terraform:0.11.10
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - apk add --update bash jq
-#       - ./e2e/drone_setup.sh ubuntu-16-04-x64
-#     when:
-#       event: [ push ]
-#   - name: e2e
-#     image: ruby:2.5
-#     commands:
-#       - ./e2e/drone.sh
-#     when:
-#       event: [ push ]
-#   - name: teardown-e2e
-#     image: docker.io/hashicorp/terraform:0.11.10
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - ./e2e/drone_teardown.sh
-#     when:
-#       event: [ push ]
-#       status: [ failure, success ]
-# ---
-# kind: pipeline
-# name: e2e-stretch
-# depends_on:
-# - e2e-bionic
-# platform:
-#   os: linux
-#   arch: amd64
-# steps:
-#   # E2E steps
-#   - name: setup-e2e
-#     image: docker.io/hashicorp/terraform:0.11.10
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - apk add --update bash jq
-#       - ./e2e/drone_setup.sh debian-9-x64
-#     when:
-#       event: [ push ]
-#   - name: e2e
-#     image: ruby:2.5
-#     commands:
-#       - ./e2e/drone.sh
-#     when:
-#       event: [ push ]
-#   - name: teardown-e2e
-#     image: docker.io/hashicorp/terraform:0.11.10
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - ./e2e/drone_teardown.sh
-#     when:
-#       event: [ push ]
-#       status: [ failure, success ]
-# ---
-# kind: pipeline
-# name: e2e-centos
-# depends_on:
-# - test
-# platform:
-#   os: linux
-#   arch: amd64
-# steps:
-#   - name: setup-e2e
-#     image: docker.io/hashicorp/terraform:0.11.10
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - apk add --update bash jq
-#       - ./e2e/drone_setup.sh centos-7-x64
-#     when:
-#       event: [ push ]
-#   - name: e2e
-#     image: ruby:2.5
-#     commands:
-#       - ./e2e/drone.sh
-#     when:
-#       event: [ push ]
-#   - name: teardown-e2e
-#     image: docker.io/hashicorp/terraform:0.11.10
-#     environment:
-#       DIGITALOCEAN_TOKEN:
-#         from_secret: digitalocean_token
-#     commands:
-#       - ./e2e/drone_teardown.sh
-#     when:
-#       event: [ push ]
-#       status: [ failure, success ]
-# ---
-# kind: pipeline
-# name: github-release
-# depends_on:
-# - e2e-bionic
-# - e2e-centos
-# - e2e-xenial
-# - e2e-stretch
-# platform:
-#   os: linux
-#   arch: amd64
-# steps:
-#   - name: create_gh_release
-#     image: ubuntu:xenial
-#     environment:
-#       GITHUB_TOKEN:
-#         from_secret: github_token
-#     commands:
-#       - ./build/drone/create_release.sh
-#     when:
-#       event: tag
-# ---
-# kind: pipeline
-# name: release-binary
-# depends_on:
-# - github-release
-# platform:
-#   os: linux
-#   arch: amd64
-# steps:
-#   - name: build_ubuntu
-#     image: ubuntu:xenial
-#     environment:
-#       CPPFLAGS: "-P"
-#       PHAROS_NON_OSS: "true"
-#     commands:
-#       - ./build/drone/ubuntu.sh
-#     when:
-#       event: tag
-#   - name: release_binary
-#     image: plugins/s3
-#     environment:
-#       AWS_ACCESS_KEY_ID:
-#         from_secret: aws_access_key_id
-#       AWS_SECRET_ACCESS_KEY:
-#         from_secret: aws_secret_access_key
-#     settings:
-#       bucket: pharos-cluster-binaries
-#       region: eu-west-1
-#       source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"
-#       target: /
-#     when:
-#       event: tag
-# ---
-# kind: pipeline
-# name: release-oss-binary
-# depends_on:
-# - github-release
-# platform:
-#   os: linux
-#   arch: amd64
-# steps:
-#   - name: build_ubuntu
-#     image: ubuntu:xenial
-#     environment:
-#       CPPFLAGS: "-P"
-#       GITHUB_TOKEN:
-#         from_secret: github_token
-#     commands:
-#       - ./build/drone/ubuntu_oss.sh
-#     when:
-#       event: tag
-#   - name: release_binary
-#     image: plugins/s3
-#     environment:
-#       AWS_ACCESS_KEY_ID:
-#         from_secret: aws_access_key_id
-#       AWS_SECRET_ACCESS_KEY:
-#         from_secret: aws_secret_access_key
-#     settings:
-#       bucket: pharos-cluster-binaries
-#       region: eu-west-1
-#       source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}+oss"
-#       target: /
-#     when:
-#       event: tag
+---
+kind: pipeline
+name: e2e-bionic-tf-0.12
+depends_on:
+- test
+platform:
+  os: linux
+  arch: amd64
+steps:
+  # E2E steps
+  - name: setup-e2e
+    image: docker.io/hashicorp/terraform:0.12.0
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - apk add --update bash jq
+      - cp e2e/digitalocean/terraform-0.12/* e2e/digitalocean/
+      - ./e2e/drone_setup.sh ubuntu-18-04-x64
+    when:
+      event: [ push ]
+  - name: e2e
+    image: ruby:2.5
+    commands:
+      - ./e2e/drone.sh
+    when:
+      event: [ push ]
+  - name: teardown-e2e
+    image: docker.io/hashicorp/terraform:0.12.0
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - ./e2e/drone_teardown.sh
+    when:
+      event: [ push ]
+      status: [ failure, success ]
+---
+kind: pipeline
+name: e2e-xenial
+depends_on:
+- e2e-bionic
+platform:
+  os: linux
+  arch: amd64
+steps:
+  # E2E steps
+  - name: setup-e2e
+    image: docker.io/hashicorp/terraform:0.11.10
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - apk add --update bash jq
+      - ./e2e/drone_setup.sh ubuntu-16-04-x64
+    when:
+      event: [ push ]
+  - name: e2e
+    image: ruby:2.5
+    commands:
+      - ./e2e/drone.sh
+    when:
+      event: [ push ]
+  - name: teardown-e2e
+    image: docker.io/hashicorp/terraform:0.11.10
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - ./e2e/drone_teardown.sh
+    when:
+      event: [ push ]
+      status: [ failure, success ]
+---
+kind: pipeline
+name: e2e-stretch
+depends_on:
+- e2e-bionic
+platform:
+  os: linux
+  arch: amd64
+steps:
+  # E2E steps
+  - name: setup-e2e
+    image: docker.io/hashicorp/terraform:0.11.10
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - apk add --update bash jq
+      - ./e2e/drone_setup.sh debian-9-x64
+    when:
+      event: [ push ]
+  - name: e2e
+    image: ruby:2.5
+    commands:
+      - ./e2e/drone.sh
+    when:
+      event: [ push ]
+  - name: teardown-e2e
+    image: docker.io/hashicorp/terraform:0.11.10
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - ./e2e/drone_teardown.sh
+    when:
+      event: [ push ]
+      status: [ failure, success ]
+---
+kind: pipeline
+name: e2e-centos
+depends_on:
+- test
+platform:
+  os: linux
+  arch: amd64
+steps:
+  - name: setup-e2e
+    image: docker.io/hashicorp/terraform:0.11.10
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - apk add --update bash jq
+      - ./e2e/drone_setup.sh centos-7-x64
+    when:
+      event: [ push ]
+  - name: e2e
+    image: ruby:2.5
+    commands:
+      - ./e2e/drone.sh
+    when:
+      event: [ push ]
+  - name: teardown-e2e
+    image: docker.io/hashicorp/terraform:0.11.10
+    environment:
+      DIGITALOCEAN_TOKEN:
+        from_secret: digitalocean_token
+    commands:
+      - ./e2e/drone_teardown.sh
+    when:
+      event: [ push ]
+      status: [ failure, success ]
+---
+kind: pipeline
+name: github-release
+depends_on:
+- e2e-bionic
+- e2e-centos
+- e2e-xenial
+- e2e-stretch
+platform:
+  os: linux
+  arch: amd64
+steps:
+  - name: create_gh_release
+    image: ubuntu:xenial
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - ./build/drone/create_release.sh
+    when:
+      event: tag
+---
+kind: pipeline
+name: release-binary
+depends_on:
+- github-release
+platform:
+  os: linux
+  arch: amd64
+steps:
+  - name: build_ubuntu
+    image: ubuntu:xenial
+    environment:
+      CPPFLAGS: "-P"
+      PHAROS_NON_OSS: "true"
+    commands:
+      - ./build/drone/ubuntu.sh
+    when:
+      event: tag
+  - name: release_binary
+    image: plugins/s3
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    settings:
+      bucket: pharos-cluster-binaries
+      region: eu-west-1
+      source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"
+      target: /
+    when:
+      event: tag
+---
+kind: pipeline
+name: release-oss-binary
+depends_on:
+- github-release
+platform:
+  os: linux
+  arch: amd64
+steps:
+  - name: build_ubuntu
+    image: ubuntu:xenial
+    environment:
+      CPPFLAGS: "-P"
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - ./build/drone/ubuntu_oss.sh
+    when:
+      event: tag
+  - name: release_binary
+    image: plugins/s3
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: aws_access_key_id
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: aws_secret_access_key
+    settings:
+      bucket: pharos-cluster-binaries
+      region: eu-west-1
+      source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}+oss"
+      target: /
+    when:
+      event: tag

--- a/.drone1.yml
+++ b/.drone1.yml
@@ -30,7 +30,7 @@ steps:
   - name: setup-e2e
     image: docker.io/hashicorp/terraform:0.11.10
     environment:
-      WORKER_UP_COUNT: "0"
+      WORKER_UP_COUNT: "1"
       DIGITALOCEAN_TOKEN:
         from_secret: digitalocean_token
     commands:
@@ -54,233 +54,233 @@ steps:
     when:
       event: [ push ]
       status: [ failure, success ]
----
-kind: pipeline
-name: e2e-bionic-tf-0.12
-depends_on:
-- test
-platform:
-  os: linux
-  arch: amd64
-steps:
-  # E2E steps
-  - name: setup-e2e
-    image: docker.io/hashicorp/terraform:0.12.0
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - apk add --update bash jq
-      - cp e2e/digitalocean/terraform-0.12/* e2e/digitalocean/
-      - ./e2e/drone_setup.sh ubuntu-18-04-x64
-    when:
-      event: [ push ]
-  - name: e2e
-    image: ruby:2.5
-    commands:
-      - ./e2e/drone.sh
-    when:
-      event: [ push ]
-  - name: teardown-e2e
-    image: docker.io/hashicorp/terraform:0.12.0
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - ./e2e/drone_teardown.sh
-    when:
-      event: [ push ]
-      status: [ failure, success ]
----
-kind: pipeline
-name: e2e-xenial
-depends_on:
-- e2e-bionic
-platform:
-  os: linux
-  arch: amd64
-steps:
-  # E2E steps
-  - name: setup-e2e
-    image: docker.io/hashicorp/terraform:0.11.10
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - apk add --update bash jq
-      - ./e2e/drone_setup.sh ubuntu-16-04-x64
-    when:
-      event: [ push ]
-  - name: e2e
-    image: ruby:2.5
-    commands:
-      - ./e2e/drone.sh
-    when:
-      event: [ push ]
-  - name: teardown-e2e
-    image: docker.io/hashicorp/terraform:0.11.10
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - ./e2e/drone_teardown.sh
-    when:
-      event: [ push ]
-      status: [ failure, success ]
----
-kind: pipeline
-name: e2e-stretch
-depends_on:
-- e2e-bionic
-platform:
-  os: linux
-  arch: amd64
-steps:
-  # E2E steps
-  - name: setup-e2e
-    image: docker.io/hashicorp/terraform:0.11.10
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - apk add --update bash jq
-      - ./e2e/drone_setup.sh debian-9-x64
-    when:
-      event: [ push ]
-  - name: e2e
-    image: ruby:2.5
-    commands:
-      - ./e2e/drone.sh
-    when:
-      event: [ push ]
-  - name: teardown-e2e
-    image: docker.io/hashicorp/terraform:0.11.10
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - ./e2e/drone_teardown.sh
-    when:
-      event: [ push ]
-      status: [ failure, success ]
----
-kind: pipeline
-name: e2e-centos
-depends_on:
-- test
-platform:
-  os: linux
-  arch: amd64
-steps:
-  - name: setup-e2e
-    image: docker.io/hashicorp/terraform:0.11.10
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - apk add --update bash jq
-      - ./e2e/drone_setup.sh centos-7-x64
-    when:
-      event: [ push ]
-  - name: e2e
-    image: ruby:2.5
-    commands:
-      - ./e2e/drone.sh
-    when:
-      event: [ push ]
-  - name: teardown-e2e
-    image: docker.io/hashicorp/terraform:0.11.10
-    environment:
-      DIGITALOCEAN_TOKEN:
-        from_secret: digitalocean_token
-    commands:
-      - ./e2e/drone_teardown.sh
-    when:
-      event: [ push ]
-      status: [ failure, success ]
----
-kind: pipeline
-name: github-release
-depends_on:
-- e2e-bionic
-- e2e-centos
-- e2e-xenial
-- e2e-stretch
-platform:
-  os: linux
-  arch: amd64
-steps:
-  - name: create_gh_release
-    image: ubuntu:xenial
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    commands:
-      - ./build/drone/create_release.sh
-    when:
-      event: tag
----
-kind: pipeline
-name: release-binary
-depends_on:
-- github-release
-platform:
-  os: linux
-  arch: amd64
-steps:
-  - name: build_ubuntu
-    image: ubuntu:xenial
-    environment:
-      CPPFLAGS: "-P"
-      PHAROS_NON_OSS: "true"
-    commands:
-      - ./build/drone/ubuntu.sh
-    when:
-      event: tag
-  - name: release_binary
-    image: plugins/s3
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: aws_access_key_id
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: aws_secret_access_key
-    settings:
-      bucket: pharos-cluster-binaries
-      region: eu-west-1
-      source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"
-      target: /
-    when:
-      event: tag
----
-kind: pipeline
-name: release-oss-binary
-depends_on:
-- github-release
-platform:
-  os: linux
-  arch: amd64
-steps:
-  - name: build_ubuntu
-    image: ubuntu:xenial
-    environment:
-      CPPFLAGS: "-P"
-      GITHUB_TOKEN:
-        from_secret: github_token
-    commands:
-      - ./build/drone/ubuntu_oss.sh
-    when:
-      event: tag
-  - name: release_binary
-    image: plugins/s3
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: aws_access_key_id
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: aws_secret_access_key
-    settings:
-      bucket: pharos-cluster-binaries
-      region: eu-west-1
-      source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}+oss"
-      target: /
-    when:
-      event: tag
+# ---
+# kind: pipeline
+# name: e2e-bionic-tf-0.12
+# depends_on:
+# - test
+# platform:
+#   os: linux
+#   arch: amd64
+# steps:
+#   # E2E steps
+#   - name: setup-e2e
+#     image: docker.io/hashicorp/terraform:0.12.0
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - apk add --update bash jq
+#       - cp e2e/digitalocean/terraform-0.12/* e2e/digitalocean/
+#       - ./e2e/drone_setup.sh ubuntu-18-04-x64
+#     when:
+#       event: [ push ]
+#   - name: e2e
+#     image: ruby:2.5
+#     commands:
+#       - ./e2e/drone.sh
+#     when:
+#       event: [ push ]
+#   - name: teardown-e2e
+#     image: docker.io/hashicorp/terraform:0.12.0
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - ./e2e/drone_teardown.sh
+#     when:
+#       event: [ push ]
+#       status: [ failure, success ]
+# ---
+# kind: pipeline
+# name: e2e-xenial
+# depends_on:
+# - e2e-bionic
+# platform:
+#   os: linux
+#   arch: amd64
+# steps:
+#   # E2E steps
+#   - name: setup-e2e
+#     image: docker.io/hashicorp/terraform:0.11.10
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - apk add --update bash jq
+#       - ./e2e/drone_setup.sh ubuntu-16-04-x64
+#     when:
+#       event: [ push ]
+#   - name: e2e
+#     image: ruby:2.5
+#     commands:
+#       - ./e2e/drone.sh
+#     when:
+#       event: [ push ]
+#   - name: teardown-e2e
+#     image: docker.io/hashicorp/terraform:0.11.10
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - ./e2e/drone_teardown.sh
+#     when:
+#       event: [ push ]
+#       status: [ failure, success ]
+# ---
+# kind: pipeline
+# name: e2e-stretch
+# depends_on:
+# - e2e-bionic
+# platform:
+#   os: linux
+#   arch: amd64
+# steps:
+#   # E2E steps
+#   - name: setup-e2e
+#     image: docker.io/hashicorp/terraform:0.11.10
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - apk add --update bash jq
+#       - ./e2e/drone_setup.sh debian-9-x64
+#     when:
+#       event: [ push ]
+#   - name: e2e
+#     image: ruby:2.5
+#     commands:
+#       - ./e2e/drone.sh
+#     when:
+#       event: [ push ]
+#   - name: teardown-e2e
+#     image: docker.io/hashicorp/terraform:0.11.10
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - ./e2e/drone_teardown.sh
+#     when:
+#       event: [ push ]
+#       status: [ failure, success ]
+# ---
+# kind: pipeline
+# name: e2e-centos
+# depends_on:
+# - test
+# platform:
+#   os: linux
+#   arch: amd64
+# steps:
+#   - name: setup-e2e
+#     image: docker.io/hashicorp/terraform:0.11.10
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - apk add --update bash jq
+#       - ./e2e/drone_setup.sh centos-7-x64
+#     when:
+#       event: [ push ]
+#   - name: e2e
+#     image: ruby:2.5
+#     commands:
+#       - ./e2e/drone.sh
+#     when:
+#       event: [ push ]
+#   - name: teardown-e2e
+#     image: docker.io/hashicorp/terraform:0.11.10
+#     environment:
+#       DIGITALOCEAN_TOKEN:
+#         from_secret: digitalocean_token
+#     commands:
+#       - ./e2e/drone_teardown.sh
+#     when:
+#       event: [ push ]
+#       status: [ failure, success ]
+# ---
+# kind: pipeline
+# name: github-release
+# depends_on:
+# - e2e-bionic
+# - e2e-centos
+# - e2e-xenial
+# - e2e-stretch
+# platform:
+#   os: linux
+#   arch: amd64
+# steps:
+#   - name: create_gh_release
+#     image: ubuntu:xenial
+#     environment:
+#       GITHUB_TOKEN:
+#         from_secret: github_token
+#     commands:
+#       - ./build/drone/create_release.sh
+#     when:
+#       event: tag
+# ---
+# kind: pipeline
+# name: release-binary
+# depends_on:
+# - github-release
+# platform:
+#   os: linux
+#   arch: amd64
+# steps:
+#   - name: build_ubuntu
+#     image: ubuntu:xenial
+#     environment:
+#       CPPFLAGS: "-P"
+#       PHAROS_NON_OSS: "true"
+#     commands:
+#       - ./build/drone/ubuntu.sh
+#     when:
+#       event: tag
+#   - name: release_binary
+#     image: plugins/s3
+#     environment:
+#       AWS_ACCESS_KEY_ID:
+#         from_secret: aws_access_key_id
+#       AWS_SECRET_ACCESS_KEY:
+#         from_secret: aws_secret_access_key
+#     settings:
+#       bucket: pharos-cluster-binaries
+#       region: eu-west-1
+#       source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}"
+#       target: /
+#     when:
+#       event: tag
+# ---
+# kind: pipeline
+# name: release-oss-binary
+# depends_on:
+# - github-release
+# platform:
+#   os: linux
+#   arch: amd64
+# steps:
+#   - name: build_ubuntu
+#     image: ubuntu:xenial
+#     environment:
+#       CPPFLAGS: "-P"
+#       GITHUB_TOKEN:
+#         from_secret: github_token
+#     commands:
+#       - ./build/drone/ubuntu_oss.sh
+#     when:
+#       event: tag
+#   - name: release_binary
+#     image: plugins/s3
+#     environment:
+#       AWS_ACCESS_KEY_ID:
+#         from_secret: aws_access_key_id
+#       AWS_SECRET_ACCESS_KEY:
+#         from_secret: aws_secret_access_key
+#     settings:
+#       bucket: pharos-cluster-binaries
+#       region: eu-west-1
+#       source: "pharos-cluster-linux-amd64-${DRONE_TAG##v}+oss"
+#       target: /
+#     when:
+#       event: tag

--- a/e2e/digitalocean/cluster.yml
+++ b/e2e/digitalocean/cluster.yml
@@ -4,6 +4,8 @@ network:
   service_cidr: 172.31.0.0/16
   firewalld:
     enabled: true
+    trusted_subnets:
+      - "10.133.0.0/16"
   weave:
     trusted_subnets:
       - "10.133.0.0/16"


### PR DESCRIPTION
Firewall rules did not allow external nodes (configured via worker up) to connect. This PR fixes it by whitelisting the private subnet where machines are provisioned.