### PR TITLE
Warn if local clock and host clock are out of sync

### DIFF
--- a/lib/pharos/phases/validate_host.rb
+++ b/lib/pharos/phases/validate_host.rb
@@ -6,6 +6,8 @@ module Pharos
       title "Validate hosts"
 
       def call
+        logger.info { "Validating host clock sync ..." }
+        check_clock
         logger.info { "Validating current role matches ..." }
         check_role
         logger.info { "Validating distro and version ..." }
@@ -20,6 +22,15 @@ module Pharos
         validate_localhost_resolve
         logger.info { "Validating peer address ..." }
         validate_peer_address
+      end
+
+      def check_clock
+        local_time = Time.now.to_i
+        server_time = transport.exec!('date +%s').to_i
+
+        return if (server_time - local_time).abs < 60
+
+        logger.warn "Clock drift #{(server_time - local_time).abs} seconds - certificate validation may fail"
       end
 
       def check_distro_version


### PR DESCRIPTION
Shows a warning if localhost and host clocks are more than 60 seconds apart.

![image](https://user-images.githubusercontent.com/224971/62625281-8eaed480-b92d-11e9-9df4-03634180a494.png)
