### PR TITLE
Added /opt/pharos folder check

### DIFF
--- a/lib/pharos/host/debian/scripts/configure-cfssl.sh
+++ b/lib/pharos/host/debian/scripts/configure-cfssl.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ ! -d "/opt/pharos" ]; then
+  mkdir /opt/pharos
+fi
+
 ctr -n pharos image pull "${IMAGE}"
 ctr -n pharos install --path /opt/pharos --replace "${IMAGE}"
 

--- a/lib/pharos/host/el7/scripts/configure-cfssl.sh
+++ b/lib/pharos/host/el7/scripts/configure-cfssl.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ ! -d "/opt/pharos" ]; then
+  mkdir /opt/pharos
+fi
+
 ctr -n pharos image pull "${IMAGE}"
 ctr -n pharos install --path /opt/pharos --replace "${IMAGE}"
 

--- a/lib/pharos/host/ubuntu/scripts/configure-cfssl.sh
+++ b/lib/pharos/host/ubuntu/scripts/configure-cfssl.sh
@@ -2,5 +2,9 @@
 
 set -e
 
+if [ ! -d "/opt/pharos" ]; then
+  mkdir /opt/pharos
+fi
+
 ctr -n pharos image pull "${IMAGE}"
 ctr -n pharos install --path /opt/pharos --replace "${IMAGE}"


### PR DESCRIPTION
After the `ctr` release of version 1.3.0 the below command will fail if the `/opt/pharos` folder does not exist (instead of creating it).
```
$ ctr -n pharos install --path /opt/pharos --replace docker.io/jakolehm/cfssl:0.1.1
ctr: mkdir /opt/pharos/bin: no such file or directory
```
I added a simple folder check that creates the folder if it does not already exists. 

See issue here: https://github.com/kontena/pharos-cluster/issues/1557