### PR TITLE
Don't attempt to create packet_bgp_session unless bgp_address_pool is defined

### DIFF
--- a/examples/terraform-packet/main.tf
+++ b/examples/terraform-packet/main.tf
@@ -82,7 +82,7 @@ resource "packet_device" "pharos_worker" {
 }
 
 resource "packet_bgp_session" "pharos_bgb_session" {
-  count            = var.worker_count
+  count            = var.bgp_address_pool != "" ? var.worker_count : 0
   device_id        = packet_device.pharos_worker[count.index].id
   address_family   = "ipv4"
 }


### PR DESCRIPTION
If you don't do this, you get:

```
Error: BGP is not enabled
  on main.tf line 84, in resource "packet_bgp_session" "pharos_bgb_session":
  84: resource "packet_bgp_session" "pharos_bgb_session" {
```

https://github.com/kontena/pharos-cluster/pull/1517#discussion_r357983835