### PR TITLE
Tunnel K8s API client to master's localhost:6443

### DIFF
--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -14,7 +14,7 @@ module Pharos
           cluster_context['kube_client'] = Pharos::Kube.client('localhost', k8s_config, 6443)
         else
           transport.close(cluster_context['kube_client'].transport.server[/:(\d+)/, 1].to_i) if cluster_context['kube_client']
-          cluster_context['kube_client'] = Pharos::Kube.client('localhost', k8s_config, transport.forward(host.api_address, 6443))
+          cluster_context['kube_client'] = Pharos::Kube.client('localhost', k8s_config, transport.forward('localhost', 6443))
         end
 
         client_prefetch

--- a/spec/pharos/phases/configure_client_spec.rb
+++ b/spec/pharos/phases/configure_client_spec.rb
@@ -32,7 +32,7 @@ describe Pharos::Phases::ConfigureClient do
   describe '#call' do
     it 'loads kubeconfig from master and configures kubeclient through port forwarding' do
       expect(remote_file).to receive(:read).and_return('content')
-      expect(transport).to receive(:forward).with('10.10.10.2', 6443).and_return(1234)
+      expect(transport).to receive(:forward).with('localhost', 6443).and_return(1234)
       expect(Pharos::Kube).to receive(:client).with('localhost', k8s_config, 1234).and_return(kubeclient)
       expect{subject.call}.to change{cluster_context}.from({}).to(hash_including('kube_client' => kubeclient))
     end


### PR DESCRIPTION
Fixes #1441 

Instead of tunneling the pharos k8s api requests to `api_address:6443` through master, connect to master's `localhost:6443` through the master ssh.
