### PR TITLE
Fix hostname and address uniqueness validation for hosts sharing an IP

### DIFF
--- a/lib/pharos/config_schema.rb
+++ b/lib/pharos/config_schema.rb
@@ -38,6 +38,7 @@ module Pharos
       result[:hosts].each.with_index do |host, idx|
         duplicates = result[:hosts].select { |h| h[:address] == host[:address] && (h[:ssh_port] || 22) == (host[:ssh_port] || 22) }
         next if duplicates.size == 1
+
         messages[:hosts][idx] = { "address:ssh_port" => ["#{host[:address]}:#{host[:ssh_port] || 22} is not unique"] }
       end
 

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -44,7 +44,7 @@ module Pharos
       end
 
       def validate_unique_hostnames
-        duplicates = @config.hosts.reject { |h| h.address == @host.address }.select { |h| h.hostname == @host.hostname && h.ssh_port == @host.ssh_port }
+        duplicates = @config.hosts.reject { |h| h.address == @host.address && h.ssh_port == @host.ssh_port }.select { |h| h.hostname == @host.hostname }
         return if duplicates.empty?
 
         raise Pharos::InvalidHostError, "Duplicate hostname #{@host.hostname} for hosts #{duplicates.map { |h| "#{h.address}:#{h.ssh_port}" }.join(',')}"

--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -44,10 +44,10 @@ module Pharos
       end
 
       def validate_unique_hostnames
-        duplicates = @config.hosts.reject { |h| h.address == @host.address }.select { |h| h.hostname == @host.hostname }
+        duplicates = @config.hosts.reject { |h| h.address == @host.address }.select { |h| h.hostname == @host.hostname && h.ssh_port == @host.ssh_port }
         return if duplicates.empty?
 
-        raise Pharos::InvalidHostError, "Duplicate hostname #{@host.hostname} for hosts #{duplicates.map(&:address).join(',')}"
+        raise Pharos::InvalidHostError, "Duplicate hostname #{@host.hostname} for hosts #{duplicates.map { |h| "#{h.address}:#{h.ssh_port}" }.join(',')}"
       end
 
       def validate_localhost_resolve

--- a/spec/pharos/command_spec.rb
+++ b/spec/pharos/command_spec.rb
@@ -87,7 +87,7 @@ describe Pharos::Command do
 
     it 'displays error message instead of backtrace' do
       expect{subject.run('pharos', [])}.to exit_with_error.status(11).and output(
-        "==> Invalid configuration:\n---\n:hosts:\n- must be filled\n- size cannot be less than 1\n"
+        "==> Invalid configuration:\n---\n:hosts:\n- must be filled\n- duplicate address:ssh_port\n- size cannot be less than 1\n"
       ).to_stderr
     end
   end

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -56,15 +56,14 @@ describe Pharos::Config do
       end
     end
 
-    context 'non unique ip and same ssh port' do
+    context 'non unique ip and ssh port' do
       let(:hosts) { [
         { 'address' => '192.0.2.1', 'role' => 'master' },
         { 'address' => '192.0.2.1', 'role' => 'worker', 'ssh_port' => 22 }
       ] }
       it 'loads' do
         expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
-          expect(exc.errors[:hosts][0]['address:ssh_port'][0]).to eq '192.0.2.1:22 is not unique'
-          expect(exc.errors[:hosts][1]['address:ssh_port'][0]).to eq '192.0.2.1:22 is not unique'
+          expect(exc.errors[:hosts]).to match array_including('duplicate address:ssh_port')
         end
       end
     end

--- a/spec/pharos/config_spec.rb
+++ b/spec/pharos/config_spec.rb
@@ -46,17 +46,25 @@ describe Pharos::Config do
       end
     end
 
-    context 'non unique ip' do
+    context 'non unique ip but different ssh port' do
       let(:hosts) { [
-        { 'address' => ' 192.0.2.1', 'role' => 'master' },
-        { 'address' => ' 192.0.2.1', 'role' => 'worker' }
+        { 'address' => '192.0.2.1', 'role' => 'master', 'ssh_port' => 22 },
+        { 'address' => '192.0.2.1', 'role' => 'worker', 'ssh_port' => 8022 }
       ] }
-      it 'fails to load' do
+      it 'loads' do
+        expect{subject}.not_to raise_error
+      end
+    end
+
+    context 'non unique ip and same ssh port' do
+      let(:hosts) { [
+        { 'address' => '192.0.2.1', 'role' => 'master' },
+        { 'address' => '192.0.2.1', 'role' => 'worker', 'ssh_port' => 22 }
+      ] }
+      it 'loads' do
         expect{subject}.to raise_error(Pharos::ConfigError) do |exc|
-          expect(exc.errors[:hosts]).to match hash_including(
-            0 => hash_including(address: array_including("is not unique")),
-            1 => hash_including(address: array_including("is not unique"))
-          )
+          expect(exc.errors[:hosts][0]['address:ssh_port'][0]).to eq '192.0.2.1:22 is not unique'
+          expect(exc.errors[:hosts][1]['address:ssh_port'][0]).to eq '192.0.2.1:22 is not unique'
         end
       end
     end

--- a/spec/pharos/phases/validate_host_spec.rb
+++ b/spec/pharos/phases/validate_host_spec.rb
@@ -150,12 +150,20 @@ describe Pharos::Phases::ValidateHost do
     end
 
     context 'duplicate hostnames' do
-      it 'raises if duplicates' do
+      before do
         config.hosts[0].hostname = "foo"
         config.hosts[1].hostname = "foo"
         config.hosts[2].hostname = "foo"
+      end
 
-        expect{ subject.validate_unique_hostnames }.to raise_error(Pharos::InvalidHostError, "Duplicate hostname foo for hosts 192.0.2.2,192.0.2.3")
+      it 'raises if duplicates' do
+        expect{ subject.validate_unique_hostnames }.to raise_error(Pharos::InvalidHostError, "Duplicate hostname foo for hosts 192.0.2.2:22,192.0.2.3:22")
+      end
+
+      it 'does not raise for hosts where ssh ports differ' do
+        config.hosts[2].attributes[:ssh_port] = 8022
+
+        expect{ subject.validate_unique_hostnames }.to raise_error(Pharos::InvalidHostError, "Duplicate hostname foo for hosts 192.0.2.2:22")
       end
     end
   end

--- a/spec/pharos/phases/validate_host_spec.rb
+++ b/spec/pharos/phases/validate_host_spec.rb
@@ -159,12 +159,6 @@ describe Pharos::Phases::ValidateHost do
       it 'raises if duplicates' do
         expect{ subject.validate_unique_hostnames }.to raise_error(Pharos::InvalidHostError, "Duplicate hostname foo for hosts 192.0.2.2:22,192.0.2.3:22")
       end
-
-      it 'does not raise for hosts where ssh ports differ' do
-        config.hosts[2].attributes[:ssh_port] = 8022
-
-        expect{ subject.validate_unique_hostnames }.to raise_error(Pharos::InvalidHostError, "Duplicate hostname foo for hosts 192.0.2.2:22")
-      end
     end
   end
 

--- a/spec/pharos/phases/validate_host_spec.rb
+++ b/spec/pharos/phases/validate_host_spec.rb
@@ -159,6 +159,19 @@ describe Pharos::Phases::ValidateHost do
       it 'raises if duplicates' do
         expect{ subject.validate_unique_hostnames }.to raise_error(Pharos::InvalidHostError, "Duplicate hostname foo for hosts 192.0.2.2:22,192.0.2.3:22")
       end
+
+      context 'with ssh port forwards' do
+        before do
+          config.hosts[0].attributes[:address] = '192.0.2.2'
+          config.hosts[1].attributes[:address] = '192.0.2.2'
+          config.hosts[0].attributes[:ssh_port] = 8022
+          config.hosts[1].attributes[:ssh_port] = 22
+        end
+
+        it 'raises if duplicates' do
+          expect{ subject.validate_unique_hostnames }.to raise_error(Pharos::InvalidHostError, "Duplicate hostname foo for hosts 192.0.2.2:22,192.0.2.3:22")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1439

Hostname uniqueness check would ignore hosts with the same IP address but a different SSH port.

A host with a non-uniqu address but a different SSH port would have been considered a duplicate, eventhough it's likely a port forward.