### PR TITLE
Release v2.4.0

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.0-rc.3"
+  VERSION = "2.4.0"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.3


- Kubernetes v1.14.3 (#1300, #1332, #1391)
- Kontena Lens 1.6.0-rc.3 (#1353, #1341, #1348, #1394, #1404, #1411, #1416, #1377, #1378, #1382) [Pro]
- Kontena-Lens: add node_selector and tolerations config options (#1355, #1380) [Pro]
- Kontena-lens addon: fix Lens redis tolerations (#1326) [Pro]
- Kontena Stats addon (#988, #1345, #1351, #1393, #1409, #1423) [Pro]
- Terraform 0.12 support (#1371)
- Kontena Universal Loadbalancer addon (#1320, #1396) [Pro]
- Kontena Storage addon: version 0.9.3 (#1349, #1359, #1388, #1387) [Pro]
- Kontena Storage addon: ceph-prom-exporter 0.2.0 (#1407, #1410) [Pro]
- Pharos cloud-controller (#953)
- Make package repos configurable (#1271)
- New sub-command: pharos worker up (#1235)
- Improved out-of-tree cloud provider support (#1186)
- Cert-manager addon: version 0.7.2 (#1328, #1413)
- Cert-manager addon: extra_args (#1317)
- Cert-manager: allow to set multiple issuers/clusterissuers (#1370)
- Improved container-runtime upgrade logic (#1321)
- Ingress-NGINX addon: version 0.23.0 (#1212)
- Ingress-NGINX: allow optionally deploy as service type=loadbalancer (#1419)
- Helm addon: version 2.13.1 (#1375)
- CRI-O v1.14.2 (#1329, #1392)
- Calico 3.6.2 (#1333)
- Weave net 2.5.2 (#1334)
- Weave flying-shuttle v0.3.0 (#1381, #1309)
- Metrics-server 0.3.2 (#1376)
- Allow to set extra args for kubelet (#1279)
- Fix e2e worker up fw issue (#1416)
- Allow to set addon defaults values without typed structs (#1422)
- Fix interactive SSH connection opening (#1399)
- Fix line joining in gather facts spec (#1400)
- Fix weave net ipam consensus race cond (#1360)
- Don't log pharos kubelet proxy wait retries (#1374)
- k8s-client v0.10.1 (#1373)
- Retry initial SSH connection opening for 60 seconds (#1372)
- Fix debian firewalld start error (#1365)
- Only set cloud provider in worker up when given [cluster-e2e] (#1347)
- Run "docker ps" in subshell using sudo (#1368)
- More SSH keepalive in e2e (#1364)
- Remove deprecated openebs addon (#1358)
- Fix previous config retrieval (#1385)
- Lower SSH connect timeout from 60 to 5 seconds (#1386)
- Allow user to configure CFS quota setting for kubelet (#1327)
- Add --trust-hosts option (#1339)
- Always tunnel Kube API client through master ssh (#1233)
- Make LabelNode phase run on single host (#1228)
- Ignore preflight errors during node join (#1294)
- Disable docker0 bridge (#1331)
- Addon deps (#1344)
