### PR TITLE
Release v2.4.4

### DIFF
--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.3"
+  VERSION = "2.4.4"
 
   def self.version
     VERSION + "+oss"


### PR DESCRIPTION
## Changes since v2.4.3

- Kubernetes v1.14.6 (#1461)
- Cert-manager addon: v0.8.1 (#1455)
- Ingress-NGINX addon: update to v0.25.1 (#1462)
- Fix node-exporter on hybrid clusters (#1457)
- Fix pharos reset worker NoMethodError (#1464)
- Fix "Can't modify Frozen String" in worker up param handling (#1420)
- Ignore expired SSL certificate when prefilling cache (#1453)
- Update vagrant ubuntu example readme (#1459)