### PR TITLE
Configurer improved version matching (allow RHEL >= 7.4, < 8.0)

### DIFF
--- a/lib/pharos/configuration/os_release.rb
+++ b/lib/pharos/configuration/os_release.rb
@@ -6,7 +6,14 @@ module Pharos
       attribute :id, Pharos::Types::Strict::String
       attribute :id_like, Pharos::Types::Strict::String.optional.default(nil)
       attribute :name, Pharos::Types::Strict::String.optional.default(nil)
-      attribute :version, Pharos::Types::Strict::String
+      attribute :version, Pharos::Types::Strict::String.optional.default(nil)
+      attribute :version_regex, Pharos::Types.Instance(Regexp).optional.default(nil)
+
+      def ==(other)
+        return false unless id == other.id
+
+        (version || version_regex) === other.version # rubocop:disable Style/CaseEquality
+      end
     end
   end
 end

--- a/lib/pharos/configuration/os_release.rb
+++ b/lib/pharos/configuration/os_release.rb
@@ -7,12 +7,12 @@ module Pharos
       attribute :id_like, Pharos::Types::Strict::String.optional.default(nil)
       attribute :name, Pharos::Types::Strict::String.optional.default(nil)
       attribute :version, Pharos::Types::Strict::String.optional.default(nil)
-      attribute :version_regex, Pharos::Types.Instance(Regexp).optional.default(nil)
+      attribute :version_matcher, Pharos::Types.Instance(Object).optional.default(nil)
 
       def ==(other)
         return false unless id == other.id
 
-        (version || version_regex) === other.version # rubocop:disable Style/CaseEquality
+        (version || version_matcher) === other.version # rubocop:disable Style/CaseEquality
       end
     end
   end

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module Pharos
   module Host
     class Configurer
@@ -13,7 +15,7 @@ module Pharos
 
       # @return [Array]
       def self.configurers
-        @configurers ||= []
+        @configurers ||= Set.new
       end
 
       # @param [Pharos::Configuration::OsRelease]
@@ -249,11 +251,14 @@ module Pharos
         # @param [Pharos::Configuration::OsRelease]
         # @return [Boolean]
         def supported_os?(os_release)
-          supported_os_releases.any? { |release| release.id == os_release.id && release.version == os_release.version }
+          supported_os_releases.any? { |release| release == os_release }
         end
 
         def register_config(name, version)
-          supported_os_releases << Pharos::Configuration::OsRelease.new(id: name, version: version)
+          os_release_opts = { id: name }
+          os_release_opts[version.is_a?(String) ? :version : :version_regex] = version
+
+          supported_os_releases << Pharos::Configuration::OsRelease.new(os_release_opts)
           Pharos::Host::Configurer.configurers << self
           self
         end

--- a/lib/pharos/host/configurer.rb
+++ b/lib/pharos/host/configurer.rb
@@ -256,7 +256,7 @@ module Pharos
 
         def register_config(name, version)
           os_release_opts = { id: name }
-          os_release_opts[version.is_a?(String) ? :version : :version_regex] = version
+          os_release_opts[version.is_a?(String) ? :version : :version_matcher] = version
 
           supported_os_releases << Pharos::Configuration::OsRelease.new(os_release_opts)
           Pharos::Host::Configurer.configurers << self

--- a/lib/pharos/host/el7/rhel7.rb
+++ b/lib/pharos/host/el7/rhel7.rb
@@ -5,9 +5,7 @@ require_relative 'el7'
 module Pharos
   module Host
     class Rhel7 < El7
-      register_config 'rhel', '7.4'
-      register_config 'rhel', '7.5'
-      register_config 'rhel', '7.6'
+      register_config 'rhel', /^7\.[4-9]|\d{2,}/ # >= 7.4, < 8.0
 
       DOCKER_VERSION = '1.13.1'
       CFSSL_VERSION = '1.2'

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -56,6 +56,40 @@ describe Pharos::Host::Configurer do
     end
   end
 
+  context 'with regex version matcher' do
+    let(:test_config_class) do
+      Class.new(described_class) do
+        register_config 'test', /^7\.[4-9]|\d{2,}/
+      end
+    end
+
+    it 'uses the matcher' do
+      expect(
+        described_class.for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '7.3')
+        )
+      ).to be_nil
+
+      expect(
+        described_class.for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '7.4')
+        ).new(host)
+      ).to be_a test_config_class
+
+      expect(
+        described_class.for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '7.12')
+        ).new(host)
+      ).to be_a test_config_class
+
+      expect(
+        described_class.for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '8.0')
+        )
+      ).to be_nil
+    end
+  end
+
   describe '#update_env_file' do
     let(:host) { instance_double(Pharos::Configuration::Host) }
     let(:ssh) { instance_double(Pharos::Transport::SSH) }

--- a/spec/pharos/host/configurer_spec.rb
+++ b/spec/pharos/host/configurer_spec.rb
@@ -90,6 +90,34 @@ describe Pharos::Host::Configurer do
     end
   end
 
+  context 'with proc version matcher' do
+    let(:test_config_class) do
+      Class.new(described_class) do
+        register_config 'test', -> (v) { v.start_with?('7') }
+      end
+    end
+
+    it 'uses the matcher' do
+      expect(
+        described_class.for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '7.0')
+        ).new(host)
+      ).to be_a test_config_class
+
+      expect(
+        described_class.for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: '7abcd')
+        ).new(host)
+      ).to be_a test_config_class
+
+      expect(
+        described_class.for_os_release(
+          Pharos::Configuration::OsRelease.new(id: 'test', version: 'abcd')
+        )
+      ).to be_nil
+    end
+  end
+
   describe '#update_env_file' do
     let(:host) { instance_double(Pharos::Configuration::Host) }
     let(:ssh) { instance_double(Pharos::Transport::SSH) }


### PR DESCRIPTION
Makes it possible to define more advanced host configurer version matchers. Currently it's only possible to list each version separately:

Before:

```ruby
class Rhel7 < Configurer
  register_config 'rhel', '7.4'
  register_config 'rhel', '7.5'
  register_config 'rhel', '7.6'
  register_config 'rhel', '7.7'
end
```

After:

```ruby
class Rhel7 < Configurer
  register_config 'rhel', /^7\.[4-9]|\d{2,}/
end
```

This has been used in this PR to make the rhel7 configurer match RHEL `>= 7.4 && < 8.0`. (Including something like `7.19-beta2.rc4`)

The matcher can be anything that handles triple equals.
 