### PR TITLE
Revert "Add LENS_VERSION env var to lens deployment"

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-lens/resources/07-dashboard-deployment.yml.erb
@@ -53,8 +53,6 @@ spec:
               value: "<%=  charts_enabled %>"
             - name: KUBE_METRICS_URL
               value: "http://rbac-proxy.kontena-stats.svc.cluster.local"
-            - name: LENS_VERSION
-              value: "<%= version %>"
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
Reverts kontena/pharos-cluster#1425

Reverted because it requires Lens 1.6.1 which is not yet included.