### PR TITLE
Add system:auth-delegator binding to cert-manager-webhook service account

### DIFF
--- a/addons/cert-manager/resources/03-roles.yml
+++ b/addons/cert-manager/resources/03-roles.yml
@@ -121,6 +121,19 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-webhook:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager-webhook
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-webhook:webhook-requester

--- a/addons/cert-manager/resources/03-roles.yml
+++ b/addons/cert-manager/resources/03-roles.yml
@@ -120,6 +120,8 @@ subjects:
   name: cert-manager-webhook
   namespace: kube-system
 ---
+# apiserver gets the auth-delegator role to delegate auth decisions to
+# the core apiserver
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
`cert-manager-webhook` service account is missing binding to `system:auth-delegator` role. This is, for example, preventing deleting namespaces properly since service account can't create `subjectaccessreview` resources. This PR adds this missing role binding to service account.