### PR TITLE
Kontena Lens addon: bump user management to 1.6.2

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-lens/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-lens/addon.rb
@@ -14,7 +14,7 @@ Pharos.addon 'kontena-lens' do
   helm_api_version = '1.6.0'
   terminal_gateway_version = '1.7.1'
   terminal_version = '1.6.0'
-  user_management_version = '1.6.1'
+  user_management_version = '1.6.2'
   resource_applier_version = '1.6.1'
   authenticator_version = '1.6.1'
   redis_version = '4-alpine'


### PR DESCRIPTION
User management 1.6.2 fixes the issue with creating new users and groups. The issue is caused by the fix for Kubernetes [CVE-2019-11247](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11247).