### PR TITLE
Wait for kube-proxy to start before moving on during runtime upgrade

### DIFF
--- a/lib/pharos/phases/configure_host.rb
+++ b/lib/pharos/phases/configure_host.rb
@@ -71,6 +71,7 @@ module Pharos
         logger.info "Uncordoning node ..."
         sleep 1 until master_host.transport.exec("kubectl uncordon #{@host.hostname}").success?
         logger.info "Waiting for node to be ready ..."
+        sleep 10 until @host.transport.exec("sudo crictl pods --namespace kube-system --name kube-proxy --state Ready | grep kube-proxy")
         sleep 10 until master_host.transport.exec("kubectl get node #{@host.hostname} -o jsonpath=\"{range @.status.conditions[*]}{@.type}={@.status};{end}\" | grep 'Ready=True'").success?
       end
 


### PR DESCRIPTION
Waiting for node to be ready is not enough, upgrade might be so fast that node never goes to non-ready state. This PR fixes this situation by waiting for `kube-proxy` pod before checking node ready status.