### PR TITLE
Allow running without cluster.yml when tf_json present [cluster-e2e]

### DIFF
--- a/lib/pharos/command_options/load_config.rb
+++ b/lib/pharos/command_options/load_config.rb
@@ -45,8 +45,8 @@ module Pharos
             Pharos::YamlFile.new($stdin, force_erb: true, override_filename: '<stdin>')
           else
             cluster_config = Dir.glob('cluster.{yml,yml.erb}').first
-            signal_usage_error 'File does not exist: cluster.yml' if cluster_config.nil?
-            Pharos::YamlFile.new(cluster_config)
+            signal_usage_error 'File does not exist: cluster.yml' if cluster_config.nil? && !tf_json
+            Pharos::YamlFile.new(cluster_config || '')
           end
         end
 


### PR DESCRIPTION
With TF 0.12 it's possible to generate the full config from TF, no need to provider cluster.yml then.
