### PR TITLE
Kontena Stats addon: fix node-exporter on hybrid clusters

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-stats/resources/10-node-exporter-ds.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/10-node-exporter-ds.yml.erb
@@ -70,4 +70,49 @@ spec:
         - name: root
           hostPath:
             path: /
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter-proxy
+  namespace: kontena-stats
+  labels:
+    component: node-exporter-proxy
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: node-exporter-proxy
+      phase: prod
+  template:
+    metadata:
+      labels:
+        component: node-exporter-proxy
+        phase: prod
+    spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      containers:
+        - name: scraper
+          image: <%= image_repository %>/pharos-scraper-proxy:0.2.0
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+            limits:
+              cpu: 200m
+              memory: 20Mi
+          env:
+            - name: NODE_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: BACKEND_ADDRESS
+              value: "http://$(NODE_ADDRESS):9100/metrics"
 <% end %>

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/11-node-exporter-svc.yml
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/11-node-exporter-svc.yml
@@ -5,14 +5,15 @@ metadata:
   namespace: kontena-stats
   annotations:
     prometheus.io/scrape: 'true'
+    prometheus.io/port: '80'
 spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    name: node-exporter
+    name: node-exporter-proxy
     phase: prod
   ports:
     - name: metrics
       protocol: TCP
       port: 80
-      targetPort: 9100
+      targetPort: 80

--- a/non-oss/pharos_pro/addons/kontena-stats/resources/50-etcd-scraper-proxy-ds.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/50-etcd-scraper-proxy-ds.yml.erb
@@ -24,7 +24,7 @@ spec:
         node-role.kubernetes.io/master: ""
       containers:
         - name: scraper-proxy-etcd
-          image: <%= image_repository %>/pharos-scraper-proxy-amd64:0.1.2
+          image: <%= image_repository %>/pharos-scraper-proxy:0.2.0
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
- use multi-arch image for scraper
- use node-exporter proxy to expose metrics via pod-network (it's accessible across datacenters)