### PR TITLE
Release v2.4.2

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.1"
+  VERSION = "2.4.2"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.4.1

- Kubernetes v1.14.5 (#1445)
- CRI-O v1.14.6 (#1444)
- Ceph-prom-exporter v0.3.0 (#1435)
- Fix apiserver cert recreate (#1437)
- Tunnel K8s API client to master's localhost:6443 (#1442)
- Fix hostname and address uniqueness validation for hosts sharing an IP (#1440)