### PR TITLE
Release v2.4.8

### DIFF
--- a/lib/pharos/host/el7/rhel7.rb
+++ b/lib/pharos/host/el7/rhel7.rb
@@ -8,6 +8,7 @@ module Pharos
       register_config 'rhel', '7.4'
       register_config 'rhel', '7.5'
       register_config 'rhel', '7.6'
+      register_config 'rhel', '7.7'
 
       DOCKER_VERSION = '1.13.1'
       CFSSL_VERSION = '1.2'

--- a/lib/pharos/version.rb
+++ b/lib/pharos/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pharos
-  VERSION = "2.4.7"
+  VERSION = "2.4.8"
 
   def self.version
     VERSION + "+oss"

--- a/non-oss/pharos_pro/addons/kontena-storage/addon.rb
+++ b/non-oss/pharos_pro/addons/kontena-storage/addon.rb
@@ -5,6 +5,8 @@ Pharos.addon 'kontena-storage' do
   ceph_version = '13.2.4-20190109'
   license 'Kontena License'
 
+  CEPHFS_MONITORS = "rook-ceph-mon.kontena-storage.svc.cluster.local:6790"
+
   config_schema {
     required(:data_dir).filled(:str?)
     required(:storage).schema do
@@ -102,12 +104,14 @@ Pharos.addon 'kontena-storage' do
   install {
     set_defaults
     cluster = build_cluster_resource(ceph_version)
+    ensure_correct_cephfs_sc
     if upgrade_from?('0.8')
       upgrade_from_08(cluster, ceph_version)
     else
       apply_resources(
         cluster: cluster.to_h.deep_transform_keys(&:to_s),
-        rook_version: rook_version
+        rook_version: rook_version,
+        cephfs_monitors: CEPHFS_MONITORS
       )
     end
   }
@@ -137,7 +141,8 @@ Pharos.addon 'kontena-storage' do
   def upgrade_from_08(cluster, ceph_version)
     storage_stack = kube_stack(
       cluster: cluster.to_h.deep_transform_keys(&:to_s),
-      rook_version: rook_version
+      rook_version: rook_version,
+      cephfs_monitors: CEPHFS_MONITORS
     )
     logger.info "Applying upgrade ..."
     storage_stack.apply(kube_client, prune: false)
@@ -187,6 +192,19 @@ Pharos.addon 'kontena-storage' do
                           .get('kontena-storage-operator')
 
     operator.spec.template.spec.containers.first.image.include?("rook-ceph:v#{version}")
+  rescue K8s::Error::NotFound
+    false
+  end
+
+  # @return [Boolean]
+  def ensure_correct_cephfs_sc
+    storage_class_client = kube_client.api('storage.k8s.io/v1').resource('storageclasses')
+    storage_class = storage_class_client.get('kontena-storage-fs')
+    return false if storage_class.parameters.monitors == CEPHFS_MONITORS
+
+    storage_class_client.delete('kontena-storage-fs')
+
+    true
   rescue K8s::Error::NotFound
     false
   end

--- a/non-oss/pharos_pro/addons/kontena-storage/resources/16-mon-service.yml
+++ b/non-oss/pharos_pro/addons/kontena-storage/resources/16-mon-service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rook-ceph-mon
+  namespace: kontena-storage
+  labels:
+    app: rook-ceph-mon
+    mon_cluster: kontena-storage
+spec:
+  clusterIP: None
+  ports:
+  - name: rook-ceph-mon
+    port: 6790
+    protocol: TCP
+    targetPort: 6790

--- a/non-oss/pharos_pro/addons/kontena-storage/resources/41-role.yml
+++ b/non-oss/pharos_pro/addons/kontena-storage/resources/41-role.yml
@@ -7,3 +7,6 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]

--- a/non-oss/pharos_pro/addons/kontena-storage/resources/43-deployment.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-storage/resources/43-deployment.yml.erb
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: cephfs-provisioner
-        image: "<%= image_repository %>/cephfs-provisioner:v2.1.0-k8s1.11"
+        image: "<%= image_repository %>/cephfs-provisioner:git-0399b029"
         env:
         - name: PROVISIONER_NAME
           value: ceph.com/cephfs
@@ -23,6 +23,11 @@ spec:
         - "/usr/local/bin/cephfs-provisioner"
         args:
         - "-id=cephfs-provisioner-1"
+      - name: ep-updater
+        image: <%= image_repository %>/cephfs-service-updater:latest
+        env:
+        - name: ENDPOINT_NAME
+          value: rook-ceph-mon
       serviceAccount: cephfs-provisioner
       resources:
         requests:

--- a/non-oss/pharos_pro/addons/kontena-storage/resources/44-storageclass.yml.erb
+++ b/non-oss/pharos_pro/addons/kontena-storage/resources/44-storageclass.yml.erb
@@ -5,7 +5,7 @@ metadata:
   name: kontena-storage-fs
 provisioner: ceph.com/cephfs
 parameters:
-    monitors: <%= config.pool.replicated.size.times.map { |i| "rook-ceph-mon#{i}:6790" }.join(',') %>
+    monitors: "<%= cephfs_monitors %>"
     adminId: admin
     adminSecretName: rook-ceph-mon
     adminSecretNamespace: "kontena-storage"


### PR DESCRIPTION
## Changes since v2.4.7

- Kubernetes v1.14.7 (#1492)
- Update k8s-client to 0.10.4 (#1485)
- RHEL 7.7 support (#1487)
- Use stable ceph-mon endpoint in cephfs storageclass (#1483)