### PR TITLE
Allow to set addon defaults values without typed structs

### DIFF
--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -105,8 +105,8 @@ module Pharos
         @config ||= Class.new(Pharos::Addons::Struct, &block)
       end
 
-      def default_values(values)
-        @default_values = values
+      def default_values(values = nil)
+        @default_values ||= values
       end
 
       def config?

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -105,8 +105,8 @@ module Pharos
         @config ||= Class.new(Pharos::Addons::Struct, &block)
       end
 
-      def default_values(&block)
-        @default_values = block.call
+      def default_values(values)
+        @default_values = values
       end
 
       def config?

--- a/lib/pharos/addon.rb
+++ b/lib/pharos/addon.rb
@@ -20,6 +20,7 @@ module Pharos
   class Addon
     using Pharos::CoreExt::Colorize
     using Pharos::CoreExt::DeepTransformKeys
+    using K8s::Util::HashDeepMerge
     include Pharos::Logging
 
     # return class for use as superclass in Dry::Validation.Params
@@ -102,6 +103,10 @@ module Pharos
 
       def config(&block)
         @config ||= Class.new(Pharos::Addons::Struct, &block)
+      end
+
+      def default_values(&block)
+        @default_values = block.call
       end
 
       def config?
@@ -188,10 +193,11 @@ module Pharos
 
       # @param config [Hash]
       def validate(config)
+        values = (@default_values || {}).deep_stringify_keys.deep_merge(config)
         if @schema
-          @schema.call(config)
+          @schema.call(values)
         else
-          validation {}.call(config)
+          validation {}.call(values)
         end
       end
     end

--- a/spec/pharos/addon_spec.rb
+++ b/spec/pharos/addon_spec.rb
@@ -29,11 +29,9 @@ describe Pharos::Addon do
       version "0.2.2"
       license "MIT"
 
-      default_values do
-        {
-          bar: 'baz'
-        }
-      end
+      default_values(
+        bar: 'baz'
+      )
 
       config_schema {
         required(:foo).filled(:str?)


### PR DESCRIPTION
Example:

```ruby
  default_values(
    kind: 'DaemonSet',
    deployment: {
      replicas: 2
    },
    configmap: {
      'worker-shutdown-timeout' => '3600s' # keep connection/workers alive for 1 hour
    },
    default_backend: {
      'image' => 'registry.pharos.sh/kontenapharos/pharos-default-backend:0.0.3'
    },
    tolerations: [],
    extra_args: []
  )

  config_schema do
    optional(:kind).filled(included_in?: ['DaemonSet', 'Deployment'])
    optional(:deployment).schema do
      required(:replicas).filled(:int?)
    end
    optional(:replicas).filled(:int?)
    optional(:configmap).filled(:hash?)
    optional(:node_selector).filled(:hash?)
    required(:default_backend).schema {
      optional(:image).filled(:str?)
    }
    optional(:tolerations).each(:hash?)
    optional(:extra_args).each(:str?)
  end
```