### PR TITLE
Create a service account and token during "pharos kubeconfig"

### DIFF
--- a/lib/pharos/kube/config.rb
+++ b/lib/pharos/kube/config.rb
@@ -18,12 +18,12 @@ module Pharos
       def config
         @config ||= yaml_content || {
           'apiVersion' => 'v1',
+          'kind' => 'Config',
           'clusters' => [],
           'contexts' => [],
-          'current-context' => nil,
-          'kind' => 'Config',
+          'users' => [],
           'preferences' => {},
-          'users' => []
+          'current-context' => nil
         }
       end
       alias to_h config
@@ -31,7 +31,7 @@ module Pharos
       # Convert to YAML
       # @return [String]
       def dump
-        YAML.dump(config)
+        YAML.dump(JSON.parse(JSON.dump(config))) # dereference to get rid of *1 &1 etc in output
       end
       alias to_s dump
 

--- a/lib/pharos/kubeconfig_command.rb
+++ b/lib/pharos/kubeconfig_command.rb
@@ -4,8 +4,9 @@ module Pharos
   class KubeconfigCommand < Pharos::Command
     options :load_config, :tf_json
 
-    option ['-n', '--name'], 'NAME', 'overwrite cluster name', attribute_name: :new_name
-    option ['-C', '--context'], 'CONTEXT', 'overwrite context name', attribute_name: :new_context
+    option ['-n', '--name'], 'NAME', 'cluster name', attribute_name: :cluster_name, default: 'pharos-cluster'
+    option ['-C', '--context'], 'CONTEXT', 'context name', attribute_name: :context_name
+    option ['-u', '--user'], 'USER', 'user name', attribute_name: :user_name, default: 'pharos-admin'
     option ['-m', '--merge'], '[FILE]', 'merge with existing configuration file', multivalued: true
 
     REMOTE_FILE = "/etc/kubernetes/admin.conf"
@@ -14,10 +15,32 @@ module Pharos
       Dir.chdir(config_yaml.dirname) do
         transport.connect
 
-        config = Pharos::Kube::Config.new(config_file_content)
-        config.rename_cluster(new_name) if new_name
-        config.rename_context(new_context) if new_context
-        config.update_server_address(master_host.api_address)
+        config = Pharos::Kube::Config.new
+        config.config['clusters'] << {
+          'cluster' => {
+            'certificate-authority-data' => certificate_authority_data,
+            'server' => "https://#{master_host.api_address}:6443"
+          },
+          'name' => cluster_name
+        }
+
+        config.config['users'] << {
+          'user' => {
+            'token' => create_or_update_sa_token
+          },
+          'name' => user_name
+        }
+
+        config.config['contexts'] << {
+          'context' => {
+            'cluster' => cluster_name,
+            'user' => 'pharos-admin'
+          },
+          'name' => context_name || "#{user_name}@#{cluster_name}"
+        }
+
+        config.config['current-context'] = context_name || "#{user_name}@#{cluster_name}"
+
         merge_list.each do |merge|
           merge_config = Pharos::Kube::Config.new(File.read(merge))
           config << merge_config
@@ -28,10 +51,16 @@ module Pharos
 
     private
 
-    def config_file_content
-      file = transport.file(REMOTE_FILE)
-      signal_usage_error "Remote file #{REMOTE_FILE} not found" unless file.exist?
-      file.read
+    # @return token [String]
+    def create_or_update_sa_token
+      transport.exec!("kubectl get -n kube-system serviceaccount/#{user_name} || kubectl -n kube-system create serviceaccount #{user_name}")
+      transport.exec!("kubectl get clusterrolebinding pharos-cluster-admin || kubectl create clusterrolebinding pharos-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:#{user_name}")
+      token_name = transport.exec!("kubectl -n kube-system get serviceaccount/#{user_name} -o jsonpath='{.secrets[0].name}'")
+      transport.exec!("kubectl -n kube-system get secret #{token_name} -o jsonpath='{.data.token}' | base64 -d")
+    end
+
+    def certificate_authority_data
+      transport.exec!("kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}'")
     end
 
     def master_host


### PR DESCRIPTION
Fixes #1454 

Create a `pharos-admin` service account and sa token and use those instead of the client certificte in the kubeconfig created during `pharos kubeconfig`.

Instead of downloading the `/etc/kubernetes/admin.conf`, a new config is built from scratch.
