### PR TITLE
Fix firewalld "inactive (dead)" problems

### DIFF
--- a/lib/pharos/host/debian/scripts/configure-firewalld.sh
+++ b/lib/pharos/host/debian/scripts/configure-firewalld.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# shellcheck disable=SC1091
+. /usr/local/share/pharos/util.sh
+
+mkdir -p /etc/systemd/system/firewalld.service.d
+cat <<EOF >/etc/systemd/system/firewalld.service.d/10-pharos.conf
+[Service]
+Restart=always
+Before=kubelet.service
+EOF
+
 if ! dpkg -l firewalld > /dev/null; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get install -y firewalld ipset ebtables
@@ -10,3 +20,5 @@ if ! dpkg -l firewalld > /dev/null; then
         systemctl start firewalld
     fi
 fi
+
+lineinfile "^CleanupOnExit=" "CleanupOnExit=no" "/etc/firewalld/firewalld.conf"

--- a/lib/pharos/host/el7/scripts/configure-firewalld.sh
+++ b/lib/pharos/host/el7/scripts/configure-firewalld.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# shellcheck disable=SC1091
+. /usr/local/share/pharos/util.sh
+
+mkdir -p /etc/systemd/system/firewalld.service.d
+cat <<EOF >/etc/systemd/system/firewalld.service.d/10-pharos.conf
+[Service]
+Restart=always
+Before=kubelet.service
+EOF
+
 if ! rpm -qi firewalld ; then
     yum install -y firewalld
 
@@ -10,3 +20,5 @@ if ! rpm -qi firewalld ; then
         systemctl start firewalld
     fi
 fi
+
+lineinfile "^CleanupOnExit=" "CleanupOnExit=no" "/etc/firewalld/firewalld.conf"

--- a/lib/pharos/host/ubuntu/scripts/configure-firewalld.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-firewalld.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# shellcheck disable=SC1091
+. /usr/local/share/pharos/util.sh
+
+mkdir -p /etc/systemd/system/firewalld.service.d
+cat <<EOF >/etc/systemd/system/firewalld.service.d/10-pharos.conf
+[Service]
+Restart=always
+Before=kubelet.service
+EOF
+
 if ! dpkg -l firewalld > /dev/null; then
     export DEBIAN_FRONTEND=noninteractive
     systemctl mask ebtables
@@ -12,3 +22,5 @@ if ! dpkg -l firewalld > /dev/null; then
         systemctl start firewalld
     fi
 fi
+
+lineinfile "^CleanupOnExit=" "CleanupOnExit=no" "/etc/firewalld/firewalld.conf"

--- a/lib/pharos/resources/calico/25-node-daemonset.yml.erb
+++ b/lib/pharos/resources/calico/25-node-daemonset.yml.erb
@@ -43,6 +43,7 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      initContainers:
         # This container performs upgrade from host-local IPAM to calico-ipam.
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.

--- a/lib/pharos/resources/calico/25-node-daemonset.yml.erb
+++ b/lib/pharos/resources/calico/25-node-daemonset.yml.erb
@@ -26,7 +26,6 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        kontena.io/firewalld: "<%= firewalld_enabled %>"
     spec:
       hostNetwork: true
       hostPID: true
@@ -44,18 +43,6 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
-      initContainers:
-        <% if firewalld_enabled && reload_iptables %>
-        # This container performs firewalld reload
-        - name: reload-firewalld
-          image: <%= image_repository %>/alpine:3.9
-          command: ["/bin/sh", "-c"]
-          env:
-            - name: TIMESTAMP
-              value: "<%= Time.now.to_f %>"
-          args:
-          - pkill -HUP firewalld
-        <% end %>
         # This container performs upgrade from host-local IPAM to calico-ipam.
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.

--- a/lib/pharos/resources/weave/daemon-set.yml.erb
+++ b/lib/pharos/resources/weave/daemon-set.yml.erb
@@ -12,21 +12,7 @@ spec:
     metadata:
       labels:
         name: weave-net
-      annotations:
-        kontena.io/firewalld: "<%= firewalld_enabled %>"
     spec:
-      <% if firewalld_enabled && reload_iptables %>
-      initContainers:
-        # This container performs firewalld reload
-        - name: reload-firewalld
-          image: <%= image_repository %>/alpine:3.9
-          command: ["/bin/sh", "-c"]
-          env:
-            - name: TIMESTAMP
-              value: "<%= Time.now.to_f %>"
-          args:
-          - pkill -HUP firewalld
-      <% end %>
       containers:
         - name: weave
           command:
@@ -61,12 +47,20 @@ spec:
                   name: weave-passwd
                   key: weave-passwd
           image: '<%= image_repository %>/weave-kube:<%= version %>'
-          livenessProbe:
+          readinessProbe:
             httpGet:
               host: 127.0.0.1
               path: /status
               port: 6784
             initialDelaySeconds: 30
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - iptables-save | grep -E -e '^-A WEAVE.+MASQUERADE$'
+              initialDelaySeconds: 60
+              periodSeconds: 60
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
Fixes firewalld reboot problems by defining execution order for systemd units. Cleanup is also disabled because it seems to crash when kubelet is still holding kernel modules.

Backports also the CNI logic from #1429 (no need to signal firewalld anymore).

Fixes #1474 