### PR TITLE
Ignore expired SSL certificate when prefilling cache

### DIFF
--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -41,6 +41,8 @@ module Pharos
       # prefetch client resources to warm up caches
       def client_prefetch
         kube_client.apis(prefetch_resources: true)
+      rescue Excon::Error::Socket => ex
+        logger.warn "Encountered #{ex.class.name} : #{ex.message}"
       end
     end
   end

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -40,9 +40,10 @@ module Pharos
 
       # prefetch client resources to warm up caches
       def client_prefetch
+        logger.info "Populating client cache"
         kube_client.apis(prefetch_resources: true)
-      rescue Excon::Error::Certificate => e
-        logger.warn "Encountered #{e.class.name} : #{e.message}"
+      rescue Excon::Error::Certificate
+        logger.warn "Certificate validation failed"
       end
     end
   end

--- a/lib/pharos/phases/configure_client.rb
+++ b/lib/pharos/phases/configure_client.rb
@@ -41,8 +41,8 @@ module Pharos
       # prefetch client resources to warm up caches
       def client_prefetch
         kube_client.apis(prefetch_resources: true)
-      rescue Excon::Error::Socket => ex
-        logger.warn "Encountered #{ex.class.name} : #{ex.message}"
+      rescue Excon::Error::Certificate => e
+        logger.warn "Encountered #{e.class.name} : #{e.message}"
       end
     end
   end


### PR DESCRIPTION
Avoids error loop when initializing a kubernetes api connection. 


