### PR TITLE
Fix node-exporter service selector

### DIFF
--- a/non-oss/pharos_pro/addons/kontena-stats/resources/11-node-exporter-svc.yml
+++ b/non-oss/pharos_pro/addons/kontena-stats/resources/11-node-exporter-svc.yml
@@ -10,7 +10,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    name: node-exporter-proxy
+    component: node-exporter-proxy
     phase: prod
   ports:
     - name: metrics


### PR DESCRIPTION
This PR fixes selector of `node-exporter` service. `node-exporter-proxy` has `component=node-exporter-proxy` label and currently the service is using wrongly `name: node-exporter-proxy` as selector.